### PR TITLE
Add K-MNIST and Fashion-MNIST datasets API

### DIFF
--- a/merlin/datasets/fashion_mnist.py
+++ b/merlin/datasets/fashion_mnist.py
@@ -1,0 +1,117 @@
+# MIT License
+#
+# Copyright (c) 2025 Quandela
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import numpy as np
+import pandas as pd
+
+from merlin.datasets import DatasetMetadata
+
+from .utils import fetch
+
+FASHION_MNIST_METADATA = {
+    "name": "Fashion-MNIST",
+    "description": "Fashion-MNIST is a dataset of Zalando's article images—consisting of a training set of 60,000 examples and a test set of 10,000 examples. Each example is a 28x28 grayscale image, associated with a label from 10 classes. Zalando intends Fashion-MNIST to serve as a direct drop-in replacement for the original MNIST dataset for benchmarking machine learning algorithms. It shares the same image size and structure of training and testing splits.",
+    "features": [
+        {
+            "name": "pixel_values",
+            "description": "Grayscale image of Zalando's article",
+            "type": "uint8",
+            "value_range": (0, 255),
+            "unit": None,
+        },
+        {
+            "name": "label",
+            "description": "Article class label",
+            "type": "uint8",
+            "value_range": (0, 9),
+            "unit": None,
+        },
+    ],
+    "num_instances": 70000,  # 60000 training + 10000 test
+    "task_type": ["classification"],
+    "num_classes": 10,
+    "characteristics": ["image"],
+    "homepage": "https://huggingface.co/datasets/vincent-espitalier/Fashion-MNIST-CSV",
+    "license": "MIT",
+    "citation": """@online{fashionmnist2017,
+        author       = {Zalando Research},
+        title        = {Fashion MNIST},
+        year         = {2017},
+    }""",
+    "creators": [
+        "Zalando Research",
+    ],
+    "year": 2017,
+}
+
+
+def get_data_train_huggingface():
+    train = fetch(
+        "https://huggingface.co/datasets/vincent-espitalier/Fashion-MNIST-CSV/resolve/main/fashion-mnist_train.csv"
+    )
+    df_train = pd.read_csv(train)
+
+    X = (
+        df_train[[col for col in df_train.columns if col.startswith("pixel")]]
+        .values.astype(np.float32)
+        .reshape(-1, 28, 28)
+    )
+    y = df_train["label"].to_numpy()
+
+    FASHION_MNIST_METADATA["num_instances"] = len(X)
+    FASHION_MNIST_METADATA["subset"] = "train"
+    return X, y, DatasetMetadata.from_dict(FASHION_MNIST_METADATA)
+
+
+def get_data_test_huggingface():
+    val = fetch(
+        "https://huggingface.co/datasets/vincent-espitalier/Fashion-MNIST-CSV/resolve/main/fashion-mnist_test.csv"
+    )
+    df_val = pd.read_csv(val)
+
+    X = (
+        df_val[[col for col in df_val.columns if col.startswith("pixel")]]
+        .values.astype(np.float32)
+        .reshape(-1, 28, 28)
+    )
+    y = df_val["label"].to_numpy()
+
+    FASHION_MNIST_METADATA["num_instances"] = len(X)
+    FASHION_MNIST_METADATA["subset"] = "val"
+    return X, y, DatasetMetadata.from_dict(FASHION_MNIST_METADATA)
+
+
+__all__ = [
+    "get_data_train_huggingface",
+    "get_data_test_huggingface",
+]
+
+# Example usage
+if __name__ == "__main__":
+    X, y, metadata = get_data_train_huggingface()
+    Xtest, ytest, _ = get_data_test_huggingface()
+    print(len(X), len(Xtest))
+    # Mean of per-pixel standard deviations – Helps characterize/identify the dataset by capturing pixel-level variability.
+    X_mean_std_per_pixel = np.std(X.reshape(X.shape[0], -1), axis=0).mean()
+    Xtest_mean_std_per_pixel = np.std(Xtest.reshape(Xtest.shape[0], -1), axis=0).mean()
+    print(X_mean_std_per_pixel, Xtest_mean_std_per_pixel)
+    print(metadata)

