### PR TITLE
PML-128 fix theta naming on test and ruff format issue with new ruff

### DIFF
--- a/merlin/algorithms/kernels.py
+++ b/merlin/algorithms/kernels.py
@@ -867,7 +867,8 @@ class FidelityKernel(MerlinModule):
             ])
             if isinstance(x2, torch.Tensor):
                 U_adjoint = torch.stack([
-                    self.feature_map.compute_unitary(x)
+                    self.feature_map
+                    .compute_unitary(x)
                     .transpose(0, 1)
                     .conj()
                     .to(x1.device)

--- a/merlin/core/generators.py
+++ b/merlin/core/generators.py
@@ -93,8 +93,10 @@ class CircuitGenerator:
             # For reservoir mode: use fixed random values instead of parameters
             return pcvl.GenericInterferometer(
                 n_modes,
-                lambda idx: pcvl.BS(theta=np.pi * 2 * random.random())
-                // (0, pcvl.PS(phi=np.pi * 2 * random.random())),
+                lambda idx: (
+                    pcvl.BS(theta=np.pi * 2 * random.random())
+                    // (0, pcvl.PS(phi=np.pi * 2 * random.random()))
+                ),
                 shape=pcvl.InterferometerShape.RECTANGLE,
                 depth=2 * n_modes,
                 phase_shifter_fun_gen=lambda idx: pcvl.PS(
@@ -105,7 +107,8 @@ class CircuitGenerator:
             # Original implementation with named parameters
             def mzi(P1, P2):
                 return (
-                    pcvl.Circuit(2)
+                    pcvl
+                    .Circuit(2)
                     .add((0, 1), pcvl.BS())
                     .add(0, pcvl.PS(P1))
                     .add((0, 1), pcvl.BS())

--- a/merlin/pcvl_pytorch/locirc_to_tensor.py
+++ b/merlin/pcvl_pytorch/locirc_to_tensor.py
@@ -364,7 +364,8 @@ class CircuitConverter:
         self.batch_size = batch_size
 
         converted_tensor = (
-            torch.eye(self.circuit.m, dtype=self.tensor_cdtype, device=self.device)
+            torch
+            .eye(self.circuit.m, dtype=self.tensor_cdtype, device=self.device)
             .unsqueeze(0)
             .repeat(batch_size, 1, 1)
         )
@@ -402,7 +403,8 @@ class CircuitConverter:
             Batched unitary tensor of shape (batch_size, comp_size, comp_size)
         """
         return (
-            torch.tensor(
+            torch
+            .tensor(
                 comp.compute_unitary(), dtype=self.tensor_cdtype, device=self.device
             )
             .unsqueeze(0)
@@ -471,7 +473,8 @@ class CircuitConverter:
             )
 
         unitary_tensor = (
-            unitary_tensor.unsqueeze(0)
+            unitary_tensor
+            .unsqueeze(0)
             .repeat(self.batch_size, 1, 1)
             .to(cos_theta.device)
         )

--- a/tests/algorithms/test_feed_forward_block.py
+++ b/tests/algorithms/test_feed_forward_block.py
@@ -285,12 +285,12 @@ def test_feedforward_block2_input_and_trainable_parameters_backward():
     exp = pcvl.Experiment()
     root = pcvl.Circuit(2)
     root.add(0, pcvl.PS(pcvl.P("phi")))
-    root.add((0, 1), pcvl.BS(theta=pcvl.P("theta")))
+    root.add((0, 1), pcvl.BS(theta=pcvl.P("theta_1")))
     exp.add(0, root)
     exp.add(0, pcvl.Detector.pnr())
 
     conditional = pcvl.Circuit(1)
-    conditional.add(0, pcvl.PS(pcvl.P("theta")))
+    conditional.add(0, pcvl.PS(pcvl.P("theta_2")))
     provider = pcvl.FFCircuitProvider(1, 0, conditional)
     exp.add(0, provider)
 


### PR DESCRIPTION
<!--
Thank you for contributing to MerLin!
Please fill out the sections below to help us review your PR efficiently.
-->

## Summary
<!-- What does this PR do? A clear, concise description. -->
Fix CPU tests and ruff :
- fix theta naming in failing test (also linked to a change made in PR #94)
- fix ruff formating issue

## Related Jira key
Related Jira: PML-128

## Context / Related Issues
<!-- Why do you do this PR ? Is it linked to a previous PR ? A clear, concise description. -->
<!-- e.g., Closes #123, Fixes #456 -->

## Type of change
- [x] Bug fix


## Proposed changes
<!-- Bulleted list of key changes. If API changes, list them explicitly. -->

- named "theta_1" and "theta_2" in `test_feedforward_block/test_feedforward_block2_input_and_trainable_parameters_backward` to avoid naming 2 parameters the same way
- ruff formatting on 3 files that did not fit with `ruff 0.14.10` last requirements


- ## How to test / How to run
<!-- Describe test plan and steps for reviewers to validate and run your changes locally. Include datasets if relevant. -->

1. Command lines

```
pytest 
ruff format .
ruff check .
```

**CAUTION**:  ruff has been updated. Here, I am using ruff 0.14.10 (otherwise I was not seeing any issue). This is due to the fact that the ruff version used by CI upon installation comes from `pip installl -e ".[dev]"` with requirements `ruff>=0.1.0`

## Checklist
- [x] Code formatted (ruff format)
- [x] Lint passes (ruff)
- [x] Static typing passes (mypy) if applicable
- [x] Tests pass locally (pytest)
- [x] Test coverage not decreased significantly

<!-- Helpful local commands – run from repo root:

# Lint & format
ruff format && ruff check .

# Type check (if used)
mypy .

# Tests with coverage
pytest

# Build docs
pip install -e .[docs] && make -C docs html

-->