### PR TITLE
Fix kernel no_bunching mode

### DIFF
--- a/merlin/algorithms/kernels.py
+++ b/merlin/algorithms/kernels.py
@@ -722,7 +722,9 @@ class FidelityKernel(torch.nn.Module):
 
         # Distribution for every evaluated circuit
         _, amplitudes = self._slos_graph.compute(all_circuits, self.input_state)
-        _, probabilities = self._slos_graph.post_pa_inc(amplitudes, all_circuits)
+        _, probabilities = self._slos_graph.compute_probs_from_amplitudes(
+            amplitudes, all_circuits
+        )
         if probabilities.ndim == 1:
             probabilities = probabilities.unsqueeze(0)
         probabilities = probabilities.to(dtype=self.dtype)
@@ -793,7 +795,9 @@ class FidelityKernel(torch.nn.Module):
 
         kernel_unitary = U @ U_adjoint
         _, amplitudes = self._slos_graph.compute(kernel_unitary, self.input_state)
-        _, probabilities = self._slos_graph.post_pa_inc(amplitudes, kernel_unitary)
+        _, probabilities = self._slos_graph.compute_probs_from_amplitudes(
+            amplitudes, kernel_unitary
+        )
         if probabilities.ndim == 1:
             probabilities = probabilities.unsqueeze(0)
         probabilities = probabilities.to(dtype=self.dtype, device=self.device)

--- a/merlin/algorithms/kernels.py
+++ b/merlin/algorithms/kernels.py
@@ -725,7 +725,7 @@ class FidelityKernel(torch.nn.Module):
         _, probabilities = self._slos_graph.post_pa_inc(amplitudes, all_circuits)
         if probabilities.ndim == 1:
             probabilities = probabilities.unsqueeze(0)
-        probabilities = probabilities.to(dtype=self.dtype, device=x1.device)
+        probabilities = probabilities.to(dtype=self.dtype)
 
         if self.shots > 0:
             probabilities = self._autodiff_process.sampling_noise.pcvl_sampler(

--- a/merlin/algorithms/kernels.py
+++ b/merlin/algorithms/kernels.py
@@ -25,6 +25,7 @@ class FeatureMap:
 
     Args:
         circuit: Pre-compiled :class:`pcvl.Circuit` to encode features.
+        input_size: Dimension of incoming classical data (required).
         builder: Optional :class:`CircuitBuilder` to compile into a circuit.
         input_parameters: Parameter prefix(es) that host the classical data.
         dtype: Torch dtype used when constructing the unitary.
@@ -34,9 +35,9 @@ class FeatureMap:
     def __init__(
         self,
         circuit: pcvl.Circuit | None = None,
+        input_size: int | None = None,
         *,
         builder: CircuitBuilder | None = None,
-        input_size: int,
         input_parameters: str | list[str] | None,
         trainable_parameters: list[str] | None = None,
         dtype: str | torch.dtype = torch.float32,
@@ -60,6 +61,8 @@ class FeatureMap:
         if circuit is None:
             raise ValueError("Either 'circuit' or 'builder' must be provided")
         self.circuit = circuit
+        if input_size is None:
+            raise TypeError("FeatureMap requires 'input_size' to be specified.")
         self.input_size = input_size
         if trainable_parameters is None:
             trainable_parameters = builder_trainable

--- a/merlin/algorithms/kernels.py
+++ b/merlin/algorithms/kernels.py
@@ -722,9 +722,7 @@ class FidelityKernel(torch.nn.Module):
 
         # Distribution for every evaluated circuit
         _, amplitudes = self._slos_graph.compute(all_circuits, self.input_state)
-        _, probabilities = self._slos_graph.compute_probs_from_amplitudes(
-            amplitudes, all_circuits
-        )
+        _, probabilities = self._slos_graph.compute_probs_from_amplitudes(amplitudes)
         if probabilities.ndim == 1:
             probabilities = probabilities.unsqueeze(0)
         probabilities = probabilities.to(dtype=self.dtype)
@@ -795,9 +793,7 @@ class FidelityKernel(torch.nn.Module):
 
         kernel_unitary = U @ U_adjoint
         _, amplitudes = self._slos_graph.compute(kernel_unitary, self.input_state)
-        _, probabilities = self._slos_graph.compute_probs_from_amplitudes(
-            amplitudes, kernel_unitary
-        )
+        _, probabilities = self._slos_graph.compute_probs_from_amplitudes(amplitudes)
         if probabilities.ndim == 1:
             probabilities = probabilities.unsqueeze(0)
         probabilities = probabilities.to(dtype=self.dtype, device=self.device)

--- a/merlin/pcvl_pytorch/slos_torchscript.py
+++ b/merlin/pcvl_pytorch/slos_torchscript.py
@@ -641,7 +641,7 @@ class SLOSComputeGraph:
 
         return amplitudes
 
-    def post_pa_inc(self, amplitudes, unitary):
+    def compute_probs_from_amplitudes(self, amplitudes, unitary):
         if len(unitary.shape) == 2:
             is_batched = False
         else:

--- a/merlin/pcvl_pytorch/slos_torchscript.py
+++ b/merlin/pcvl_pytorch/slos_torchscript.py
@@ -641,11 +641,14 @@ class SLOSComputeGraph:
 
         return amplitudes
 
-    def compute_probs_from_amplitudes(self, amplitudes, unitary):
-        if len(unitary.shape) == 2:
-            is_batched = False
-        else:
-            is_batched = True
+    def compute_probs_from_amplitudes(self, amplitudes):
+        added_batch_dim = False
+        if amplitudes.ndim == 1:
+            amplitudes = amplitudes.unsqueeze(0)
+            added_batch_dim = True
+
+        is_batched = amplitudes.shape[0] > 1
+
         probabilities = amplitudes.real**2 + amplitudes.imag**2
         probabilities *= self.norm_factor_output.to(probabilities.device)
         probabilities /= self.norm_factor_input
@@ -670,7 +673,7 @@ class SLOSComputeGraph:
                     )
             keys = self.final_keys if self.keep_keys else None
         # Remove batch dimension if input was single unitary
-        if not is_batched:
+        if not is_batched or added_batch_dim:
             probabilities = probabilities.squeeze(0)
 
         return keys, probabilities

--- a/tests/algorithms/test_kernels.py
+++ b/tests/algorithms/test_kernels.py
@@ -244,6 +244,111 @@ class TestFidelityKernel:
         )
 
 
