### PR TITLE
minimal feedforward example from tests that passed + sketch of how to…

### DIFF
--- a/docs/source/user_guide/feed_forward.rst
+++ b/docs/source/user_guide/feed_forward.rst
@@ -135,5 +135,4 @@ Shape & parameter checklist
 
 - **Pooling** (Section C):
   - Stand-alone: feed a tensor with width ``len(match_indices)+len(exclude_indices)``.
-  - End-to-end: place :class:`PoolingFeedForward` between a producer and a consumer
-    of amplitudes defined on matching mode spaces.
+  - End-to-end: place :class:`PoolingFeedForward` between a producer and a consumer of amplitudes defined on matching mode spaces.


### PR DESCRIPTION
## Summary
This doc replaces the feedforward documentation with code that is guaranteed to run following the tests that Gregoire left. Issues with computation space currently therefore the aim is to make the feedforward.rst docs very minimal and to provide sketches of how custom layers would be done once fixed

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / Cleanup
- [ ] Performance improvement
- [ ] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)

## Documentation
- [x] User docs updated (Sphinx)
- [ ] Examples / notebooks updated
- [ ] Docstrings updated

## Checklist
- [x ] Code formatted (ruff format)
- [x ] Lint passes (ruff)
- [x ] Static typing passes (mypy) if applicable
- [x ] Unit tests added/updated (pytest)
- [x ] Tests pass locally (pytest)
- [x ] Tests pass on GPU (pytest)
- [x ] Test coverage not decreased significantly
- [x ] Docs build locally if affected (sphinx)
- [x ] Dependencies updated (if needed) and pinned appropriately
- [x ] I have added a clear PR title and description

<!-- Helpful local commands – run from repo root:

# Lint & format
ruff format && ruff check .

# Type check (if used)
mypy .

# Tests with coverage
pytest

# Build docs
pip install -e .[docs] && make -C docs html

-->