### PR TITLE
PML-151 : tests now running on python3.13 and python3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
<!--
Thank you for contributing to MerLin!
Please fill out the sections below to help us review your PR efficiently.

NOTE: this repo is a public repository, therefore, do NOT paste Jira URLs. Use the Jira issue key only (e.g., PML-126).
The Jira–GitHub integration will link PRs/commits automatically when the key is present.
-->

<!-- Add the Jira issue key in the title -->
<!-- e.g., PML-126 Updating PR template -->

## Summary
<!-- What does this PR do? A clear, concise description. -->
The pyproject requires python>=3.10 but our tests only run on python versions 3.10, 3.11 and 3.12
To avoid issues with latest python, we need to make sure our tests run on python3.13 and python3.14

## Related Jira ticket (required)
<!-- Use the Jira issue key ONLY (no URL), e.g.:
Related Jira: PML-126
-->
Related Jira: PML-151

## Type of change
- [x] CI / Build / Tooling

## Proposed changes
<!-- Bulleted list of key changes. If API changes, list them explicitly. -->
I added python 3.13 and 3.14 in the ci config for the jobs to run at each PR


## Performance considerations (optional)
<!-- Note expected speed/memory impact and how you measured it. -->


## Checklist
- [x] PR title includes Jira issue key (e.g., PML-126)
- [x] "Related Jira ticket" section includes the Jira issue key (no URL)
- [x] Test coverage not decreased significantly
- [x] Dependencies updated (if needed) and pinned appropriately
- [x] PR description explains what changed and how to validate it

<!-- Helpful local commands – run from repo root:

# Lint & format
ruff format && ruff check .

# Type check (if used)
mypy .

# Tests with coverage
pytest

# Build docs
pip install -e .[docs] && make -C docs html

-->