### PR TITLE
PML-126 PR template update to include Jira key

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,22 @@
 <!--
 Thank you for contributing to MerLin!
 Please fill out the sections below to help us review your PR efficiently.
+
+NOTE: this repo is a public repository, therefore, do NOT paste Jira URLs. Use the Jira issue key only (e.g., PML-126).
+The Jira–GitHub integration will link PRs/commits automatically when the key is present.
 -->
+
+<!-- Add the Jira issue key in the title -->
+<!-- e.g., PML-126 Updating PR template -->
 
 ## Summary
 <!-- What does this PR do? A clear, concise description. -->
+
+## Related Jira ticket (required)
+<!-- Use the Jira issue key ONLY (no URL), e.g.:
+Related Jira: PML-126
+-->
+Related Jira:
 
 ## Context / Related Issues
 <!-- Why do you do this PR ? Is it linked to a previous PR ? A clear, concise description. -->
@@ -45,6 +57,8 @@ Block of code
 - [ ] Docstrings updated
 
 ## Checklist
+- [ ] PR title includes Jira issue key (e.g., PML-126)
+- [ ] "Related Jira ticket" section includes the Jira issue key (no URL)
 - [ ] Code formatted (ruff format)
 - [ ] Lint passes (ruff)
 - [ ] Static typing passes (mypy) if applicable
@@ -54,7 +68,7 @@ Block of code
 - [ ] Test coverage not decreased significantly
 - [ ] Docs build locally if affected (sphinx)
 - [ ] Dependencies updated (if needed) and pinned appropriately
-- [ ] I have added a clear PR title and description
+- [ ] PR description explains what changed and how to validate it
 
 <!-- Helpful local commands – run from repo root:
 


### PR DESCRIPTION
<!--
Thank you for contributing to MerLin!
Please fill out the sections below to help us review your PR efficiently.
-->

## Summary
<!-- What does this PR do? A clear, concise description. -->
I am updating slightly the PR template to:

- advise to have the Jira ticket key in the title of the PR
- add a "mandatory" section to give the Jira ticket key
- edit checklist accordingly
Note: the "mandatory" is not blocking the PR as external contributor could make a PR without having access to the Jira

This PR needs to be merged on `main` branch for the change to be propagated to all branches

This PR acts as a test as well for the Jira-GitHub workflow

## Related Jira ticket (required)
<!-- Use the Jira issue key ONLY (no URL), e.g.:
Related Jira: PML-126
-->
Related Jira: PML-126

## Context / Related Issues
<!-- Why do you do this PR ? Is it linked to a previous PR ? A clear, concise description. -->
<!-- e.g., Closes #123, Fixes #456 -->
It is not obvious that we need to write the Jira ticket key in title and in description of our PR

## Type of change
- [x] CI / Build / Tooling

## Checklist
- [x] PR title includes Jira issue key (e.g., PML-126)
- [x] "Related Jira ticket" section includes the Jira issue key (no URL)

**REMARK**: failing tests are not related to this PR and are fixed in #100 

<!-- Helpful local commands – run from repo root:

# Lint & format
ruff format && ruff check .

# Type check (if used)
mypy .

# Tests with coverage
pytest

# Build docs
pip install -e .[docs] && make -C docs html

-->