+    def test_kernel_no_bunching(self):
+        from merlin.algorithms import FidelityKernel
+        from perceval import Circuit, BS, PS, P, Processor, GenericInterferometer, Unitary, BasicState
+        from perceval.algorithm import Sampler
+
+        # ---- Evaluate kernel using Perceval ----
+        def circ_func(x):
+            """Function for generating rectangular generic Interferometer
+            with an MZI depth equal to the number of modes
+            """
+            circuit = Circuit(2) // PS(P(f"phi{2 * x}")) // BS()
+            circuit.add(0, PS(P(f"phi{2 * x + 1}")))
+            circuit.add(0, BS())
+            return circuit
+
+        input_state = [1, 1, 0, 0]
+
+        # Define the unbunching kernel
+        circuit = GenericInterferometer(len(input_state), circ_func)
+        input_size = len(circuit.get_parameters())
+
+        feature_map = FeatureMap(circuit, input_size, input_parameters=["phi"])
+
+        unbunching_kernel = FidelityKernel(
+            feature_map,
+            input_state,
+            no_bunching=True,
+            force_psd=False,
+        )
+        quantum_kernel = FidelityKernel(
+            feature_map,
+            input_state,
+            no_bunching=False,
+        )
+
+        rng = np.random.default_rng(42)
+        X1 = rng.random(input_size)
+        X2 = rng.random(input_size)
+
+        merlin_pnr = float(quantum_kernel(X1, X2))
+        merlin_thr = float(unbunching_kernel(X1, X2))
+
+        print(F"MerLin quantum kernel (PNR) {quantum_kernel(X1, X2)}")
+        print(F"MerLin quantum kernel (THR) {unbunching_kernel(X1, X2)} \n")
+        # --- Compute kernel circuit unitary using Perceval ---
+        circuit_forward = GenericInterferometer(len(input_state), circ_func)
+        for i, p in enumerate(circuit_forward.get_parameters()):
+            p.set_value(X1[i])
+        forward_unitary = np.asarray(circuit_forward.compute_unitary(), dtype=np.complex128)
+
+        feature_forward = feature_map.compute_unitary(
+            torch.as_tensor(X1, dtype=feature_map.dtype)
+        ).detach().cpu().numpy()
+        assert np.allclose(feature_forward, forward_unitary, atol=1e-6)
+
+        circuit_backward = GenericInterferometer(len(input_state), circ_func)
+        for i, p in enumerate(circuit_backward.get_parameters()):
+            p.set_value(X2[i])
+        backward_unitary = np.asarray(circuit_backward.compute_unitary(), dtype=np.complex128)
+
+        feature_backward = feature_map.compute_unitary(
+            torch.as_tensor(X2, dtype=feature_map.dtype)
+        ).detach().cpu().numpy()
+        assert np.allclose(feature_backward, backward_unitary, atol=1e-6)
+
+        circ_unitary = forward_unitary @ backward_unitary.conj().T
+        circ_unitary = Unitary(pcvl.Matrix(circ_unitary))
+
+        # Set up processor
+        processor = Processor("SLOS")
+        processor.set_circuit(circ_unitary)
+        processor.with_input(BasicState([1, 1, 0, 0]))
+        processor.min_detected_photons_filter(0)
+
+        sampler = Sampler(processor)
+        def state_to_tuple(state):
+            try:
+                return tuple(int(n) for n in state.tolist())
+            except AttributeError:
+                return tuple(int(n) for n in state)
+
+        raw_results = sampler.probs()["results"]
+        results = {
+            state_to_tuple(state): float(prob)
+            for state, prob in raw_results.items()
+        }
+
+        key = tuple(input_state)
+        assert key in results
+        perceval_pnr = results[key]
+
+        thresholded_results = {
+            state: prob for state, prob in results.items() if max(state) == 1
+        }
+        print(f"Thresholded results with Perceval = {thresholded_results}")
+        total_threshold_prob = sum(thresholded_results.values())
+
+        assert total_threshold_prob > 0
+        assert key in thresholded_results
+
+        perceval_thr = thresholded_results[key] / total_threshold_prob
+
+        assert merlin_pnr == pytest.approx(perceval_pnr, rel=1e-6, abs=1e-8)
+        assert merlin_thr == pytest.approx(perceval_thr, rel=1e-6, abs=1e-8)
+
 class TestNKernelAlignment:
     def setup_method(self):
         self.loss_fn = NKernelAlignment()

