### PR TITLE
Removed device handling for Ansatz and added Nonetype handling for input and trainable parameters

### DIFF
--- a/merlin/core/ansatz.py
+++ b/merlin/core/ansatz.py
@@ -97,7 +97,6 @@ class Ansatz:
         # Create computation process with proper dtype
 
     def _build_computation_process(self):
-        print(f" - Bulding computation process with device = {self.device}")
         self.computation_process = ComputationProcessFactory.create(
             circuit=self.circuit,
             input_state=self.input_state,

--- a/merlin/core/layer.py
+++ b/merlin/core/layer.py
@@ -81,7 +81,8 @@ class QuantumLayer(nn.Module):
         index_photons: list[tuple[int, int]] | None = None,
     ):
         super().__init__()
-
+        trainable_parameters = trainable_parameters or []
+        input_parameters = input_parameters or []
         self.device = device
         self.dtype = dtype or torch.float32
         self.input_size = input_size

--- a/merlin/core/layer.py
+++ b/merlin/core/layer.py
@@ -124,8 +124,6 @@ class QuantumLayer(nn.Module):
 
         # For ansatz mode, we need to create a new computation process with correct device
         if self.index_photons is not None:
-            print("\n - Creating a circuit with ComputationProcessFactory")
-
             # Create a new computation process with index_photons support or correct device
             self.computation_process = ComputationProcessFactory.create(
                 circuit=ansatz.circuit,
@@ -139,12 +137,10 @@ class QuantumLayer(nn.Module):
                 index_photons=self.index_photons,
             )
         else:
-            print("\n -> Creating a circuit with Ansatz")
             # Use the ansatz's computation process as before
             # Set ansatz device to be the same as the QuantumLayer
             if self.device is not None:
                 ansatz.device = self.device
-            print(f"Ansatz input parameter = {ansatz.input_parameters}")
             # Build computation process from ansatz on the correct device
             self.computation_process = ansatz._build_computation_process()
 

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -70,15 +70,7 @@ class ComputationProcess(AbstractComputationProcess):
     def _setup_computation_graphs(self):
         """Setup unitary and simulation computation graphs."""
         # Determine parameter specs
-        parameter_specs = self.trainable_parameters + list(self.input_parameters)
-        # Include static phi parameters if reservoir_mode is enabled
-        if self.reservoir_mode:
-            phi_parameters = [
-                param
-                for param in self.circuit.get_parameters()
-                if param.name.startswith("phi_")
-            ]
-            parameter_specs += phi_parameters
+        parameter_specs = self.trainable_parameters + self.input_parameters
 
         # Build unitary graph
         self.converter = CircuitConverter(

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -26,7 +26,6 @@ import torch
 import torch.nn as nn
 
 import merlin as ml
-from merlin import QuantumLayer
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -37,13 +36,12 @@ def test_load_model_on_cuda():
         shape=pcvl.InterferometerShape.RECTANGLE,
     )
 
-    layer = QuantumLayer(
+    layer = ml.QuantumLayer(
         input_size=2,
         output_size=1,
         circuit=circuit,
         input_state=[1, 1, 0, 0],
-        trainable_parameters=["phi_"],
-        input_parameters=[],
+        trainable_parameters=["phi"],
         device=torch.device("cuda"),
     )
     assert layer.device == torch.device("cuda")
@@ -66,13 +64,12 @@ def test_switch_model_to_cuda():
         pcvl.components.catalog["mzi phase last"].generate,
         shape=pcvl.InterferometerShape.RECTANGLE,
     )
