### PR TITLE
Created PoolingFeedForward layer

### DIFF
--- a/docs/source/user_guide/feed_forward.rst
+++ b/docs/source/user_guide/feed_forward.rst
@@ -114,6 +114,75 @@ Example
 
 
 
+----------------------------
+PoolingFeedforward in MerLin
+----------------------------
+Similarly to the FeedforwardBlock previously presented, the pooling feedforward creates a partial measurement that determines the configuration of the downstream circuit.
+However, this measure will modify the input state in the circuit instead of creating dynamic circuits. This object involves a measure made on some of the modes and a report of all the measured photons on the remaining modes of the circuit.
+
+**Key properties:**
+
+- Initialization specifies:
+
+  -  ``n_modes`` : number of modes before the pooling feedforward layer.
+  -  ``n_photons`` : number of photons.
+  - ``n_output_modes``: number of modes exiting the pooling feedforward layer.
+  - ``pooling_modes``: List of modes to aggregate together. The length of this list must be equal to the number of output modes
+  - ``no_bunching``: Whether bunched states are allowed are not (default is True i.e bunched states not allowed)
+This pooling layer doesn't contain any parameters, but pools some modes. This method is based on the pooling layer used in the Convolutional Neural Network, and is then very similar to it, the number of photons on every mode here corresponding to the values of the tensor in the CNN.
+
+
+----------------------------
+Example
+----------------------------
+
+.. code-block:: python
+
+   from MerLin import QuantumLayer, FeedforwardBlock
+   import torch
+
+   quantum_dim = 10
+   # Define Quantum Layer before pff layer
+   experiment = ML.Experiment(
+                circuit_type=ML.CircuitType.SERIES,
+                n_modes=16,
+                n_photons=4,
+                use_bandwidth_tuning=True
+            )
+    ansatz = ML.AnsatzFactory.create(
+        experiment=experiment,
+        input_size=quantum_dim,
+        output_size=quantum_dim * 2
+    )
+    q_layer_pre_pff = ML.QuantumLayer(input_size=quantum_dim, ansatz=ansatz)
+
+    # Define pff layer
+    pff = PoolingFeedForward(n_modes=16, n_photons=4, n_output_modes=8)
+
+    # Define Quantum Layer after pff layer
+    experiment = ML.Experiment(
+                circuit_type=ML.CircuitType.SERIES,
+                n_modes=8,
+                n_photons=4,
+                use_bandwidth_tuning=True
+            )
+    ansatz = ML.AnsatzFactory.create(
+        experiment=experiment,
+        input_size=0,
+        output_size=quantum_dim * 2
+    )
+    q_layer_post_pff = ML.QuantumLayer(input_size=quantum_dim, ansatz=ansatz)
+
+    # Example of a forward pass
+    x = torch.rand(quantum_dim)
+    #Get the amplitudes and not the output probabilities to perform the pooling
+    _, amplitudes = q_layer_pre_pff(x, return_amplitudes=True)
+    # Going from amplitudes in the space with 16 modes, 4 photons, to 8 modes, 4 photons
+    amplitudes = pff(amplitudes)
+    # Set input state : If we provide a tensor -> Every component of the tensor refers to the amplitude of a different fock state -> Entangled input state
+    q_layer_post_pff.set_input_state(amplitudes)
+    output = q_layer_post_pff()
+
 
 ----------------------------
 Further Reading

--- a/merlin/core/feed_forward.py
+++ b/merlin/core/feed_forward.py
@@ -469,6 +469,93 @@ class FeedForwardBlock(torch.nn.Module):
         print(f"New input size: {self.input_size}")
 
 