--- a/tests/core/test_superposition_state.py
+++ b/tests/core/test_superposition_state.py
@@ -18,7 +18,7 @@ def classical_method(layer, input_state):
             value * layer.computation_process.simulation_graph.prev_amplitudes
         )
 
-    output_probs = layer.computation_process.simulation_graph.post_pa_inc(
+    output_probs = layer.computation_process.simulation_graph.compute_probs_from_amplitudes(
         output_classical, layer.computation_process.unitary
     )
     return output_probs[1]

--- a/tests/core/test_superposition_state.py
+++ b/tests/core/test_superposition_state.py
@@ -19,7 +19,7 @@ def classical_method(layer, input_state):
         )
 
     output_probs = layer.computation_process.simulation_graph.compute_probs_from_amplitudes(
-        output_classical, layer.computation_process.unitary
+        output_classical
     )
     return output_probs[1]
 


### PR DESCRIPTION
<!--
Thank you for contributing to MerLin!
Please fill out the sections below to help us review your PR efficiently.
-->

## Summary
<!-- What does this PR do? A clear, concise description. -->
As highligthed by Anthony, there was an issue with the no_bunching = True mode of the FidelityKernel

- the unbunching statistics are not normalized (presumably after removing the bunching stats from the results.)
- in layer.py, we normalize the results after the SLOS graph (line 605 in  layer.py) -> we should do the same for the FidelityKernel


## Context / Related Issues
<!-- Why do you do this PR ? Is it linked to a previous PR ? A clear, concise description. -->
<!-- e.g., Closes #123, Fixes #456 -->
The no_bunching mode of the FidelityKernel is wrong

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / Cleanup
- [ ] Performance improvement
- [ ] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)


## Proposed changes
<!-- Bulleted list of key changes. If API changes, list them explicitly. -->
- First, I added a test (based on Anthony's failing case) and edited it a bit:

1. I added a deterministic RNG so PNR/THR comparisons are reproducible and tightened the Perceval post-processing
2. I rebuilt the Perceval reference unitary without mutating shared circuit objects—fresh forward/backward interferometers mirror the FeatureMap outputs and construct a valid Perceval Unitary for the comparison step

- I updated the kernel to pull normalized probabilities straight from SLOS, ensuring the no‑bunching branch matches Perceval’s thresholded distribution before any sampling noise


## How to test / How to run
<!-- Describe test plan and steps for reviewers to validate and run your changes locally. Include datasets if relevant. -->


```
pytest tests/algorithms/test_kernels.py::TestFidelityKernel::test_kernel_no_bunching
```

## Checklist
- [ ] Code formatted (ruff format)
- [ ] Lint passes (ruff)
- [ ] Static typing passes (mypy) if applicable
- [ ] Unit tests added/updated (pytest)
- [ ] Tests pass locally (pytest)
- [ ] Tests pass on GPU (pytest)
- [ ] Test coverage not decreased significantly
- [ ] Docs build locally if affected (sphinx)
- [ ] Dependencies updated (if needed) and pinned appropriately
- [ ] I have added a clear PR title and description

<!-- Helpful local commands – run from repo root:

# Lint & format
ruff format && ruff check .

# Type check (if used)
mypy .

# Tests with coverage
pytest

# Build docs
pip install -e .[docs] && make -C docs html

-->