### PR TITLE
Add the superposition input state in the quantum layer 

### DIFF
--- a/merlin/core/layer.py
+++ b/merlin/core/layer.py
@@ -478,7 +478,10 @@ class QuantumLayer(nn.Module):
         params = self.prepare_parameters(list(input_parameters))
 
         # Get quantum output
-        distribution = self.computation_process.compute(params)
+        if type(self.computation_process.input_state) is dict:
+            distribution = self.computation_process.compute_superposition_state(params)
+        else:
+            distribution = self.computation_process.compute(params)
 
         # Handle sampling
         needs_gradient = (

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -26,7 +26,7 @@ Quantum computation processes and factories.
 
 import perceval as pcvl
 import torch
-
+from typing import List, Optional
 from merlin.pcvl_pytorch import CircuitConverter, build_slos_distribution_computegraph
 
 from .base import AbstractComputationProcess
@@ -60,6 +60,8 @@ class ComputationProcess(AbstractComputationProcess):
         self.index_photons = index_photons
 
         # Extract circuit parameters for graph building
+        if type(input_state) is dict:
+            input_state = list(input_state.keys())[0]
         self.m = len(input_state)  # Number of modes
         self.n_photons = sum(input_state)  # Total number of photons
 
@@ -99,9 +101,56 @@ class ComputationProcess(AbstractComputationProcess):
         unitary = self.converter.to_tensor(*parameters)
 
         # Compute output distribution using the input state
-        keys, distribution = self.simulation_graph.compute(unitary, self.input_state)
+        if type(self.input_state) is dict:
+            input_state = list(self.input_state.keys())[0]
+        else:
+            input_state = self.input_state
+        keys, distribution = self.simulation_graph.compute(unitary, input_state)
 
         return distribution
+
+    def compute_superposition_state(self, parameters: List[torch.Tensor]) -> torch.Tensor:
+        unitary = self.converter.to_tensor(*parameters)
+
+        def is_swap_permutation(t1, t2):
+
+            if t1 == t2:
+                return False
+            diff = [(i, i) for i, (x, y) in enumerate(zip(t1, t2)) if x != y]
+            if len(diff) != 2:
+                return False
+            i, j = diff[0][0], diff[1][0]
+
+            return t1[i] == t2[j] and t1[j] == t2[i]
+
+        def reorder_swap_chain(lst):
+
+            from collections import deque
+
+            remaining = lst[:]
+            chain = [remaining.pop(0)]  # Commence avec le premier élément
+            while remaining:
+                for i, candidate in enumerate(remaining):
+                    if is_swap_permutation(chain[-1], candidate):
+                        chain.append(remaining.pop(i))
+                        break
+                else:
+                    chain.append(remaining.pop(0))
+
+            return chain
+
+        state_list = reorder_swap_chain(list(self.input_state.keys()))
+
+        prev_state = state_list.pop(0)
+        keys, distribution = self.simulation_graph.compute(unitary, prev_state)
+        distributions = distribution * self.input_state[prev_state]
+
+        for fock_state in state_list:
+            keys, distribution = self.simulation_graph.compute_pa_inc(unitary, prev_state, fock_state)
+            distributions += distribution * self.input_state[fock_state]
+            prev_state = fock_state
+
+        return distributions
 
     def compute_with_keys(self, parameters: list[torch.Tensor]):
         """Compute quantum output distribution and return both keys and probabilities."""

--- a/tests/test_superposition_state.py
+++ b/tests/test_superposition_state.py
@@ -1,0 +1,83 @@
+import torch
+import pytest
+import math
+from merlin import QuantumLayer, OutputMappingStrategy  # Replace with actual import path
+import perceval as pcvl
+
+def classical_method(layer, input_state):
+    output_classical = torch.zeros(layer.output_size)
+    for key, value in input_state.items():
+        layer.computation_process.input_state = key
+        output_classical += value * layer()
+    return output_classical
+
+
+class TestOutputSuperposedState:
+    """Test cases for output mapping strategies in QuantumLayer.simple()."""
+
+    def test_superposed_state(self, benchmark):
+        """Test NONE strategy when output_size is not specified."""
+        print("\n=== Testing Superposed input state method ===")
+
+        # When using NONE strategy without specifying output_size,
+        # the output size should equal the distribution size
+        circuit = pcvl.components.GenericInterferometer(
+            6,
+            pcvl.components.catalog['mzi phase last'].generate,
+            shape=pcvl.InterferometerShape.RECTANGLE
+        )
+        input_state_superposed = {(1, 1, 1, 0, 0, 0): 0.6, (0, 1, 1, 1, 0, 0):0.3,
+            (0, 0, 1, 0, 1, 1):0.4, (0, 1, 1, 0, 1, 0):0.25,
+            (0, 0, 1, 1, 0, 1):0.45, (1, 1, 0, 1, 0, 0):0.4,
+            (1, 1, 0, 0, 0, 1):0.25}
+        sum_values = sum([k**2 for k in list(input_state_superposed.values())])
+        for key in input_state_superposed.keys():
+            input_state_superposed[key] = input_state_superposed[key] / (sum_values)**0.5
+        layer = QuantumLayer(
+            input_size=0,
+            circuit=circuit,
+            n_photons=3,
+            output_mapping_strategy=OutputMappingStrategy.NONE,
+            input_state=input_state_superposed,
+            trainable_parameters=["phi"],
+            input_parameters=[],
+        )
+
+        output_superposed = benchmark(layer)
+
+        output_classical = classical_method(layer, input_state_superposed)
+        assert torch.allclose(output_superposed, output_classical, rtol=1e-3, atol=1e-6)
+
+
+    def test_classical_method(self, benchmark):
+        """Test NONE strategy when output_size is not specified."""
+        print("\n=== Testing Superposed input state method ===")
+
+        # When using NONE strategy without specifying output_size,
+        # the output size should equal the distribution size
+        circuit = pcvl.components.GenericInterferometer(
+            6,
+            pcvl.components.catalog['mzi phase last'].generate,
+            shape=pcvl.InterferometerShape.RECTANGLE
+        )
+        input_state_superposed = {(1, 1, 1, 0, 0, 0): 0.6, (0, 1, 1, 1, 0, 0):0.3,
+            (0, 0, 1, 0, 1, 1):0.4, (0, 1, 1, 0, 1, 0):0.25,
+            (0, 0, 1, 1, 0, 1):0.45, (1, 1, 0, 1, 0, 0):0.4,
+            (1, 1, 0, 0, 0, 1):0.25}
+        sum_values = sum([k**2 for k in list(input_state_superposed.values())])
+        for key in input_state_superposed.keys():
+            input_state_superposed[key] = input_state_superposed[key] / (sum_values)**0.5
+        layer = QuantumLayer(
+            input_size=0,
+            circuit=circuit,
+            n_photons=3,
+            output_mapping_strategy=OutputMappingStrategy.NONE,
+            input_state=input_state_superposed,
+            trainable_parameters=["phi"],
+            input_parameters=[],
+        )
+
+        output_superposed = layer()
+
+        output_classical = benchmark(lambda: classical_method(layer, input_state_superposed))
+        assert torch.allclose(output_superposed, output_classical, rtol=1e-3, atol=1e-7)


### PR DESCRIPTION
- The superposed input state must be a dictionary (tuple, value)
- The Quantum Layer now acts differently if the input state type is a dictionnary
- Add a compute superposition function in the process layer, to iterate on every fock state of the superposed input state,
- Add a method in the slos torchscript to compute the amplitudes from another fock state, simply swapping one photon, instead of recomputing the whole circuit,
- Add a layer backward function that precalculates the invert tensors used to go from the amplitudes of a fock state to the amplitudes of the same fock state minus one photon