+class PoolingFeedForward(torch.nn.Module):
+    def __init__(
+        self,
+        n_modes: int,
+        n_photons: int,
+        n_output_modes: int,
+        pooling_modes: list[list[int]] = None,
+        no_bunching=True,
+    ):
+        super().__init__()
+        keys_in = QuantumLayer(
+            0,
+            10,
+            circuit=pcvl.Circuit(n_modes),
+            n_photons=n_photons,
+            no_bunching=no_bunching,
+        ).computation_process.simulation_graph.mapped_keys
+        keys_out = QuantumLayer(
+            0,
+            10,
+            circuit=pcvl.Circuit(n_output_modes),
+            n_photons=n_photons,
+            no_bunching=no_bunching,
+        ).computation_process.simulation_graph.mapped_keys
+        if pooling_modes is None:
+            num_skips = n_modes // n_output_modes
+            first_skips = n_modes % n_output_modes
+            index_num_skips = list(range(0, n_modes + 1, num_skips))
+            index_first_skips = (
+                [0]
+                + list(range(1, first_skips + 1))
+                + [first_skips] * (n_output_modes - first_skips)
+            )
+            index_skips = [
+                index_first_skip + index_num_skip
+                for (index_first_skip, index_num_skip) in zip(
+                    index_first_skips, index_num_skips, strict=False
+                )
+            ]
+            pooling_modes = [
+                list(range(index_skips[k], index_skips[k + 1]))
+                for k in range(n_output_modes)
+            ]
+        match_indices, exclude_indices = self.match_tuples(
+            keys_in, keys_out, pooling_modes
+        )
+        self.match_indices = torch.tensor(match_indices)
+        self.exclude_indices = torch.tensor(exclude_indices)
+        self.keys_out = keys_out
+        self.n_modes = n_modes
+
+    def forward(self, amplitudes):
+        batch_size = amplitudes.shape[0]
+        output = torch.zeros(
+            batch_size,
+            len(self.keys_out),
+            dtype=amplitudes.dtype,
+            device=amplitudes.device,
+        )
+        # Create a mask to exclude certain indices
+        mask = torch.ones(amplitudes.shape[1], dtype=torch.bool)
+        if self.exclude_indices.numel() != 0:
+            mask[self.exclude_indices] = False
+        filtered_amplitudes = amplitudes[:, mask]
+        output.scatter_add_(
+            1,
+            self.match_indices.unsqueeze(0).repeat(batch_size, 1),
+            filtered_amplitudes,
+        )
+        return output
+
+    def match_tuples(self, keys_in, keys_out, pooling_modes):
+        indices = []
+        exclude_indices = []
+        for i, key_in in enumerate(keys_in):
+            key_out = tuple(
+                sum(key_in[i] for i in indices) for indices in pooling_modes
+            )
+            index = keys_out.index(key_out) if key_out in keys_out else None
+            if index is not None:
+                indices.append(index)
+            else:
+                exclude_indices.append(i)
+
+        return indices, exclude_indices
+
+
 if __name__ == "__main__":
     from itertools import chain
 
@@ -495,5 +582,20 @@ if __name__ == "__main__":
         result = feed_forward(L(x)).pow(2).sum()
         print(result)
         result.backward()
+        optimizer.step()
+        optimizer.zero_grad()
+    print("testing pff")
+    pff = PoolingFeedForward(16, 2, 8)
+    pre_layer = define_layer_no_input(16, 2)
+    post_layer = define_layer_no_input(8, 2)
+    params = chain(pre_layer.parameters(), post_layer.parameters())
+    optimizer = torch.optim.Adam(params)
+    for _ in range(10):
+        _, amplitudes = pre_layer(return_amplitudes=True)
+        amplitudes = pff(amplitudes)
+        post_layer.set_input_state(amplitudes)
+        res = post_layer().pow(2).sum()
+        print(res)
+        res.backward()
         optimizer.step()
         optimizer.zero_grad()

--- a/merlin/core/layer.py
+++ b/merlin/core/layer.py
@@ -448,6 +448,10 @@ class QuantumLayer(nn.Module):
             # For custom circuits, apply 2π scaling directly
             return x * torch.pi
 
+    def set_input_state(self, input_state):
+        self.input_state = input_state
+        self.computation_process.input_state = input_state
+
     def prepare_parameters(
         self, input_parameters: list[torch.Tensor]
     ) -> list[torch.Tensor]:


### PR DESCRIPTION
…dded a set_input_state method to define the input state easily when doing amplitudes encoding



## Summary
Similarly to the FeedforwardBlock, the pooling feedforward creates a partial measurement that determines the configuration of the downstream circuit. However, this measure will modify the input state in the circuit instead of creating dynamic circuits. This object involves a measure made on some of the modes and a report of all the measured photons on the remaining modes of the circuit.

## Context / Related Issues
This PR was made to implement the photonic QCNN paper. The method defined is based on the pooling layer used in the Convolutional Neural Network, and is very similar to it, the number of photons on every mode here corresponding to the values of the tensor in the CNN. 

## Type of change
- [ ] Bug fix
- [y] New feature
- [y] Documentation update
- [ ] Refactor / Cleanup
- [ ] Performance improvement
- [ ] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)


## Proposed changes
- Defined a PoolingFeedForward object
- Created a set_input_state method in the QuantumLayer
- Modified documentation related to FeedForward
- Modified test file related to FeedForward


## How to test / How to run
See the section on PoolingFeedForward in the user documentation to understand how to run it. (with the example provided)




## Documentation
- [ y] User docs updated (Sphinx)
- [ ] Examples / notebooks updated
- [ ] Docstrings updated

## Checklist
- [ ] Code formatted (ruff format)
- [ ] Lint passes (ruff)
- [ ] Static typing passes (mypy) if applicable
- [ ] Unit tests added/updated (pytest)
- [ ] Tests pass locally (pytest)
- [ ] Tests pass on GPU (pytest)
- [ ] Test coverage not decreased significantly
- [ ] Docs build locally if affected (sphinx)
- [ ] Dependencies updated (if needed) and pinned appropriately
- [ ] I have added a clear PR title and description

<!-- Helpful local commands – run from repo root:

# Lint & format
ruff format && ruff check .

# Type check (if used)
mypy .

# Tests with coverage
pytest

# Build docs
pip install -e .[docs] && make -C docs html

-->