--- a/merlin/datasets/k_mnist.py
+++ b/merlin/datasets/k_mnist.py
@@ -1,0 +1,126 @@
+# MIT License
+#
+# Copyright (c) 2025 Quandela
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import numpy as np
+import pandas as pd
+
+from merlin.datasets import DatasetMetadata
+
+from .utils import fetch
+
+K_MNIST_METADATA = {
+    "name": "Kuzushiji-MNIST",
+    "description": "Kuzushiji-MNIST is a drop-in replacement for the MNIST dataset (28x28 grayscale, 70,000 images). Since MNIST restricts us to 10 classes, we chose one character to represent each of the 10 rows of Hiragana when creating Kuzushiji-MNIST.",
+    "features": [
+        {
+            "name": "pixel_values",
+            "description": "Grayscale image of handwritten character",
+            "type": "uint8",
+            "value_range": (0, 255),
+            "unit": None,
+        },
+        {
+            "name": "label",
+            "description": "Character class label",
+            "type": "uint8",
+            "value_range": (0, 9),
+            "unit": None,
+        },
+    ],
+    "num_instances": 70000,  # 60000 training + 10000 test
+    "task_type": ["classification"],
+    "num_classes": 10,
+    "characteristics": ["image", "handwritten"],
+    "homepage": "https://huggingface.co/datasets/vincent-espitalier/K-MNIST-CSV",
+    "license": "Creative Commons Attribution-Share Alike 4.0",
+    "citation": """@online{clanuwat2018deep,
+        author       = {Tarin Clanuwat and Mikel Bober-Irizar and Asanobu Kitamoto and Alex Lamb and Kazuaki Yamamoto and David Ha},
+        title        = {Deep Learning for Classical Japanese Literature},
+        date         = {2018-12-03},
+        year         = {2018},
+        eprintclass  = {cs.CV},
+        eprinttype   = {arXiv},
+        eprint       = {cs.CV/1812.01718},
+    }""",
+    "creators": [
+        "Tarin Clanuwat",
+        "Mikel Bober-Irizar",
+        "Asanobu Kitamoto",
+        "Alex Lamb",
+        "Kazuaki Yamamoto",
+        "David Ha",
+    ],
+    "year": 2018,
+}
+
+
+def get_data_train_huggingface():
+    train = fetch(
+        "https://huggingface.co/datasets/vincent-espitalier/K-MNIST-CSV/resolve/main/kmnist_train.csv"
+    )
+    df_train = pd.read_csv(train)
+
+    X = (
+        df_train[[col for col in df_train.columns if col.startswith("pixel")]]
+        .values.astype(np.float32)
+        .reshape(-1, 28, 28)
+    )
+    y = df_train["label"].to_numpy()
+
+    K_MNIST_METADATA["num_instances"] = len(X)
+    K_MNIST_METADATA["subset"] = "train"
+    return X, y, DatasetMetadata.from_dict(K_MNIST_METADATA)
+
+
+def get_data_test_huggingface():
+    val = fetch(
+        "https://huggingface.co/datasets/vincent-espitalier/K-MNIST-CSV/resolve/main/kmnist_test.csv"
+    )
+    df_val = pd.read_csv(val)
+
+    X = (
+        df_val[[col for col in df_val.columns if col.startswith("pixel")]]
+        .values.astype(np.float32)
+        .reshape(-1, 28, 28)
+    )
+    y = df_val["label"].to_numpy()
+
+    K_MNIST_METADATA["num_instances"] = len(X)
+    K_MNIST_METADATA["subset"] = "val"
+    return X, y, DatasetMetadata.from_dict(K_MNIST_METADATA)
+
+
+__all__ = [
+    "get_data_train_huggingface",
+    "get_data_test_huggingface",
+]
+
+# Example usage
+if __name__ == "__main__":
+    X, y, metadata = get_data_train_huggingface()
+    Xtest, ytest, _ = get_data_test_huggingface()
+    print(len(X), len(Xtest))
+    # Mean of per-pixel standard deviations – Helps characterize/identify the dataset by capturing pixel-level variability.
+    X_mean_std_per_pixel = np.std(X.reshape(X.shape[0], -1), axis=0).mean()
+    Xtest_mean_std_per_pixel = np.std(Xtest.reshape(Xtest.shape[0], -1), axis=0).mean()
+    print(X_mean_std_per_pixel, Xtest_mean_std_per_pixel)
+    print(metadata)

--- a/merlin/datasets/mnist_digits.py
+++ b/merlin/datasets/mnist_digits.py
@@ -207,7 +207,12 @@ __all__ = [
 
 # Example usage
 if __name__ == "__main__":
-    X, y, metadata = get_data_train_percevalquest()
-    Xtest, ytest, _ = get_data_test_percevalquest()
+    X, y, metadata = get_data_train_original()
+    Xtest, ytest, _ = get_data_test_original()
+    X_mean_std_per_pixel = np.std(X.reshape(X.shape[0], -1), axis=0).mean()
     print(len(X), len(Xtest))
+    # Mean of per-pixel standard deviations – Helps characterize/identify the dataset by capturing pixel-level variability.
+    X_mean_std_per_pixel = np.std(X.reshape(X.shape[0], -1), axis=0).mean()
+    Xtest_mean_std_per_pixel = np.std(Xtest.reshape(Xtest.shape[0], -1), axis=0).mean()
+    print(X_mean_std_per_pixel, Xtest_mean_std_per_pixel)
     print(metadata)


### PR DESCRIPTION
## Summary
Add K-MNIST and Fashion-MNIST datasets

## Context / Related Issues
Extend MerLin's datasets API with common ML datasets.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Refactor / Cleanup
- [ ] Performance improvement
- [ ] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)

## How to test / How to run
The following commands, run from the MerLin directory, download the datasets and display their metadata: :
```
$ python -m datasets.k_mnist
$ python -m datasets.fashion_mnist
```

