### PR TITLE
PML-133: refactor QuantumLayer.init into composable setup steps

### DIFF
--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -254,6 +254,10 @@ class QuantumLayer(MerlinModule):
         # Phase 11: assign context to self + warnings
         self._finalize_from_context(context)
         # Phase 12: downstream setup
+        # Defaults/validation handled in this method:
+        # - Generate default input_state from n_photons when missing.
+        # - Infer/validate input_size against encoder metadata.
+        # - Setup parameters, measurement strategy, and output sizing.
         self._init_from_custom_circuit(context)
 
     def _finalize_from_context(self, context: InitializationContext) -> None:

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -46,14 +46,10 @@ from ..measurement import OutputMapper
 from ..measurement.autodiff import AutoDiffProcess
 from ..measurement.detectors import DetectorTransform
 from ..measurement.photon_loss import PhotonLossTransform
-from ..measurement.strategies import MeasurementStrategy
-from ..measurement.detectors import DetectorTransform, resolve_detectors
-from ..measurement.photon_loss import PhotonLossTransform, resolve_photon_loss
 from ..measurement.strategies import (
     MeasurementStrategy,
     resolve_measurement_strategy,
 )
-from ..pcvl_pytorch.utils import pcvl_to_tensor
 from ..utils.deprecations import sanitize_parameters
 from ..utils.grouping import ModGrouping
 from .layer_utils import (

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -233,14 +233,7 @@ class QuantumLayer(MerlinModule):
 
         self._finalize_from_context(context)
 
-        self._init_from_custom_circuit(
-            self.circuit,
-            self.input_state,
-            self.n_photons,
-            self.trainable_parameters,
-            self.input_parameters,
-            self.measurement_strategy,
-        )
+        self._init_from_custom_circuit(context)
 
     def _finalize_from_context(self, context: InitializationContext) -> None:
         """Assign initialization context to instance attributes."""
@@ -276,16 +269,15 @@ class QuantumLayer(MerlinModule):
 
     # ---------------- core init paths ----------------
 
-    def _init_from_custom_circuit(
-        self,
-        circuit: pcvl.Circuit,
-        input_state: list[int] | None,
-        n_photons: int | None,
-        trainable_parameters: list[str],
-        input_parameters: list[str],
-        measurement_strategy: MeasurementStrategy,
-    ):
+    def _init_from_custom_circuit(self, context: InitializationContext):
         """Initialize from custom circuit (backward compatible mode)."""
+        circuit = context.circuit
+        input_state = context.input_state
+        n_photons = context.n_photons
+        trainable_parameters = context.trainable_parameters
+        input_parameters = context.input_parameters
+        measurement_strategy = context.measurement_strategy
+
         if input_state is not None:
             self.input_state = input_state
         elif n_photons is not None:

--- a/merlin/algorithms/layer_utils.py
+++ b/merlin/algorithms/layer_utils.py
@@ -1,0 +1,495 @@
+# MIT License
+#
+# Copyright (c) 2025 Quandela
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Utilities and helpers for QuantumLayer initialization and configuration.
+"""
+
+# Usage outline (mirrors QuantumLayer.__init__ phases):
+# 1) validate_and_resolve_circuit_source -> obtain prefixes/specs
+# 2) validate_encoding_mode -> enforce amplitude/classical constraints
+# 3) prepare_input_state -> normalize input state (incl. experiment override)
+# 4) vet_experiment -> reject unsupported experiments
+# 5) resolve_circuit -> build circuit/experiment wrapper
+# 6) setup_noise_and_detectors -> extract noise/detectors + compatibility checks
+# 7) Encoding/output utilities -> used during parameter prep & forward
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import exqalibur as xqlbr
+import perceval as pcvl
+import torch
+
+from ..builder.circuit_builder import CircuitBuilder
+from ..core.computation_space import ComputationSpace
+from ..measurement.detectors import resolve_detectors
+from ..measurement.photon_loss import resolve_photon_loss
+from ..measurement.strategies import MeasurementStrategy
+from ..pcvl_pytorch.utils import pcvl_to_tensor
+
+
+@dataclass(frozen=True)
+class EncodingModeConfig:
+    """Validated encoding configuration."""
+
+    amplitude_encoding: bool
+    input_size: int | None
+    n_photons: int | None
+    input_parameters: list[str]
+
+
+@dataclass(frozen=True)
+class CircuitSource:
+    """Resolved circuit source configuration."""
+
+    source_type: Literal["builder", "circuit", "experiment"]
+    builder: CircuitBuilder | None
+    circuit: pcvl.Circuit | None
+    experiment: pcvl.Experiment | None
+    trainable_parameters: list[str]
+    input_parameters: list[str]
+    angle_encoding_specs: dict[str, dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class ResolvedCircuit:
+    """Resolved circuit and experiment."""
+
+    circuit: pcvl.Circuit
+    experiment: pcvl.Experiment
+    noise_model: Any | None
+    has_custom_noise: bool
+
+
+@dataclass(frozen=True)
+class NoiseAndDetectorConfig:
+    """Extracted noise and detector configuration."""
+
+    photon_survival_probs: list[float]
+    has_custom_noise: bool
+    detectors: list[pcvl.Detector]
+    has_custom_detectors: bool
+    detector_warnings: list[str]
+
+
+@dataclass(frozen=True)
+class InitializationContext:
+    """Immutable context for QuantumLayer initialization."""
+
+    device: torch.device | None
+    dtype: torch.dtype
+    complex_dtype: torch.dtype
+    amplitude_encoding: bool
+    input_size: int | None
+    circuit: pcvl.Circuit
+    experiment: pcvl.Experiment
+    noise_model: Any | None
+    has_custom_noise: bool
+    input_state: list[int] | torch.Tensor | None
+    n_photons: int | None
+    trainable_parameters: list[str]
+    input_parameters: list[str]
+    angle_encoding_specs: dict[str, dict[str, Any]]
+    photon_survival_probs: list[float]
+    detectors: list[pcvl.Detector]
+    has_custom_detectors: bool
+    computation_space: ComputationSpace
+    measurement_strategy: MeasurementStrategy
+    warnings: list[str]
+
+
+def validate_encoding_mode(
+    amplitude_encoding: bool,
+    input_size: int | None,
+    n_photons: int | None,
+    input_parameters: list[str] | None,
+) -> EncodingModeConfig:
+    """Fail-fast validation for amplitude encoding constraints."""
+    resolved_input_params = list(input_parameters) if input_parameters else []
+
+    if amplitude_encoding:
+        if input_size is not None:
+            raise ValueError(
+                "When amplitude_encoding is enabled, do not specify input_size; it "
+                "is inferred from the computation space."
+            )
+        if n_photons is None:
+            raise ValueError("n_photons must be provided when amplitude_encoding=True.")
+        if resolved_input_params:
+            raise ValueError(
+                "Amplitude encoding cannot be combined with classical input parameters."
+            )
+        resolved_input_size = None
+    else:
+        resolved_input_size = int(input_size) if input_size is not None else None
+
+    return EncodingModeConfig(
+        amplitude_encoding=amplitude_encoding,
+        input_size=resolved_input_size,
+        n_photons=n_photons,
+        input_parameters=resolved_input_params,
+    )
+
+
+def prepare_input_state(
+    input_state: list[int] | pcvl.BasicState | pcvl.StateVector | None,
+    n_photons: int | None,
+    computation_space: ComputationSpace,
+    device: torch.device | None,
+    complex_dtype: torch.dtype,
+    experiment: pcvl.Experiment | None = None,
+) -> tuple[list[int] | torch.Tensor | None, int | None]:
+    """Normalize input_state to canonical form."""
+    if experiment is not None and experiment.input_state is not None:
+        if input_state is not None and experiment.input_state != input_state:
+            warnings.warn(
+                "Both 'experiment.input_state' and 'input_state' are provided. "
+                "'experiment.input_state' will be used.",
+                UserWarning,
+                stacklevel=2,
+            )
+        input_state = experiment.input_state
+
+    if isinstance(input_state, pcvl.BasicState):
+        if not isinstance(input_state, xqlbr.FockState):
+            raise ValueError("BasicState with annotations is not supported")
+        input_state = list(input_state)
+    elif isinstance(input_state, pcvl.StateVector):
+        if len(input_state) == 0:
+            raise ValueError("input_state StateVector cannot be empty")
+        sv_n_photons = input_state.n.pop()
+        if n_photons is not None and sv_n_photons != n_photons:
+            raise ValueError(
+                "Inconsistent number of photons between input_state and n_photons."
+            )
+        return (
+            pcvl_to_tensor(
+                input_state,
+                computation_space,
+                device=device,
+                dtype=complex_dtype,
+            ),
+            sv_n_photons,
+        )
+
+    if input_state is None and n_photons is None:
+        raise ValueError("Either input_state or n_photons must be provided")
+
+    return input_state, n_photons
+
+
+def validate_and_resolve_circuit_source(
+    builder: CircuitBuilder | None,
+    circuit: pcvl.Circuit | None,
+    experiment: pcvl.Experiment | None,
+    trainable_parameters: list[str] | None,
+    input_parameters: list[str] | None,
+) -> CircuitSource:
+    """Enforce exactly one of (builder, circuit, experiment) is provided."""
+    if sum(x is not None for x in (circuit, builder, experiment)) != 1:
+        raise ValueError(
+            "Provide exactly one of 'circuit', 'builder', or 'experiment'."
+        )
+
+    if builder is not None and (
+        trainable_parameters is not None or input_parameters is not None
+    ):
+        raise ValueError(
+            "When providing a builder, do not also specify 'trainable_parameters' "
+            "or 'input_parameters'. Those prefixes are derived from the builder."
+        )
+
+    if builder is not None:
+        return CircuitSource(
+            source_type="builder",
+            builder=builder,
+            circuit=None,
+            experiment=None,
+            trainable_parameters=list(builder.trainable_parameter_prefixes),
+            input_parameters=list(builder.input_parameter_prefixes),
+            angle_encoding_specs=builder.angle_encoding_specs,
+        )
+
+    resolved_trainable = list(trainable_parameters) if trainable_parameters else []
+    resolved_input = list(input_parameters) if input_parameters else []
+    source_type: Literal["circuit", "experiment"] = (
+        "circuit" if circuit is not None else "experiment"
+    )
+
+    return CircuitSource(
+        source_type=source_type,
+        builder=None,
+        circuit=circuit,
+        experiment=experiment,
+        trainable_parameters=resolved_trainable,
+        input_parameters=resolved_input,
+        angle_encoding_specs={},
+    )
+
+
+def vet_experiment(experiment: pcvl.Experiment) -> dict[str, bool]:
+    """Check experiment constraints."""
+    has_post_select = experiment.post_select_fn is not None
+    has_heralding = bool(experiment.heralds) or bool(experiment.in_heralds)
+    has_feedforward = bool(getattr(experiment, "has_feedforward", False))
+    has_td_attr = getattr(experiment, "has_td", None)
+    has_td = has_td_attr() if callable(has_td_attr) else bool(has_td_attr)
+    has_min_photons_filter = bool(getattr(experiment, "min_photons_filter", False))
+    has_noise = bool(getattr(experiment, "noise", None))
+
+    if has_post_select or has_heralding:
+        raise ValueError(
+            "The provided experiment must not have post-selection or heralding."
+        )
+    if has_feedforward:
+        raise ValueError(
+            "Feed-forward components are not supported inside a QuantumLayer experiment."
+        )
+    if has_td:
+        raise ValueError(
+            "The provided experiment must be unitary, and must not have post-selection or heralding."
+        )
+    if has_min_photons_filter:
+        raise ValueError("The provided experiment must not have a min_photons_filter.")
+
+    return {
+        "is_unitary": not has_td,
+        "has_noise": has_noise,
+        "has_post_select": has_post_select,
+        "has_heralding": has_heralding,
+        "has_feedforward": has_feedforward,
+        "has_min_photons_filter": has_min_photons_filter,
+    }
+
+
+def resolve_circuit(
+    circuit_source: CircuitSource,
+    pcvl_module,
+) -> ResolvedCircuit:
+    """Convert builder/circuit/experiment to unified circuit form."""
+    if circuit_source.source_type == "builder":
+        if circuit_source.builder is None:
+            raise RuntimeError("Builder must be provided for builder source type.")
+        circuit = circuit_source.builder.to_pcvl_circuit(pcvl_module)
+        experiment = pcvl_module.Experiment(circuit)
+        noise_model = None
+        has_custom_noise = False
+    elif circuit_source.source_type == "circuit":
+        if circuit_source.circuit is None:
+            raise RuntimeError("Circuit must be provided for circuit source type.")
+        circuit = circuit_source.circuit
+        experiment = pcvl_module.Experiment(circuit)
+        noise_model = None
+        has_custom_noise = False
+    elif circuit_source.source_type == "experiment":
+        if circuit_source.experiment is None:
+            raise RuntimeError(
+                "Experiment must be provided for experiment source type."
+            )
+        experiment = circuit_source.experiment
+        noise_model = getattr(experiment, "noise", None)
+        circuit = experiment.unitary_circuit()
+        has_custom_noise = noise_model is not None
+    else:
+        raise RuntimeError("Resolved circuit could not be determined.")
+
+    return ResolvedCircuit(
+        circuit=circuit,
+        experiment=experiment,
+        noise_model=noise_model,
+        has_custom_noise=has_custom_noise,
+    )
+
+
+def setup_noise_and_detectors(
+    experiment: pcvl.Experiment,
+    circuit: pcvl.Circuit,
+    computation_space: ComputationSpace,
+    measurement_strategy: MeasurementStrategy,
+) -> NoiseAndDetectorConfig:
+    """Extract and validate noise/detectors."""
+    photon_survival_probs, empty_noise_model = resolve_photon_loss(
+        experiment, circuit.m
+    )
+    detectors, empty_detectors = resolve_detectors(experiment, circuit.m)
+
+    has_custom_noise = not empty_noise_model
+    has_custom_detectors = not empty_detectors
+    detector_warnings: list[str] = []
+
+    if has_custom_detectors and computation_space is not ComputationSpace.FOCK:
+        detectors = [pcvl.Detector.pnr()] * circuit.m
+        detector_warnings.append(
+            f"Detectors are ignored in favor of ComputationSpace: {computation_space}"
+        )
+
+    amplitude_readout = measurement_strategy == MeasurementStrategy.AMPLITUDES
+    if amplitude_readout and has_custom_noise:
+        raise RuntimeError(
+            "measurement_strategy=MeasurementStrategy.AMPLITUDES cannot be used when the experiment defines a NoiseModel."
+        )
+    if amplitude_readout and has_custom_detectors:
+        raise RuntimeError(
+            "measurement_strategy=MeasurementStrategy.AMPLITUDES does not support experiments with detectors. "
+            "Compute amplitudes without detectors and apply a Partial DetectorTransform manually if needed."
+        )
+
+    return NoiseAndDetectorConfig(
+        photon_survival_probs=photon_survival_probs,
+        has_custom_noise=has_custom_noise,
+        detectors=detectors,
+        has_custom_detectors=has_custom_detectors,
+        detector_warnings=detector_warnings,
+    )
+
+
+def apply_angle_encoding(
+    x: torch.Tensor,
+    spec: dict[str, Any],
+) -> torch.Tensor:
+    """Apply custom angle encoding using stored metadata."""
+    combos: list[tuple[int, ...]] = spec.get("combinations", [])
+    scale_map: dict[int, float] = spec.get("scales", {})
+
+    if x.dim() == 1:
+        x_batch = x.unsqueeze(0)
+        squeeze = True
+    elif x.dim() == 2:
+        x_batch = x
+        squeeze = False
+    else:
+        raise ValueError(
+            f"Angle encoding expects 1D or 2D tensors, got shape {tuple(x.shape)}"
+        )
+
+    if not combos:
+        encoded = x_batch
+        return encoded.squeeze(0) if squeeze else encoded
+
+    encoded_cols: list[torch.Tensor] = []
+    feature_dim = x_batch.shape[-1]
+
+    for combo in combos:
+        indices = list(combo)
+        if any(idx >= feature_dim for idx in indices):
+            raise ValueError(
+                f"Input feature dimension {feature_dim} insufficient for angle encoding combination {combo}"
+            )
+
+        selected = x_batch[:, indices]
+        scales = [scale_map.get(idx, 1.0) for idx in indices]
+        scale_tensor = x_batch.new_tensor(scales)
+        value = (selected * scale_tensor).sum(dim=1, keepdim=True)
+        encoded_cols.append(value)
+
+    encoded = (
+        torch.cat(encoded_cols, dim=1)
+        if encoded_cols
+        else x_batch.new_zeros((x_batch.shape[0], 0))
+    )
+
+    return encoded.squeeze(0) if squeeze else encoded
+
+
+def prepare_input_encoding(
+    x: torch.Tensor,
+    prefix: str | None = None,
+    angle_encoding_specs: dict[str, dict[str, Any]] | None = None,
+) -> torch.Tensor:
+    """Prepare input encoding based on mode."""
+    if not angle_encoding_specs:
+        return x
+
+    spec = None
+    if prefix is not None:
+        spec = angle_encoding_specs.get(prefix)
+    elif len(angle_encoding_specs) == 1:
+        spec = next(iter(angle_encoding_specs.values()))
+
+    if spec:
+        return apply_angle_encoding(x, spec)
+
+    return x
+
+
+def split_inputs_by_prefix(
+    prefixes: list[str],
+    tensor: torch.Tensor,
+    angle_encoding_specs: dict[str, dict[str, Any]],
+    spec_mappings: dict[str, list[str]] | None = None,
+) -> list[torch.Tensor] | None:
+    """Split a single logical input tensor into per-prefix chunks when possible."""
+    counts: list[int] = []
+    for prefix in prefixes:
+        count = feature_count_for_prefix(prefix, angle_encoding_specs, spec_mappings)
+        if count is None:
+            return None
+        counts.append(count)
+
+    total_required = sum(counts)
+    feature_dim = tensor.shape[-1] if tensor.dim() > 1 else tensor.shape[0]
+    if total_required != feature_dim:
+        return None
+
+    slices: list[torch.Tensor] = []
+    offset = 0
+    for count in counts:
+        end = offset + count
+        slices.append(
+            tensor[..., offset:end] if tensor.dim() > 1 else tensor[offset:end]
+        )
+        offset = end
+    return slices
+
+
+def feature_count_for_prefix(
+    prefix: str,
+    angle_encoding_specs: dict[str, dict[str, Any]],
+    spec_mappings: dict[str, list[str]] | None = None,
+) -> int | None:
+    """Infer the number of raw features associated with an encoding prefix."""
+    spec = angle_encoding_specs.get(prefix)
+    if spec:
+        combos = spec.get("combinations", [])
+        feature_indices = {idx for combo in combos for idx in combo}
+        if feature_indices:
+            return len(feature_indices)
+
+    mapping = (spec_mappings or {}).get(prefix, [])
+    if mapping:
+        return len(mapping)
+
+    return None
+
+
+def normalize_output_key(
+    key: Iterable[int] | torch.Tensor | Sequence[int],
+) -> tuple[int, ...]:
+    """Normalize output key to tuple[int, ...]."""
+    if isinstance(key, torch.Tensor):
+        return tuple(int(v) for v in key.tolist())
+    return tuple(int(v) for v in key)

--- a/merlin/algorithms/module.py
+++ b/merlin/algorithms/module.py
@@ -24,7 +24,10 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 
+import torch
 import torch.nn as nn
+
+from ..utils.dtypes import complex_dtype_for
 
 
 class MerlinModule(nn.Module):
@@ -74,3 +77,17 @@ class MerlinModule(nn.Module):
 
         # execution policy: when True, always simulate locally (do not offload)
         self._force_simulation: bool = False
+
+    @staticmethod
+    def setup_device_and_dtype(
+        device: torch.device | None,
+        dtype: torch.dtype | None,
+    ) -> tuple[torch.device | None, torch.dtype, torch.dtype]:
+        """Normalize device/dtype to final forms."""
+        resolved_dtype = dtype or torch.float32
+        if resolved_dtype not in (torch.float32, torch.float64):
+            raise ValueError(
+                "dtype must be torch.float32 or torch.float64 for Merlin modules."
+            )
+        resolved_complex = complex_dtype_for(resolved_dtype)
+        return device, resolved_dtype, resolved_complex

--- a/tests/algorithms/test_layer_utils.py
+++ b/tests/algorithms/test_layer_utils.py
@@ -112,6 +112,20 @@ def test_prepare_input_state_experiment_override_warns():
     assert state == [1, 0]
 
 
+def test_prepare_input_state_default_generation():
+    state, _ = prepare_input_state(
+        None,
+        2,
+        ComputationSpace.UNBUNCHED,
+        None,
+        torch.complex64,
+        circuit_m=4,
+        amplitude_encoding=False,
+    )
+    assert state == ML.StateGenerator.generate_state(
+        4, 2, ML.StatePattern.SPACED
+    )
+
 def test_validate_and_resolve_circuit_source_builder_conflict():
     builder = ML.CircuitBuilder(n_modes=2)
     with pytest.raises(ValueError, match="do not also specify"):

--- a/tests/algorithms/test_layer_utils.py
+++ b/tests/algorithms/test_layer_utils.py
@@ -1,0 +1,230 @@
+# MIT License
+#
+# Copyright (c) 2025 Quandela
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import perceval as pcvl
+import pytest
+import torch
+
+import merlin as ML
+from merlin.algorithms.layer_utils import (
+    apply_angle_encoding,
+    feature_count_for_prefix,
+    normalize_output_key,
+    prepare_input_encoding,
+    prepare_input_state,
+    resolve_circuit,
+    setup_noise_and_detectors,
+    split_inputs_by_prefix,
+    validate_and_resolve_circuit_source,
+    validate_encoding_mode,
+    vet_experiment,
+)
+from merlin.core.computation_space import ComputationSpace
+from merlin.measurement.strategies import MeasurementStrategy
+
+
+def test_validate_encoding_mode_constraints():
+    with pytest.raises(ValueError, match="input_size"):
+        validate_encoding_mode(True, 2, 1, None)
+
+    with pytest.raises(ValueError, match="n_photons"):
+        validate_encoding_mode(True, None, None, None)
+
+    with pytest.raises(ValueError, match="input parameters"):
+        validate_encoding_mode(True, None, 1, ["x"])
+
+    config = validate_encoding_mode(False, 3, None, ["x"])
+    assert config.input_size == 3
+    assert config.input_parameters == ["x"]
+
+
+def test_prepare_input_state_basic_state():
+    state, resolved = prepare_input_state(
+        pcvl.BasicState([1, 0, 1]),
+        None,
+        ComputationSpace.UNBUNCHED,
+        None,
+        torch.complex64,
+    )
+    assert state == [1, 0, 1]
+    assert resolved is None
+
+
+def test_prepare_input_state_statevector():
+    sv = pcvl.StateVector()
+    sv += pcvl.StateVector(pcvl.BasicState([1, 0])) * 1.0
+
+    state, resolved = prepare_input_state(
+        sv,
+        None,
+        ComputationSpace.UNBUNCHED,
+        None,
+        torch.complex64,
+    )
+    assert isinstance(state, torch.Tensor)
+    assert resolved == 1
+
+
+def test_prepare_input_state_empty_statevector_rejected():
+    empty_sv = pcvl.StateVector()
+    with pytest.raises(ValueError, match="StateVector cannot be empty"):
+        prepare_input_state(
+            empty_sv,
+            None,
+            ComputationSpace.UNBUNCHED,
+            None,
+            torch.complex64,
+        )
+
+
+def test_prepare_input_state_experiment_override_warns():
+    experiment = pcvl.Experiment(pcvl.Circuit(2))
+    experiment.with_input(pcvl.BasicState([1, 0]))
+
+    with pytest.warns(UserWarning, match="experiment.input_state"):
+        state, _ = prepare_input_state(
+            [0, 1],
+            None,
+            ComputationSpace.UNBUNCHED,
+            None,
+            torch.complex64,
+            experiment=experiment,
+        )
+    assert state == [1, 0]
+
+
+def test_validate_and_resolve_circuit_source_builder_conflict():
+    builder = ML.CircuitBuilder(n_modes=2)
+    with pytest.raises(ValueError, match="do not also specify"):
+        validate_and_resolve_circuit_source(
+            builder,
+            None,
+            None,
+            trainable_parameters=["theta"],
+            input_parameters=None,
+        )
+
+
+def test_validate_and_resolve_circuit_source_multiple_sources():
+    with pytest.raises(ValueError, match="exactly one"):
+        validate_and_resolve_circuit_source(
+            None,
+            pcvl.Circuit(1),
+            pcvl.Experiment(pcvl.Circuit(1)),
+            None,
+            None,
+        )
+
+
+def test_validate_and_resolve_circuit_source_builder_prefixes():
+    builder = ML.CircuitBuilder(n_modes=2)
+    builder.add_angle_encoding(modes=[0], name="x")
+    source = validate_and_resolve_circuit_source(builder, None, None, None, None)
+    assert source.source_type == "builder"
+    assert source.input_parameters == ["x"]
+
+
+def test_vet_experiment_rejects_post_select():
+    experiment = pcvl.Experiment(pcvl.Circuit(1))
+    experiment.set_postselection(pcvl.PostSelect("[0]==1"))
+    with pytest.raises(ValueError, match="post-selection"):
+        vet_experiment(experiment)
+
+
+def test_vet_experiment_rejects_time_dependent():
+    experiment = pcvl.Experiment(pcvl.Circuit(1))
+    experiment.add(0, pcvl.TD(1))
+    with pytest.raises(ValueError, match="unitary"):
+        vet_experiment(experiment)
+
+
+def test_resolve_circuit_experiment_path():
+    circuit = pcvl.Circuit(2)
+    experiment = pcvl.Experiment(circuit)
+    source = validate_and_resolve_circuit_source(None, None, experiment, None, None)
+    resolved = resolve_circuit(source, pcvl)
+    assert resolved.experiment is experiment
+    assert resolved.circuit.m == 2
+
+
+def test_setup_noise_and_detectors_amplitudes_rejects_detectors():
+    experiment = pcvl.Experiment(pcvl.Circuit(2))
+    experiment._add_detector(mode=0, detector=pcvl.Detector.threshold())
+    result = validate_and_resolve_circuit_source(None, None, experiment, None, None)
+    resolved = resolve_circuit(result, pcvl)
+
+    with pytest.raises(RuntimeError, match="does not support experiments with detectors"):
+        setup_noise_and_detectors(
+            resolved.experiment,
+            resolved.circuit,
+            ComputationSpace.FOCK,
+            MeasurementStrategy.AMPLITUDES,
+        )
+
+
+def test_setup_noise_and_detectors_computation_space_overrides():
+    experiment = pcvl.Experiment(pcvl.Circuit(2))
+    experiment._add_detector(mode=0, detector=pcvl.Detector.threshold())
+    result = validate_and_resolve_circuit_source(None, None, experiment, None, None)
+    resolved = resolve_circuit(result, pcvl)
+
+    config = setup_noise_and_detectors(
+        resolved.experiment,
+        resolved.circuit,
+        ComputationSpace.UNBUNCHED,
+        MeasurementStrategy.PROBABILITIES,
+    )
+    assert config.has_custom_detectors is True
+    assert len(config.detectors) == 2
+    assert config.detector_warnings
+
+
+def test_apply_angle_encoding_basic():
+    spec = {"combinations": [(0, 1)], "scales": {0: 1.0, 1: 2.0}}
+    x = torch.tensor([1.0, 2.0])
+    encoded = apply_angle_encoding(x, spec)
+    assert encoded.shape == (1,)
+    assert torch.allclose(encoded, torch.tensor([5.0]))
+
+
+def test_prepare_input_encoding_passthrough():
+    x = torch.tensor([1.0, 2.0])
+    assert torch.allclose(prepare_input_encoding(x), x)
+
+
+def test_split_inputs_by_prefix_uses_specs():
+    specs = {"x": {"combinations": [(0,), (1,)]}, "y": {"combinations": [(0,)]}}
+    tensor = torch.tensor([1.0, 2.0, 3.0])
+    splits = split_inputs_by_prefix(["x", "y"], tensor, specs)
+    assert splits is not None
+    assert [t.numel() for t in splits] == [2, 1]
+
+
+def test_feature_count_for_prefix_spec_mappings():
+    specs: dict[str, dict[str, object]] = {}
+    spec_mappings = {"x": ["x0", "x1", "x2"]}
+    assert feature_count_for_prefix("x", specs, spec_mappings) == 3
+
+
+def test_normalize_output_key_tensor():
+    key = normalize_output_key(torch.tensor([1, 0, 2]))
+    assert key == (1, 0, 2)


### PR DESCRIPTION
<!--
Thank you for contributing to MerLin!
Please fill out the sections below to help us review your PR efficiently.

NOTE: this repo is a public repository, therefore, do NOT paste Jira URLs. Use the Jira issue key only (e.g., PML-126).
The Jira–GitHub integration will link PRs/commits automatically when the key is present.
-->

<!-- Add the Jira issue key in the title -->
<!-- e.g., PML-126 Updating PR template -->

## Summary
<!-- What does this PR do? A clear, concise description. -->
`QuantumLayer.__init__` previously performed:

- device/dtype setup, 
- experiment vetting, 
- circuit resolution, 
- input-state fabrication, 
- noise/detector configuration, 
- parameter wiring, 
- validation 
in a large, branch-heavy block, which obscured side effects and hindered extensibility. This PR refactors those concerns into composable helpers and a context object.

## Related Jira ticket (required)
<!-- Use the Jira issue key ONLY (no URL), e.g.:
Related Jira: PML-126
-->
Related Jira: PML-133

## Context / Related Issues
<!-- Why do you do this PR ? Is it linked to a previous PR ? A clear, concise description. -->
<!-- e.g., Closes #123, Fixes #456 -->

## Type of change
- [x] Refactor / Cleanup


## Proposed changes
<!-- Bulleted list of key changes. If API changes, list them explicitly. -->
The goal of this PR is to re-architect the __init__ constructor of QuantumLayer to make it more readable, more maintanable : it should be an orchestrator more than a God method. Overall, I
- split `QuantumLayer.__init__` into linear, named phases with helper functions in `layer_utils.py`
- added `InitializationContext` to minimize mutable state and centralize initialization assignments
- moved encoding/normalization helpers into `layer_utils` and routed class methods through them to avoid drift
- introduced `MerlinModule.setup_device_and_dtype` for consistent dtype handling and validation
- added focused unit tests for `layer_utils` and characterization tests for `init` edge cases (amplitude encoding constraints, experiment input_state override warning, empty StateVector rejection, and amplitudes + custom detectors incompatibility)
- aligned `prepare_input_state` with the plan to generate defaults from `n_photons`
- the test coverage improves to 75.04% (before 74.65%)

## How to test / How to run
<!-- Describe test plan and steps for reviewers to validate and run your changes locally. Include datasets if relevant. -->

1. Command lines

```
pytest tests/algorithms
```

## Documentation
- [x] Docstrings updated

## Checklist
- [x] PR title includes Jira issue key (e.g., PML-126)
- [x] "Related Jira ticket" section includes the Jira issue key (no URL)
- [x] Code formatted (ruff format)
- [x] Lint passes (ruff)
- [x] Static typing passes (mypy) if applicable
- [x] Unit tests added/updated (pytest)
- [x] Tests pass locally (pytest)
- [x] Tests pass on GPU (pytest)
- [x] Test coverage not decreased significantly (improved)
- [x] Dependencies updated (if needed) and pinned appropriately
- [x] PR description explains what changed and how to validate it

<!-- Helpful local commands – run from repo root:

# Lint & format
ruff format && ruff check .

# Type check (if used)
mypy .

# Tests with coverage
pytest

# Build docs
pip install -e .[docs] && make -C docs html

-->