-    layer = QuantumLayer(
+    layer = ml.QuantumLayer(
         input_size=2,
         output_size=1,
         circuit=circuit,
         input_state=[1, 1, 0, 0],
-        trainable_parameters=["phi_"],
-        input_parameters=[],
+        trainable_parameters=["phi"],
         device=torch.device("cpu"),
     )
     assert layer.device == torch.device("cpu")
@@ -97,7 +94,7 @@ class QuantumClassifier_withAnsatz(nn.Module):
         super().__init__()
 
         # This layer downscales the inputs to fit in the QLayer
-        self.downscaling_layer = nn.Linear(input_dim, hidden_dim, device=device)
+        self.downscaling_layer = nn.Linear(input_dim, hidden_dim, device = device)
 
         # Building the QLayer with Merlin
         experiment = ml.PhotonicBackend(
@@ -114,16 +111,14 @@ class QuantumClassifier_withAnsatz(nn.Module):
         ansatz = ml.AnsatzFactory.create(
             PhotonicBackend=experiment,
             input_size=hidden_dim,
-            # output_size=output_size_slos,
             output_mapping_strategy=ml.OutputMappingStrategy.NONE,
-            device=device,
         )
 
         # Build the QLayer using Merlin
-        self.q_circuit = ml.QuantumLayer(input_size=hidden_dim, ansatz=ansatz, device=device)
+        self.q_circuit = ml.QuantumLayer(input_size=hidden_dim, ansatz=ansatz, device = device)
 
         # Linear output layer as in the original paper
-        self.output_layer = nn.Linear(self.q_circuit.output_size, num_classes, device=device)
+        self.output_layer = nn.Linear(self.q_circuit.output_size, num_classes, device = device)
 
     def forward(self, x):
         # Forward pass through the quantum-classical hybrid
@@ -155,7 +150,7 @@ def test_QuantumClassifier_withAnsatz():
         modes=modes,
         num_classes=num_classes,
         input_state=input_state,
-        device=device,
+        device = device,
     )
 
     # Move model to GPU
@@ -215,17 +210,16 @@ def test_different_configurations():
     configs = [
         {"modes": 4, "hidden_dim": 50, "input_state": [1, 0, 1, 0]},
         {"modes": 6, "hidden_dim": 100, "input_state": [1, 0, 1, 0, 1, 0]},
-        {"modes": 10, "hidden_dim": 150, "input_state": [1, 0, 1, 0, 1, 0, 0, 0, 0, 0]},
     ]
 
     for i, config in enumerate(configs):
 
         model = QuantumClassifier_withAnsatz(
             input_dim=768,
-            hidden_dim=config["hidden_dim"],
-            modes=config["modes"],
+            hidden_dim=config['hidden_dim'],
+            modes=config['modes'],
             num_classes=2,
-            input_state=config["input_state"],
+            input_state=config['input_state'],
             device=device
         ).to(device)
 


### PR DESCRIPTION
Here I propose to remove the need to precise the device twice in `Ansatz` and `QuantumLayer` to run models on GPU and I am also proposing a way to fixe None handling for input and trainable parameters for the `QuantumLayer`. Please note this code uses the code merged between main and release candidate from PR #25 and therefore should be merged after.

For the device handling in `Ansatz`:
- Removed device parameter from `Ansatz` and `AnsatzFactory` constructors                                                                                                                               
- Implemented proper device initialization where `ansatz.device` is set from `layer.device`                                                                                                             
- Added `_build_computation_process()` method to `Ansatz` for proper device handling                                                                                                                    
- Updated QuantumLayer to handle device assignment and computation process creation 

For the `None` handling in `QuantumLayer`:
- Added comprehensive tests for None input parameters and None trainable parameters                                                                                                                     
- Fixed parameter handling in ComputationProcess for proper None handling                                                                                                                                

### Changes Made       
- in **merlin/core/ansatz.py**: Removed device parameter from constructor, added device initialization and `_build_computation_process()` method
- in **merlin/core/layer.py**: Updated device handling logic to set ansatz device from layer device                                                                                                    
- in **merlin/core/process.py**: Added None handling for trainable_parameters and input_parameters                                                                                                          
- in **tests/test_cuda.py**: Updated tests to remove device parameter usage                                                                                                                                 
- in **tests/test_layer.py**: Added comprehensive tests for edge cases with None parameters                                                                                                                 

### Test Plan   
Device assignment and computation process creation validation:
- Existing CUDA tests pass with updated device handling                                                                                                                                              
- New tests for None input parameters and None trainable parameters                                                                                                                                  
- Edge case testing for proper parameter handling                                                                                                                                                    