### PR TITLE
PML-165: update tests with new MeasurementStrategy and some fix new API

### DIFF
--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -218,7 +218,7 @@ class MeasurementStrategy(metaclass=_MeasurementStrategyMeta):
 
     @staticmethod
     def probs(
-        computation_space: ComputationSpace,
+        computation_space: ComputationSpace = ComputationSpace.UNBUNCHED,
         grouping: LexGrouping | ModGrouping | None = None,
     ) -> MeasurementStrategy:
         # Full measurement returning a probability distribution.

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -230,7 +230,7 @@ class MeasurementStrategy(metaclass=_MeasurementStrategyMeta):
 
     @staticmethod
     def mode_expectations(
-        computation_space: ComputationSpace,
+        computation_space: ComputationSpace = ComputationSpace.UNBUNCHED,
     ) -> MeasurementStrategy:
         # Mode_expectations
         # Per-mode expectation values from the measured distribution.

--- a/tests/algorithms/test_all_apis.py
+++ b/tests/algorithms/test_all_apis.py
@@ -83,7 +83,7 @@ def test_builder_api_pipeline_on_iris(iris_batch):
         input_size=features.shape[1],
         builder=builder,
         n_photons=5,
-        measurement_strategy=MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=MeasurementStrategy.probs(),
         dtype=features.dtype,
     )
     pcvl.pdisplay(layer.computation_process.circuit, output_format=pcvl.Format.TEXT)
@@ -145,7 +145,7 @@ def test_manual_pcvl_circuit_pipeline_on_iris(iris_batch):
         n_photons=1,
         trainable_parameters=["theta"],
         input_parameters=["input"],
-        measurement_strategy=MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=MeasurementStrategy.probs(),
         dtype=features.dtype,
     )
     model = torch.nn.Sequential(layer, torch.nn.Linear(layer.output_size, 3))

--- a/tests/algorithms/test_amplitude_encoding.py
+++ b/tests/algorithms/test_amplitude_encoding.py
@@ -42,7 +42,6 @@ def make_layer():
             "input_parameters": [],
             "dtype": torch.float32,
             "amplitude_encoding": True,
-            "computation_space": ComputationSpace.UNBUNCHED,
         }
         params.update(overrides)
         if not params.get("amplitude_encoding", False):
@@ -108,9 +107,8 @@ def test_amplitude_encoding_output_matches_computation_space(
     layer = QuantumLayer(
         circuit=circuit,
         n_photons=n_photons,
-        measurement_strategy=MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=MeasurementStrategy.probs(computation_space=space),
         amplitude_encoding=True,
-        computation_space=space,
         trainable_parameters=["phi"],
         input_parameters=[],
         dtype=torch.float32,
@@ -142,9 +140,8 @@ def test_amplitude_encoding_gradients_follow_computation_space(
     layer = QuantumLayer(
         circuit=circuit,
         n_photons=n_photons,
-        measurement_strategy=MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=MeasurementStrategy.probs(computation_space=space),
         amplitude_encoding=True,
-        computation_space=space,
         trainable_parameters=["phi"],
         input_parameters=[],
         dtype=torch.float32,
@@ -194,9 +191,8 @@ def test_amplitude_encoding_gpu_roundtrip(
     layer = QuantumLayer(
         circuit=circuit,
         n_photons=n_photons,
-        measurement_strategy=MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=MeasurementStrategy.probs(computation_space=space),
         amplitude_encoding=True,
-        computation_space=space,
         trainable_parameters=["phi"],
         input_parameters=[],
         dtype=torch.float32,
@@ -343,7 +339,7 @@ def test_computation_space_consistency_no_warning(make_layer):
 
 
 def test_amplitude_encoding_probabilities_strategy(make_layer):
-    layer = make_layer(measurement_strategy=MeasurementStrategy.PROBABILITIES)
+    layer = make_layer(measurement_strategy=MeasurementStrategy.probs())
     num_states = len(layer.computation_process.simulation_graph.mapped_keys)
     raw_amplitude = torch.arange(1, num_states + 1, dtype=torch.float32)
 
@@ -371,13 +367,14 @@ def test_mapped_keys_no_bunching_space():
     layer = QuantumLayer(
         circuit=circuit,
         n_photons=n_photons,
-        measurement_strategy=MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=MeasurementStrategy.probs(
+            computation_space=ComputationSpace.UNBUNCHED
+        ),
         input_state=input_state,
         trainable_parameters=["phi"],
         input_parameters=[],
         dtype=torch.float32,
         amplitude_encoding=True,
-        computation_space=ComputationSpace.UNBUNCHED,
     )
 
     mapped_keys = layer.output_keys
@@ -399,13 +396,14 @@ def test_mapped_keys_fock_space():
     layer = QuantumLayer(
         circuit=circuit,
         n_photons=n_photons,
-        measurement_strategy=MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=MeasurementStrategy.probs(
+            computation_space=ComputationSpace.FOCK
+        ),
         input_state=input_state,
         trainable_parameters=["phi"],
         input_parameters=[],
         dtype=torch.float32,
         amplitude_encoding=True,
-        computation_space=ComputationSpace.FOCK,
     )
 
     mapped_keys = layer.output_keys
@@ -427,13 +425,14 @@ def test_mapped_keys_dual_rail_space():
     layer = QuantumLayer(
         circuit=circuit,
         n_photons=n_photons,
-        measurement_strategy=MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=MeasurementStrategy.probs(
+            computation_space=ComputationSpace.DUAL_RAIL
+        ),
         input_state=input_state,
         trainable_parameters=["phi"],
         input_parameters=[],
         dtype=torch.float32,
         amplitude_encoding=True,
-        computation_space=ComputationSpace.DUAL_RAIL,
     )
 
     mapped_keys = layer.output_keys
@@ -461,13 +460,14 @@ def test_ebs_batches_group_fock_states(computation_space: ComputationSpace):
     layer = QuantumLayer(
         circuit=circuit,
         n_photons=n_photons,
-        measurement_strategy=MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=MeasurementStrategy.probs(
+            computation_space=computation_space
+        ),
         input_state=None,
         trainable_parameters=["phi"],
         input_parameters=[],
         dtype=torch.float32,
         amplitude_encoding=True,
-        computation_space=computation_space,
     )
 
     expected_states = layer.input_size

--- a/tests/algorithms/test_compute_ebs_simultaneously.py
+++ b/tests/algorithms/test_compute_ebs_simultaneously.py
@@ -78,13 +78,14 @@ class TestComputeEbsSimultaneously:
             input_size=0,
             circuit=self.circuit,
             n_photons=self.n_photons,
-            measurement_strategy=MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=MeasurementStrategy.probs(
+                computation_space=ComputationSpace.UNBUNCHED
+            ),
             input_state=self.input_state_tensor,
             trainable_parameters=self.trainable_parameters,
             input_parameters=self.input_parameters,
             dtype=torch.float64,
             device=device,
-            computation_space=ComputationSpace.UNBUNCHED,
         )
         # Create computation process
         self.process = self.layer.computation_process

--- a/tests/algorithms/test_cuda.py
+++ b/tests/algorithms/test_cuda.py
@@ -46,7 +46,7 @@ def test_load_model_on_cuda():
         input_state=[1, 1, 0, 0],
         trainable_parameters=["phi"],
         device=torch.device("cuda"),
-        measurement_strategy=ml.MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=ml.MeasurementStrategy.probs(),
     )
     model = nn.Sequential(layer, torch.nn.Linear(layer.output_size, 1)).to(
         torch.device("cuda")
@@ -78,7 +78,7 @@ def test_switch_model_to_cuda():
         input_state=[1, 1, 0, 0],
         trainable_parameters=["phi"],
         device=torch.device("cpu"),
-        measurement_strategy=ml.MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=ml.MeasurementStrategy.probs(),
     )
     model = nn.Sequential(layer, torch.nn.Linear(layer.output_size, 1)).to(
         torch.device("cpu")
@@ -148,7 +148,7 @@ class QuantumClassifier_withBuilder(nn.Module):
             input_size=hidden_dim,
             builder=builder,
             n_photons=modes // 2,
-            measurement_strategy=ml.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ml.MeasurementStrategy.probs(),
             device=device,
         )
 

--- a/tests/algorithms/test_dtype_propagation.py
+++ b/tests/algorithms/test_dtype_propagation.py
@@ -293,7 +293,7 @@ class TestQuantumLayerDtypePropagation:
             circuit=circuit_2mode_no_params,
             n_photons=1,
             amplitude_encoding=True,
-            measurement_strategy=MeasurementStrategy.AMPLITUDES,
+            measurement_strategy=MeasurementStrategy.NONE,
             dtype=torch.float32,
         )
 
@@ -319,7 +319,7 @@ class TestQuantumLayerDtypePropagation:
             circuit=circuit_2mode_no_params,
             n_photons=1,
             amplitude_encoding=True,
-            measurement_strategy=MeasurementStrategy.AMPLITUDES,
+            measurement_strategy=MeasurementStrategy.NONE,
             dtype=torch.float64,
         )
 

--- a/tests/algorithms/test_dtype_propagation.py
+++ b/tests/algorithms/test_dtype_propagation.py
@@ -113,8 +113,9 @@ class TestQuantumLayerDtypePropagation:
             trainable_parameters=[],
             input_parameters=["px"],
             input_state=[1, 0],
-            computation_space=ComputationSpace.UNBUNCHED,
-            measurement_strategy=MeasurementStrategy.MODE_EXPECTATIONS,
+            measurement_strategy=MeasurementStrategy.mode_expectations(
+                computation_space=ComputationSpace.UNBUNCHED
+            ),
             dtype=torch.float64,
         )
 
@@ -131,8 +132,9 @@ class TestQuantumLayerDtypePropagation:
             trainable_parameters=[],
             input_parameters=["px"],
             input_state=[1, 0],
-            computation_space=ComputationSpace.UNBUNCHED,
-            measurement_strategy=MeasurementStrategy.MODE_EXPECTATIONS,
+            measurement_strategy=MeasurementStrategy.mode_expectations(
+                computation_space=ComputationSpace.UNBUNCHED
+            ),
             dtype=torch.float32,
         )
 
@@ -147,8 +149,9 @@ class TestQuantumLayerDtypePropagation:
             trainable_parameters=[],
             input_parameters=["px"],
             input_state=[1, 0],
-            computation_space=ComputationSpace.UNBUNCHED,
-            measurement_strategy=MeasurementStrategy.MODE_EXPECTATIONS,
+            measurement_strategy=MeasurementStrategy.mode_expectations(
+                computation_space=ComputationSpace.UNBUNCHED
+            ),
             dtype=torch.float64,
         )
 
@@ -170,8 +173,9 @@ class TestQuantumLayerDtypePropagation:
             trainable_parameters=[],
             input_parameters=["px"],
             input_state=[1, 0],
-            computation_space=ComputationSpace.UNBUNCHED,
-            measurement_strategy=MeasurementStrategy.MODE_EXPECTATIONS,
+            measurement_strategy=MeasurementStrategy.mode_expectations(
+                computation_space=ComputationSpace.UNBUNCHED
+            ),
             dtype=torch.float32,
         )
 
@@ -188,8 +192,9 @@ class TestQuantumLayerDtypePropagation:
             trainable_parameters=[],
             input_parameters=["px"],
             input_state=[1, 0],
-            computation_space=ComputationSpace.UNBUNCHED,
-            measurement_strategy=MeasurementStrategy.MODE_EXPECTATIONS,
+            measurement_strategy=MeasurementStrategy.mode_expectations(
+                computation_space=ComputationSpace.UNBUNCHED
+            ),
             dtype=torch.float64,
         )
 
@@ -208,8 +213,9 @@ class TestQuantumLayerDtypePropagation:
             trainable_parameters=[],
             input_parameters=["px"],
             input_state=[1, 0, 1, 0],
-            computation_space=ComputationSpace.UNBUNCHED,
-            measurement_strategy=MeasurementStrategy.MODE_EXPECTATIONS,
+            measurement_strategy=MeasurementStrategy.mode_expectations(
+                computation_space=ComputationSpace.UNBUNCHED
+            ),
             dtype=torch.float64,
         )
 
@@ -246,8 +252,9 @@ class TestQuantumLayerDtypePropagation:
             trainable_parameters=[],
             input_parameters=["px"],
             input_state=[1, 0],
-            computation_space=ComputationSpace.FOCK,
-            measurement_strategy=MeasurementStrategy.MODE_EXPECTATIONS,
+            measurement_strategy=MeasurementStrategy.mode_expectations(
+                computation_space=ComputationSpace.FOCK
+            ),
             dtype=torch.float64,
         )
 
@@ -266,8 +273,9 @@ class TestQuantumLayerDtypePropagation:
             trainable_parameters=[],
             input_parameters=["px"],
             input_state=[1, 0],
-            computation_space=ComputationSpace.UNBUNCHED,
-            measurement_strategy=MeasurementStrategy.MODE_EXPECTATIONS,
+            measurement_strategy=MeasurementStrategy.mode_expectations(
+                computation_space=ComputationSpace.UNBUNCHED
+            ),
             dtype=torch.float64,
         )
 
@@ -370,8 +378,9 @@ class TestOriginalBugReproduction:
             trainable_parameters=[],
             input_parameters=["px"],
             input_state=[1, 0],
-            computation_space=merlin.ComputationSpace.UNBUNCHED,
-            measurement_strategy=merlin.MeasurementStrategy.MODE_EXPECTATIONS,
+            measurement_strategy=merlin.MeasurementStrategy.mode_expectations(
+                computation_space=merlin.ComputationSpace.UNBUNCHED
+            ),
             dtype=torch_dtype,
         )
 

--- a/tests/algorithms/test_dtype_propagation.py
+++ b/tests/algorithms/test_dtype_propagation.py
@@ -227,8 +227,9 @@ class TestQuantumLayerDtypePropagation:
             trainable_parameters=[],
             input_parameters=["px"],
             input_state=[1, 0],
-            computation_space=ComputationSpace.UNBUNCHED,
-            measurement_strategy=MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=MeasurementStrategy.probs(
+                computation_space=ComputationSpace.UNBUNCHED
+            ),
             dtype=torch.float64,
         )
 

--- a/tests/algorithms/test_feed_forward_block.py
+++ b/tests/algorithms/test_feed_forward_block.py
@@ -234,7 +234,9 @@ def test_feedforward_block2_mode_expectations():
     block_expect = FeedForwardBlock(
         exp,
         input_state=input_state,
-        measurement_strategy=MeasurementStrategy.MODE_EXPECTATIONS,
+        measurement_strategy=MeasurementStrategy.mode_expectations(
+            ComputationSpace.UNBUNCHED
+        ),
     )
 
     prob_outputs = block_prob()

--- a/tests/algorithms/test_feed_forward_block.py
+++ b/tests/algorithms/test_feed_forward_block.py
@@ -193,7 +193,7 @@ def test_feedforward_block2_amplitude_strategy_matches_probabilities():
     block_amp = FeedForwardBlock(
         exp,
         input_state=input_state,
-        measurement_strategy=MeasurementStrategy.AMPLITUDES,
+        measurement_strategy=MeasurementStrategy.NONE,
     )
 
     prob_outputs = block_prob()

--- a/tests/algorithms/test_kernels.py
+++ b/tests/algorithms/test_kernels.py
@@ -306,8 +306,7 @@ class TestFidelityKernel:
         )
 
         feature_forward = (
-            feature_map
-            .compute_unitary(torch.as_tensor(X1, dtype=feature_map.dtype))
+            feature_map.compute_unitary(torch.as_tensor(X1, dtype=feature_map.dtype))
             .detach()
             .cpu()
             .numpy()
@@ -322,8 +321,7 @@ class TestFidelityKernel:
         )
 
         feature_backward = (
-            feature_map
-            .compute_unitary(torch.as_tensor(X2, dtype=feature_map.dtype))
+            feature_map.compute_unitary(torch.as_tensor(X2, dtype=feature_map.dtype))
             .detach()
             .cpu()
             .numpy()
@@ -677,8 +675,7 @@ class TestKernelCircuitBuilder:
         device = torch.device("cpu")
         builder = KernelCircuitBuilder()
         feature_map = (
-            builder
-            .input_size(2)
+            builder.input_size(2)
             .n_modes(4)
             .device(device)
             .dtype(torch.float64)
@@ -699,8 +696,7 @@ class TestKernelCircuitBuilder:
         assert not feature_map.is_trainable
 
         feature_map = (
-            builder
-            .input_size(2)
+            builder.input_size(2)
             .n_modes(4)
             .trainable(True, prefix="phi_")
             .build_feature_map()
@@ -725,8 +721,7 @@ class TestKernelCircuitBuilder:
         builder = KernelCircuitBuilder()
         custom_state = [2, 0, 0, 0]
         kernel = (
-            builder
-            .input_size(2)
+            builder.input_size(2)
             .n_modes(4)
             .build_fidelity_kernel(input_state=custom_state)
         )
@@ -737,8 +732,7 @@ class TestKernelCircuitBuilder:
         """Test building FidelityKernel with sampling configuration."""
         builder = KernelCircuitBuilder()
         kernel = (
-            builder
-            .input_size(2)
+            builder.input_size(2)
             .n_modes(4)
             .build_fidelity_kernel(
                 shots=1000, sampling_method="multinomial", no_bunching=True
@@ -761,8 +755,7 @@ class TestKernelCircuitBuilder:
     def test_builder_angle_encoding_configuration(self):
         builder = KernelCircuitBuilder()
         feature_map = (
-            builder
-            .input_size(3)
+            builder.input_size(3)
             .n_modes(4)
             .angle_encoding(scale=0.5)
             .build_feature_map()
@@ -874,8 +867,7 @@ class TestKernelConstructionConsistency:
         # Builder API
         builder_api = KernelCircuitBuilder()
         k_builder = (
-            builder_api
-            .input_size(2)
+            builder_api.input_size(2)
             .n_modes(4)
             .trainable(False)
             .build_fidelity_kernel()
@@ -1316,8 +1308,7 @@ def test_iris_with_supported_constructors():
         try:
             builder = KernelCircuitBuilder()
             kernel_builder = (
-                builder
-                .input_size(4)
+                builder.input_size(4)
                 .n_modes(4)
                 .trainable(trainable_flag)
                 .build_fidelity_kernel()
@@ -1536,8 +1527,6 @@ def test_fidelity_kernel_gpu_execution_all_constructors(cuda_device, constructor
         kernel = FidelityKernel.simple(
             input_size=4,
             n_modes=4,
-            n_photons=2,
-            trainable=False,
         )
     elif constructor == "manual":
         params = [pcvl.P(f"x{i + 1}") for i in range(4)]
@@ -1580,8 +1569,6 @@ def test_fidelity_kernel_gpu_training_step(cuda_device):
     kernel = FidelityKernel.simple(
         input_size=4,
         n_modes=6,
-        n_photons=4,
-        trainable=True,
     ).to(device)
 
     if sum(p.numel() for p in kernel.parameters()) == 0:

--- a/tests/algorithms/test_layer.py
+++ b/tests/algorithms/test_layer.py
@@ -217,8 +217,9 @@ class TestQuantumLayer:
                 input_size=0,
                 experiment=experiment,
                 input_state=[1, 0],
-                computation_space=ML.ComputationSpace.FOCK,
-                measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
+                measurement_strategy=ML.MeasurementStrategy.amplitudes(
+                    computation_space=ML.ComputationSpace.FOCK
+                ),
             )
 
     def test_builder_based_layer_creation(self):
@@ -291,7 +292,7 @@ class TestQuantumLayer:
             circuit=circuit,
             n_photons=1,
             amplitude_encoding=True,
-            measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
+            measurement_strategy=ML.MeasurementStrategy.NONE,
             trainable_parameters=[],
             input_parameters=[],
         )
@@ -367,7 +368,7 @@ class TestQuantumLayer:
                 amplitude_encoding=True,
                 input_parameters=["px"],
                 trainable_parameters=[],
-                measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
+                measurement_strategy=ML.MeasurementStrategy.NONE,
             )
 
     def test_amplitude_encoding_requires_amplitude_input(self):
@@ -377,7 +378,7 @@ class TestQuantumLayer:
             circuit=circuit,
             n_photons=1,
             amplitude_encoding=True,
-            measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
+            measurement_strategy=ML.MeasurementStrategy.NONE,
             trainable_parameters=[],
             input_parameters=[],
         )
@@ -822,7 +823,7 @@ class TestQuantumLayer:
             input_size=2,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
+            measurement_strategy=ML.MeasurementStrategy.NONE,
         )
 
         # Get actual distribution size
@@ -835,7 +836,7 @@ class TestQuantumLayer:
             input_size=2,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
+            measurement_strategy=ML.MeasurementStrategy.NONE,
         )
 
         x = torch.rand(2, 2)
@@ -983,8 +984,9 @@ class TestQuantumLayer:
             n_photons=n,
             circuit=circuit,
             input_parameters=["phi"],  # No input parameters
-            measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
-            computation_space=computation_space,
+            measurement_strategy=ML.MeasurementStrategy.amplitudes(
+                computation_space=computation_space
+            ),
         )
 
         o = layer.forward(torch.rand(batch_size, m))
@@ -1039,7 +1041,7 @@ class TestQuantumLayer:
             input_size=0,
             builder=builder,
             input_state=[0, 1, 0, 1, 0],
-            measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
+            measurement_strategy=ML.MeasurementStrategy.NONE,
         )
 
         res_no_obj = qlayer()
@@ -1247,7 +1249,7 @@ class TestQuantumLayer:
                     input_size=2,
                     input_state=[1, 1, 0, 0],
                     builder=builder,
-                    measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
+                    measurement_strategy=ML.MeasurementStrategy.NONE,
                     return_object=True,
                 )
                 self.clayer = torch.nn.Linear(
@@ -1291,7 +1293,7 @@ class TestQuantumLayer:
             [ML.MeasurementStrategy.MODE_EXPECTATIONS, False],
             [ML.MeasurementStrategy.MODE_EXPECTATIONS, True],
             [ML.MeasurementStrategy.probs(), False],
-            [ML.MeasurementStrategy.AMPLITUDES, False],
+            [ML.MeasurementStrategy.NONE, False],
         ]
         for strategy, typed_object in to_test:
 

--- a/tests/algorithms/test_layer.py
+++ b/tests/algorithms/test_layer.py
@@ -1088,7 +1088,9 @@ class TestQuantumLayer:
             input_size=0,
             builder=builder,
             input_state=[0, 1, 0, 1, 0],
-            measurement_strategy=ML.MeasurementStrategy.MODE_EXPECTATIONS,
+            measurement_strategy=ML.MeasurementStrategy.mode_expectations(
+                ComputationSpace.UNBUNCHED
+            ),
         )
 
         res_no_obj = qlayer()
@@ -1290,8 +1292,14 @@ class TestQuantumLayer:
         builder.add_entangling_layer(trainable=True, name="U2")
 
         to_test = [
-            [ML.MeasurementStrategy.MODE_EXPECTATIONS, False],
-            [ML.MeasurementStrategy.MODE_EXPECTATIONS, True],
+            [
+                ML.MeasurementStrategy.mode_expectations(ComputationSpace.UNBUNCHED),
+                False,
+            ],
+            [
+                ML.MeasurementStrategy.mode_expectations(ComputationSpace.UNBUNCHED),
+                True,
+            ],
             [ML.MeasurementStrategy.probs(), False],
             [ML.MeasurementStrategy.NONE, False],
         ]

--- a/tests/algorithms/test_layer.py
+++ b/tests/algorithms/test_layer.py
@@ -105,7 +105,7 @@ class TestQuantumLayer:
             experiment=experiment,
             input_state=[1, 0],
             trainable_parameters=["phi"],
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         expected = pcvl.Circuit(2)
@@ -139,7 +139,7 @@ class TestQuantumLayer:
                 input_size=0,
                 experiment=experiment,
                 input_state=[1, 0],
-                measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+                measurement_strategy=ML.MeasurementStrategy.probs(),
             )
 
     def test_amplitude_encoding_rejects_input_size(self):
@@ -232,7 +232,7 @@ class TestQuantumLayer:
             input_size=3,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
         assert layer.input_size == 3
         assert layer.thetas[0].shape[0] == 2 * 4 * (
@@ -249,7 +249,7 @@ class TestQuantumLayer:
             input_size=5,
             input_state=[1, 0, 0, 0, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
         pcvl.pdisplay(layer.circuit, output_format=pcvl.Format.TEXT)
 
@@ -272,7 +272,7 @@ class TestQuantumLayer:
             input_size=2,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         model = torch.nn.Sequential(layer, torch.nn.Linear(layer.output_size, 3))
@@ -325,7 +325,7 @@ class TestQuantumLayer:
             input_size=4,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         with pytest.raises(ValueError, match="Inconsistent batch dimensions"):
@@ -342,7 +342,7 @@ class TestQuantumLayer:
             input_size=4,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         params, batch_dim = layer._prepare_classical_parameters([
@@ -396,7 +396,7 @@ class TestQuantumLayer:
             input_size=4,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         input_a = torch.rand(2, 2)
@@ -421,7 +421,7 @@ class TestQuantumLayer:
         layer = ML.QuantumLayer(
             builder=builder,
             input_state=[1, 0, 0],
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         assert layer.input_size == 2
@@ -434,8 +434,9 @@ class TestQuantumLayer:
         layer = ML.QuantumLayer(
             circuit=circuit,
             input_state=[1, 0],
-            computation_space=ML.ComputationSpace.UNBUNCHED,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ML.ComputationSpace.UNBUNCHED
+            ),
         )
 
         amplitudes = torch.tensor([[2.0 + 0j, 0.0 + 0j]], dtype=torch.cfloat)
@@ -454,8 +455,9 @@ class TestQuantumLayer:
         layer = ML.QuantumLayer(
             circuit=circuit,
             input_state=[1, 0],
-            computation_space=ML.ComputationSpace.FOCK,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ML.ComputationSpace.FOCK
+            ),
         )
 
         amplitudes = torch.tensor([[2.0 + 0j, 0.0 + 0j]], dtype=torch.cfloat)
@@ -477,7 +479,7 @@ class TestQuantumLayer:
             input_size=2,
             input_state=[1, 0, 0, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         model = torch.nn.Sequential(layer, torch.nn.Linear(layer.output_size, 3))
@@ -497,7 +499,7 @@ class TestQuantumLayer:
             input_size=0,
             circuit=circuit,
             n_photons=2,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         expected_state = ML.StateGenerator.generate_state(
@@ -517,7 +519,7 @@ class TestQuantumLayer:
             input_size=2,
             input_state=[1, 1, 0, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         model = torch.nn.Sequential(layer, torch.nn.Linear(layer.output_size, 3))
@@ -551,7 +553,7 @@ class TestQuantumLayer:
             input_size=2,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         # Compose with a linear head (as in the old test)
@@ -617,7 +619,7 @@ class TestQuantumLayer:
             input_size=2,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
         model_normal = torch.nn.Sequential(
             layer_normal, torch.nn.Linear(layer_normal.output_size, 3)
@@ -627,7 +629,7 @@ class TestQuantumLayer:
             input_size=2,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
         model_reservoir = torch.nn.Sequential(
             layer_reservoir, torch.nn.Linear(layer_reservoir.output_size, 3)
@@ -663,15 +665,15 @@ class TestQuantumLayer:
 
         configs = [
             {
-                "measurement_strategy": ML.MeasurementStrategy.PROBABILITIES,
+                "measurement_strategy": ML.MeasurementStrategy.probs(),
                 "grouping_policy": None,
             },
             {
-                "measurement_strategy": ML.MeasurementStrategy.PROBABILITIES,
+                "measurement_strategy": ML.MeasurementStrategy.probs(),
                 "grouping_policy": ML.LexGrouping,
             },
             {
-                "measurement_strategy": ML.MeasurementStrategy.PROBABILITIES,
+                "measurement_strategy": ML.MeasurementStrategy.probs(),
                 "grouping_policy": ML.ModGrouping,
             },
         ]
@@ -744,7 +746,7 @@ class TestQuantumLayer:
             input_size=3,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         layer_str = str(layer)
@@ -777,7 +779,7 @@ class TestQuantumLayer:
                 input_size=3,
                 input_state=[1, 0, 1, 0],
                 builder=builder,
-                measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+                measurement_strategy=ML.MeasurementStrategy.probs(),
             )
 
         with pytest.raises(ValueError):
@@ -785,7 +787,7 @@ class TestQuantumLayer:
                 input_size=2,
                 n_photons=5,  # more photons than modes
                 builder=builder,
-                measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+                measurement_strategy=ML.MeasurementStrategy.probs(),
             )
 
         with pytest.raises(ValueError):
@@ -804,7 +806,7 @@ class TestQuantumLayer:
             input_size=3,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         assert layer.input_size == 3
@@ -865,7 +867,7 @@ class TestQuantumLayer:
             input_state=input_state,
             trainable_parameters=["phi"],  # Parameters to train (by prefix)
             input_parameters=[],  # No input parameters
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         output_size = math.comb(3, sum(input_state))  # Calculate output size
@@ -879,7 +881,7 @@ class TestQuantumLayer:
                 input_state=input_state,
                 trainable_parameters=["phi"],  # Parameters to train (by prefix)
                 input_parameters=None,  # No input parameters
-                measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+                measurement_strategy=ML.MeasurementStrategy.probs(),
             )
 
         # Test layer properties
@@ -924,7 +926,7 @@ class TestQuantumLayer:
             input_state=input_state,
             trainable_parameters=[],  # No trainable parameters
             input_parameters=["phi"],  # No input parameters
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
         model = torch.nn.Sequential(layer, torch.nn.Linear(layer.output_size, 3))
 
@@ -1061,7 +1063,7 @@ class TestQuantumLayer:
             input_size=0,
             builder=builder,
             input_state=[0, 1, 0, 1, 0],
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
         res_no_obj = qlayer()
 
@@ -1200,7 +1202,7 @@ class TestQuantumLayer:
                     input_size=2,
                     input_state=[1, 1, 0, 0],
                     builder=builder,
-                    measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+                    measurement_strategy=ML.MeasurementStrategy.probs(),
                     return_object=True,
                 )
                 self.clayer = torch.nn.Linear(
@@ -1288,7 +1290,7 @@ class TestQuantumLayer:
         to_test = [
             [ML.MeasurementStrategy.MODE_EXPECTATIONS, False],
             [ML.MeasurementStrategy.MODE_EXPECTATIONS, True],
-            [ML.MeasurementStrategy.PROBABILITIES, False],
+            [ML.MeasurementStrategy.probs(), False],
             [ML.MeasurementStrategy.AMPLITUDES, False],
         ]
         for strategy, typed_object in to_test:

--- a/tests/algorithms/test_layer_utils.py
+++ b/tests/algorithms/test_layer_utils.py
@@ -206,7 +206,7 @@ def test_setup_noise_and_detectors_computation_space_overrides():
         resolved.experiment,
         resolved.circuit,
         ComputationSpace.UNBUNCHED,
-        MeasurementStrategy.PROBABILITIES,
+        MeasurementStrategy.probs(computation_space=ComputationSpace.UNBUNCHED),
     )
     assert config.has_custom_detectors is True
     assert len(config.detectors) == 2

--- a/tests/algorithms/test_layer_utils.py
+++ b/tests/algorithms/test_layer_utils.py
@@ -192,7 +192,7 @@ def test_setup_noise_and_detectors_amplitudes_rejects_detectors():
             resolved.experiment,
             resolved.circuit,
             ComputationSpace.FOCK,
-            MeasurementStrategy.AMPLITUDES,
+            MeasurementStrategy.amplitudes(computation_space=ComputationSpace.FOCK),
         )
 
 

--- a/tests/algorithms/test_robustness.py
+++ b/tests/algorithms/test_robustness.py
@@ -45,7 +45,7 @@ class TestRobustness:
             input_size=2,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         model = torch.nn.Sequential(layer, torch.nn.Linear(layer.output_size, 3))
@@ -71,7 +71,7 @@ class TestRobustness:
             input_size=2,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         model = torch.nn.Sequential(layer, torch.nn.Linear(layer.output_size, 3))
@@ -101,7 +101,7 @@ class TestRobustness:
             input_size=2,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         model = torch.nn.Sequential(layer, torch.nn.Linear(layer.output_size, 3))
@@ -131,7 +131,7 @@ class TestRobustness:
             input_size=2,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         model = torch.nn.Sequential(layer, torch.nn.Linear(layer.output_size, 3))
@@ -166,7 +166,7 @@ class TestRobustness:
             input_size=2,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
             device=torch.device("cpu"),
         )
         model_cpu = torch.nn.Sequential(
@@ -193,7 +193,7 @@ class TestRobustness:
             input_size=2,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
             dtype=torch.float32,
         )
         model_f32 = torch.nn.Sequential(
@@ -208,7 +208,7 @@ class TestRobustness:
             input_size=2,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
             dtype=torch.float64,
         )
         model_f64 = torch.nn.Sequential(
@@ -242,7 +242,7 @@ class TestRobustness:
             input_size=2,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         model1 = torch.nn.Sequential(layer1, torch.nn.Linear(layer1.output_size, 3))
@@ -252,7 +252,7 @@ class TestRobustness:
             input_size=2,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         model2 = torch.nn.Sequential(layer2, torch.nn.Linear(layer2.output_size, 3))

--- a/tests/algorithms/test_statevector_input.py
+++ b/tests/algorithms/test_statevector_input.py
@@ -140,7 +140,7 @@ class TestConstructorInputTypes:
                 input_state=tensor_state,
                 n_photons=1,
                 amplitude_encoding=True,
-                measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
+                measurement_strategy=ML.MeasurementStrategy.NONE,
             )
 
             # Check if any DeprecationWarning was raised
@@ -173,7 +173,7 @@ class TestDeprecationWarnings:
                 circuit=circuit,
                 n_photons=1,
                 amplitude_encoding=True,
-                measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
+                measurement_strategy=ML.MeasurementStrategy.NONE,
             )
 
             deprecation_warnings = [
@@ -196,7 +196,7 @@ class TestDeprecationWarnings:
                 circuit=circuit,
                 n_photons=1,
                 amplitude_encoding=True,
-                measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
+                measurement_strategy=ML.MeasurementStrategy.NONE,
             )
 
             deprecation_warnings = [
@@ -241,8 +241,9 @@ class TestForwardDispatch:
         return ML.QuantumLayer(
             circuit=circuit,
             n_photons=2,
-            computation_space=ML.ComputationSpace.FOCK,
-            measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
+            measurement_strategy=ML.MeasurementStrategy.amplitudes(
+                computation_space=ML.ComputationSpace.FOCK
+            ),
         )
 
     def test_forward_float_tensor_uses_angle_encoding(self, angle_encoding_layer):
@@ -429,7 +430,7 @@ class TestLegacyAmplitudeEncodingCompatibility:
                 circuit=circuit,
                 n_photons=2,
                 amplitude_encoding=True,
-                measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
+                measurement_strategy=ML.MeasurementStrategy.NONE,
             )
 
         # Create amplitude input matching layer's output_size
@@ -454,7 +455,7 @@ class TestLegacyAmplitudeEncodingCompatibility:
                 circuit=circuit,
                 n_photons=1,
                 amplitude_encoding=True,
-                measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
+                measurement_strategy=ML.MeasurementStrategy.NONE,
             )
 
         with pytest.raises(ValueError, match="expects an amplitude tensor input"):
@@ -543,8 +544,9 @@ class TestStateVectorForwardPath:
         layer = ML.QuantumLayer(
             circuit=circuit,
             n_photons=2,
-            computation_space=ML.ComputationSpace.FOCK,
-            measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
+            measurement_strategy=ML.MeasurementStrategy.amplitudes(
+                computation_space=ML.ComputationSpace.FOCK
+            ),
         )
 
         sv = StateVector.from_basic_state(
@@ -570,8 +572,9 @@ class TestStateVectorForwardPath:
         layer = ML.QuantumLayer(
             circuit=circuit,
             n_photons=2,
-            computation_space=ML.ComputationSpace.FOCK,
-            measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
+            measurement_strategy=ML.MeasurementStrategy.amplitudes(
+                computation_space=ML.ComputationSpace.FOCK
+            ),
         )
 
         # Create a superposition state
@@ -593,8 +596,9 @@ class TestStateVectorForwardPath:
         layer = ML.QuantumLayer(
             circuit=circuit,
             n_photons=2,
-            computation_space=ML.ComputationSpace.FOCK,
-            measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
+            measurement_strategy=ML.MeasurementStrategy.amplitudes(
+                computation_space=ML.ComputationSpace.FOCK
+            ),
             dtype=torch.float64,
         )
 
@@ -623,8 +627,9 @@ class TestComplexTensorForwardPath:
         layer = ML.QuantumLayer(
             circuit=circuit,
             n_photons=2,
-            computation_space=ML.ComputationSpace.FOCK,
-            measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
+            measurement_strategy=ML.MeasurementStrategy.amplitudes(
+                computation_space=ML.ComputationSpace.FOCK
+            ),
         )
 
         n_states = layer.output_size
@@ -644,8 +649,9 @@ class TestComplexTensorForwardPath:
         layer = ML.QuantumLayer(
             circuit=circuit,
             n_photons=2,
-            computation_space=ML.ComputationSpace.FOCK,
-            measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
+            measurement_strategy=ML.MeasurementStrategy.amplitudes(
+                computation_space=ML.ComputationSpace.FOCK
+            ),
         )
 
         batch_size = 5
@@ -727,7 +733,7 @@ class TestAmplitudeEncodingRealInputDeprecation:
                 circuit=circuit,
                 n_photons=2,
                 amplitude_encoding=True,
-                measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
+                measurement_strategy=ML.MeasurementStrategy.NONE,
             )
 
         # Create real-valued amplitude input (not complex)

--- a/tests/algorithms/test_statevector_input.py
+++ b/tests/algorithms/test_statevector_input.py
@@ -63,7 +63,7 @@ class TestConstructorInputTypes:
             circuit=circuit,
             input_state=sv,
             n_photons=2,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         assert layer.n_photons == 2
@@ -77,7 +77,7 @@ class TestConstructorInputTypes:
             input_size=0,
             circuit=circuit,
             input_state=pcvl_sv,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         assert layer.n_photons == 2
@@ -91,7 +91,7 @@ class TestConstructorInputTypes:
             input_size=0,
             circuit=circuit,
             input_state=basic_state,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         assert layer.input_state == [1, 0, 1]
@@ -104,7 +104,7 @@ class TestConstructorInputTypes:
             input_size=0,
             circuit=circuit,
             input_state=[1, 1, 0],
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         assert layer.input_state == [1, 1, 0]
@@ -117,7 +117,7 @@ class TestConstructorInputTypes:
             input_size=0,
             circuit=circuit,
             input_state=(1, 0, 1),
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         # Layer should work regardless of internal representation
@@ -227,7 +227,7 @@ class TestForwardDispatch:
             input_size=2,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
     @pytest.fixture
@@ -367,7 +367,7 @@ class TestNNSequentialCompatibility:
             input_size=2,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         model = torch.nn.Sequential(
@@ -394,7 +394,7 @@ class TestNNSequentialCompatibility:
             input_size=2,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         model = torch.nn.Sequential(
@@ -475,7 +475,7 @@ class TestAngleEncodingBackwardCompatibility:
             input_size=2,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         # Standard usage pattern
@@ -497,7 +497,7 @@ class TestAngleEncodingBackwardCompatibility:
             input_size=3,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         # Test various batch sizes
@@ -516,7 +516,7 @@ class TestAngleEncodingBackwardCompatibility:
             input_size=4,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         # Single combined input
@@ -678,7 +678,7 @@ class TestErrorHandling:
             input_size=2,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         try:
@@ -699,7 +699,7 @@ class TestErrorHandling:
             input_size=2,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         tensor = torch.rand(2, 2)

--- a/tests/algorithms/test_superposition_state.py
+++ b/tests/algorithms/test_superposition_state.py
@@ -339,12 +339,13 @@ class TestOutputSuperposedState:
         amplitude_layer = QuantumLayer(
             circuit=circuit,
             n_photons=n_photons,
-            measurement_strategy=MeasurementStrategy.AMPLITUDES,
+            measurement_strategy=MeasurementStrategy.amplitudes(
+                computation_space=computation_space
+            ),
             input_state=input_state,
             input_parameters=["theta"],
             trainable_parameters=["phi"],
             dtype=torch.float64,
-            computation_space=computation_space,
         )
 
         classical_dim = amplitude_layer.input_size or n_modes
@@ -382,12 +383,13 @@ class TestOutputSuperposedState:
             basis_layer = QuantumLayer(
                 circuit=copy.deepcopy(circuit),
                 n_photons=n_photons,
-                measurement_strategy=MeasurementStrategy.AMPLITUDES,
+                measurement_strategy=MeasurementStrategy.amplitudes(
+                    computation_space=computation_space
+                ),
                 input_state=list(state),
                 input_parameters=["theta"],
                 trainable_parameters=["phi"],
                 dtype=torch.float64,
-                computation_space=computation_space,
             )
 
             load_result = basis_layer.load_state_dict(shared_state, strict=False)

--- a/tests/algorithms/test_superposition_state.py
+++ b/tests/algorithms/test_superposition_state.py
@@ -64,12 +64,13 @@ class TestOutputSuperposedState:
         layer = QuantumLayer(
             circuit=circuit,
             n_photons=n_photons,
-            measurement_strategy=MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=MeasurementStrategy.probs(
+                computation_space=ComputationSpace.UNBUNCHED
+            ),
             input_state=input_state,
             trainable_parameters=["phi"],
             input_parameters=[],
             dtype=torch.float64,
-            computation_space=ComputationSpace.UNBUNCHED,
         )
 
         input_state_superposed = {
@@ -105,12 +106,13 @@ class TestOutputSuperposedState:
         layer = QuantumLayer(
             circuit=circuit,
             n_photons=n_photons,
-            measurement_strategy=MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=MeasurementStrategy.probs(
+                computation_space=ComputationSpace.UNBUNCHED
+            ),
             input_state=input_state,
             trainable_parameters=["phi"],
             input_parameters=[],
             dtype=torch.float64,
-            computation_space=ComputationSpace.UNBUNCHED,
         )
 
         input_state_superposed = {
@@ -145,12 +147,13 @@ class TestOutputSuperposedState:
             input_size=0,
             circuit=circuit,
             n_photons=n_photons,
-            measurement_strategy=MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=MeasurementStrategy.probs(
+                computation_space=ComputationSpace.UNBUNCHED
+            ),
             input_state=input_state,
             trainable_parameters=["phi"],
             input_parameters=[],
             dtype=torch.float64,
-            computation_space=ComputationSpace.UNBUNCHED,
         )
 
         process = layer.computation_process
@@ -194,12 +197,13 @@ class TestOutputSuperposedState:
             input_size=0,
             circuit=circuit,
             n_photons=n_photons,
-            measurement_strategy=MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=MeasurementStrategy.probs(
+                computation_space=ComputationSpace.UNBUNCHED
+            ),
             input_state=input_state,
             trainable_parameters=["phi"],
             input_parameters=[],
             dtype=torch.float64,
-            computation_space=ComputationSpace.UNBUNCHED,
         )
 
         process = layer.computation_process
@@ -240,12 +244,13 @@ class TestOutputSuperposedState:
         layer = QuantumLayer(
             circuit=circuit,
             n_photons=n_photons,
-            measurement_strategy=MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=MeasurementStrategy.probs(
+                computation_space=ComputationSpace.UNBUNCHED
+            ),
             input_state=input_state,
             trainable_parameters=[],
             input_parameters=["px"],
             dtype=torch.float64,
-            computation_space=ComputationSpace.UNBUNCHED,
         )
 
         process = layer.computation_process
@@ -456,12 +461,13 @@ class TestOutputSuperposedState:
         layer = QuantumLayer(
             circuit=circuit,
             n_photons=n_photons,
-            measurement_strategy=MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=MeasurementStrategy.probs(
+                computation_space=ComputationSpace.DUAL_RAIL
+            ),
             input_state=sv,
             trainable_parameters=["phi"],
             input_parameters=["theta"],
             dtype=torch.float64,
-            computation_space=ComputationSpace.DUAL_RAIL,
         )
 
         # input is a batch of 10 tensor

--- a/tests/builder/test_circuit_builder.py
+++ b/tests/builder/test_circuit_builder.py
@@ -158,7 +158,7 @@ def test_builder_integrates_directly_with_quantum_layer():
         input_size=3,
         builder=builder,
         n_photons=1,
-        measurement_strategy=MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=MeasurementStrategy.probs(),
         dtype=torch.float32,
     )
     model = torch.nn.Sequential(layer, torch.nn.Linear(layer.output_size, 3))
@@ -238,7 +238,7 @@ def test_angle_encoding_applies_scaling_in_quantum_layer():
         input_size=3,
         builder=builder,
         n_photons=1,
-        measurement_strategy=MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=MeasurementStrategy.probs(),
         dtype=torch.float32,
     )
     torch.nn.Sequential(layer, torch.nn.Linear(layer.output_size, 3))
@@ -267,7 +267,7 @@ def test_angle_encoding_subset_combinations_in_quantum_layer():
         input_size=3,
         builder=builder,
         n_photons=1,
-        measurement_strategy=MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=MeasurementStrategy.probs(),
         dtype=torch.float32,
     )
 
@@ -415,7 +415,7 @@ def test_entangling_layer_models_forward_backward(model):
         input_size=4,
         builder=builder,
         n_photons=1,
-        measurement_strategy=MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=MeasurementStrategy.probs(),
         dtype=torch.float32,
     )
 
@@ -449,7 +449,7 @@ def test_entangling_layer_layer_trains():
         input_size=4,
         builder=builder,
         n_photons=1,
-        measurement_strategy=MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=MeasurementStrategy.probs(),
         dtype=torch.float32,
     )
     model = torch.nn.Sequential(layer, torch.nn.Linear(layer.output_size, 4))
@@ -476,7 +476,7 @@ def test_entangling_layer_with_additional_components_trains():
         input_size=5,
         builder=builder,
         n_photons=1,
-        measurement_strategy=MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=MeasurementStrategy.probs(),
         dtype=torch.float32,
     )
     pcvl.pdisplay(layer.computation_process.circuit, output_format=pcvl.Format.TEXT)
@@ -508,7 +508,7 @@ def test_entangling_layer_models_on_gpu(model):
         input_size=4,
         builder=builder,
         n_photons=1,
-        measurement_strategy=MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=MeasurementStrategy.probs(),
         dtype=torch.float32,
     ).to(device)
 

--- a/tests/core/test_no_bunching.py
+++ b/tests/core/test_no_bunching.py
@@ -184,16 +184,18 @@ class TestNoBunchingFunctionality:
             input_state = StateGenerator.generate_state(
                 n_modes, n_photons, StatePattern.PERIODIC
             )
+            computation_space = (
+                ComputationSpace.UNBUNCHED if no_bunching else ComputationSpace.FOCK
+            )
             q_layer = QuantumLayer(
                 input_size=3,
                 circuit=circuit,
                 input_state=input_state,
                 trainable_parameters=["phi_"],
                 input_parameters=["pl"],
-                measurement_strategy=MeasurementStrategy.PROBABILITIES,
-                computation_space=ComputationSpace.UNBUNCHED
-                if no_bunching
-                else ComputationSpace.FOCK,
+                measurement_strategy=MeasurementStrategy.probs(
+                    computation_space=computation_space
+                ),
             )
 
             # Create dummy parameters

--- a/tests/measurement/test_detectors.py
+++ b/tests/measurement/test_detectors.py
@@ -167,8 +167,9 @@ class TestDetectorsWithQuantumLayer:
                 input_size=0,
                 experiment=experiment,
                 input_state=[1, 0],
-                measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
-                computation_space=ComputationSpace.FOCK,
+                measurement_strategy=ML.MeasurementStrategy.amplitudes(
+                    computation_space=ComputationSpace.FOCK
+                ),
             )
 
         # No error with MeasurementStrategy PROBABILITIES or MODE_EXPECTATIONS
@@ -176,15 +177,17 @@ class TestDetectorsWithQuantumLayer:
             input_size=0,
             experiment=experiment,
             input_state=[1, 0],
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
         ML.QuantumLayer(
             input_size=0,
             experiment=experiment,
             input_state=[1, 0],
-            measurement_strategy=ML.MeasurementStrategy.MODE_EXPECTATIONS,
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.mode_expectations(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
     def test_pnr_detectors_match_default_distribution(self):
@@ -736,8 +739,9 @@ class TestDetectorsWithQuantumLayer:
             input_size=0,
             experiment=_build_experiment(detector_specs),
             input_state=INPUT_STATE,
-            measurement_strategy=ML.MeasurementStrategy.MODE_EXPECTATIONS,
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.mode_expectations(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
         expectations = expectation_layer().squeeze(0)
         assert [_normalize_key(key) for key in expectation_layer.output_keys] == keys

--- a/tests/measurement/test_detectors_partial.py
+++ b/tests/measurement/test_detectors_partial.py
@@ -160,8 +160,9 @@ def test_partial_detector_transform_mixed_pnr_case(
 
     ql = QuantumLayer(
         experiment=exp,
-        measurement_strategy=MeasurementStrategy.PROBABILITIES,
-        computation_space=ComputationSpace.FOCK,
+        measurement_strategy=MeasurementStrategy.probs(
+            computation_space=ComputationSpace.FOCK
+        ),
     )
     probabilities = ql().squeeze(0)
 
@@ -180,8 +181,9 @@ def test_partial_detector_transform_mixed_pnr_case(
 
     ql_nodetect = QuantumLayer(
         experiment=exp_nodetect,
-        measurement_strategy=MeasurementStrategy.AMPLITUDES,
-        computation_space=ComputationSpace.FOCK,
+        measurement_strategy=MeasurementStrategy.amplitudes(
+            computation_space=ComputationSpace.FOCK
+        ),
     )
     amplitudes = ql_nodetect().squeeze(0)
 

--- a/tests/measurement/test_mappers.py
+++ b/tests/measurement/test_mappers.py
@@ -48,7 +48,7 @@ class TestOutputMapper:
 
     def test_state_vector_mapping_creation_valid(self):
         """Test creation of state vector mapping with matching sizes."""
-        mapping = ML.OutputMapper.create_mapping(ML.MeasurementStrategy.amplitudes())
+        mapping = ML.OutputMapper.create_mapping(ML.MeasurementStrategy.NONE)
         batch_size = 4
         input_amps = torch.rand(batch_size, 5)
         output_amps = mapping(input_amps)
@@ -111,7 +111,7 @@ class TestOutputMappingIntegration:
             ML.MeasurementStrategy.mode_expectations(
                 computation_space=ML.ComputationSpace.UNBUNCHED
             ),
-            ML.MeasurementStrategy.amplitudes(),
+            ML.MeasurementStrategy.NONE,
         ]
 
         builder = ML.CircuitBuilder(n_modes=6)

--- a/tests/measurement/test_mappers.py
+++ b/tests/measurement/test_mappers.py
@@ -32,7 +32,7 @@ class TestOutputMapper:
     def test_linear_mapping_creation(self):
         """Test creation of linear output mapping."""
         fock_distribution = ML.OutputMapper.create_mapping(
-            ML.MeasurementStrategy.PROBABILITIES
+            ML.MeasurementStrategy.probs()
         )
         mapping = torch.nn.Sequential(fock_distribution, nn.Linear(6, 3))
         assert isinstance(mapping[0], ML.Probabilities)
@@ -42,13 +42,13 @@ class TestOutputMapper:
 
     def test_fock_distribution_mapping_creation(self):
         fock_distribution = ML.OutputMapper.create_mapping(
-            ML.MeasurementStrategy.PROBABILITIES
+            ML.MeasurementStrategy.probs()
         )
         assert isinstance(fock_distribution, ML.Probabilities)
 
     def test_state_vector_mapping_creation_valid(self):
         """Test creation of state vector mapping with matching sizes."""
-        mapping = ML.OutputMapper.create_mapping(ML.MeasurementStrategy.AMPLITUDES)
+        mapping = ML.OutputMapper.create_mapping(ML.MeasurementStrategy.amplitudes())
         batch_size = 4
         input_amps = torch.rand(batch_size, 5)
         output_amps = mapping(input_amps)
@@ -70,7 +70,11 @@ class TestOutputMapper:
             ValueError,
             match="When using ModeExpectations measurement strategy, keys must be provided.",
         ):
-            ML.OutputMapper.create_mapping(ML.MeasurementStrategy.MODE_EXPECTATIONS)
+            ML.OutputMapper.create_mapping(
+                ML.MeasurementStrategy.mode_expectations(
+                    computation_space=ML.ComputationSpace.UNBUNCHED
+                )
+            )
 
 
 class TestOutputMappingIntegration:
@@ -88,7 +92,7 @@ class TestOutputMappingIntegration:
             input_size=2,
             n_photons=2,
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         model = torch.nn.Sequential(layer, torch.nn.Linear(layer.output_size, 3))
@@ -103,9 +107,11 @@ class TestOutputMappingIntegration:
         """Test gradient flow through different mapping strategies."""
 
         strategies = [
-            ML.MeasurementStrategy.PROBABILITIES,
-            ML.MeasurementStrategy.MODE_EXPECTATIONS,
-            ML.MeasurementStrategy.AMPLITUDES,
+            ML.MeasurementStrategy.probs(),
+            ML.MeasurementStrategy.mode_expectations(
+                computation_space=ML.ComputationSpace.UNBUNCHED
+            ),
+            ML.MeasurementStrategy.amplitudes(),
         ]
 
         builder = ML.CircuitBuilder(n_modes=6)
@@ -162,7 +168,7 @@ class TestOutputMappingIntegration:
             input_size=2,
             n_photons=2,
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
         model = torch.nn.Sequential(layer, torch.nn.Linear(layer.output_size, 3))
         output_linear = model(x)
@@ -180,7 +186,7 @@ class TestOutputMappingIntegration:
                 input_size=2,
                 n_photons=2,
                 builder=builder,
-                measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+                measurement_strategy=ML.MeasurementStrategy.probs(),
                 dtype=dtype,
             )
             model = torch.nn.Sequential(
@@ -205,7 +211,7 @@ class TestOutputMappingIntegration:
             input_size=1,
             n_photons=1,
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
         model = torch.nn.Sequential(layer, torch.nn.Linear(layer.output_size, 1))
 

--- a/tests/measurement/test_measurement_strategy.py
+++ b/tests/measurement/test_measurement_strategy.py
@@ -338,7 +338,7 @@ class TestQuantumLayerMeasurementStrategy:
             input_size=2,
             n_photons=1,
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.amplitudes(),
+            measurement_strategy=ML.MeasurementStrategy.NONE,
         )
         x = torch.rand(2, 2, requires_grad=True)
         output = layer(x)
@@ -372,7 +372,7 @@ class TestQuantumLayerMeasurementStrategy:
             input_state=input_state,
             trainable_parameters=[],
             input_parameters=["px"],
-            measurement_strategy=MeasurementStrategy.amplitudes(),
+            measurement_strategy=MeasurementStrategy.NONE,
         )
         x = torch.rand(2, 2, requires_grad=True)
         output = layer(x)
@@ -680,7 +680,7 @@ def test_amplitudes_strategy_rejects_sampling_in_layer():
         input_size=2,
         n_photons=1,
         builder=builder,
-        measurement_strategy=ML.MeasurementStrategy.amplitudes(),
+        measurement_strategy=ML.MeasurementStrategy.NONE,
     )
     layer.eval()
     x = torch.rand(2, 2)

--- a/tests/measurement/test_photon_loss.py
+++ b/tests/measurement/test_photon_loss.py
@@ -117,7 +117,7 @@ class TestPhotonLossWithQuantumLayer:
                 input_size=0,
                 experiment=experiment,
                 input_state=[1, 0],
-                measurement_strategy=ML.MeasurementStrategy.amplitudes(),
+                measurement_strategy=ML.MeasurementStrategy.NONE,
             )
 
         prob_layer = ML.QuantumLayer(
@@ -147,7 +147,7 @@ class TestPhotonLossWithQuantumLayer:
             input_size=0,
             experiment=experiment_no_noise,
             input_state=[1, 0],
-            measurement_strategy=ML.MeasurementStrategy.amplitudes(),
+            measurement_strategy=ML.MeasurementStrategy.NONE,
         )
 
         keys_amplitudes = amplitude_layer.output_keys

--- a/tests/measurement/test_photon_loss.py
+++ b/tests/measurement/test_photon_loss.py
@@ -117,20 +117,22 @@ class TestPhotonLossWithQuantumLayer:
                 input_size=0,
                 experiment=experiment,
                 input_state=[1, 0],
-                measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
+                measurement_strategy=ML.MeasurementStrategy.amplitudes(),
             )
 
         prob_layer = ML.QuantumLayer(
             input_size=0,
             experiment=experiment,
             input_state=[1, 0],
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
         expectation_layer = ML.QuantumLayer(
             input_size=0,
             experiment=experiment,
             input_state=[1, 0],
-            measurement_strategy=ML.MeasurementStrategy.MODE_EXPECTATIONS,
+            measurement_strategy=ML.MeasurementStrategy.mode_expectations(
+                computation_space=ComputationSpace.UNBUNCHED
+            ),
         )
         prob_output = prob_layer()
         expectation_output = expectation_layer()
@@ -145,7 +147,7 @@ class TestPhotonLossWithQuantumLayer:
             input_size=0,
             experiment=experiment_no_noise,
             input_state=[1, 0],
-            measurement_strategy=ML.MeasurementStrategy.AMPLITUDES,
+            measurement_strategy=ML.MeasurementStrategy.amplitudes(),
         )
 
         keys_amplitudes = amplitude_layer.output_keys

--- a/tests/measurement/test_sampling.py
+++ b/tests/measurement/test_sampling.py
@@ -230,7 +230,7 @@ class TestSamplingIntegration:
             input_size=2,
             input_state=[1, 0, 1, 0],
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
         return layer
 

--- a/tests/memory_benchmark.py
+++ b/tests/memory_benchmark.py
@@ -94,8 +94,7 @@ def benchmark_bs(MODES=8, PHOTONS=4, BS=32, TYPE=torch.float32, set_hp=False):
     circuit = pcvl.GenericInterferometer(
         MODES,
         lambda i: (
-            pcvl
-            .BS(theta=pcvl.P(f"theta_1_{i}"))
+            pcvl.BS(theta=pcvl.P(f"theta_1_{i}"))
             .add(0, pcvl.PS(pcvl.P(f"phase_1_{i}")))
             .add(0, pcvl.BS(theta=pcvl.P(f"theta_2_{i}")))
             .add(0, pcvl.PS(pcvl.P(f"phase_2_{i}")))
@@ -129,7 +128,7 @@ def benchmark_bs(MODES=8, PHOTONS=4, BS=32, TYPE=torch.float32, set_hp=False):
         input_state=input_state,
         trainable_parameters=[],
         input_parameters=["phase", "theta"],
-        measurement_strategy=MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=MeasurementStrategy.probs(),
         device=device,
         no_bunching=True,
     )

--- a/tests/pcvl_pytorch/test_perceval_comparison.py
+++ b/tests/pcvl_pytorch/test_perceval_comparison.py
@@ -65,8 +65,7 @@ class TestPercevalComparison:
             parameters.append(parameter)
 
         chip = (
-            pcvl
-            .Circuit(self.N_MODES, name="chip")
+            pcvl.Circuit(self.N_MODES, name="chip")
             .add(0, pre_U)
             .add(0, phases_U, merge=False)
             .add(0, reservoir_U, merge=False)
@@ -87,7 +86,7 @@ class TestPercevalComparison:
             n_photons=self.N_PHOTONS,
             input_parameters=["φ"],
             trainable_parameters=[],
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
         # Create dummy input to get parameters (add batch dimension)

--- a/tests/utils/test_grouping.py
+++ b/tests/utils/test_grouping.py
@@ -266,7 +266,7 @@ def test_lexgrouping_mapping_integration():
         input_size=2,
         n_photons=2,
         builder=builder,
-        measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=ML.MeasurementStrategy.probs(),
     )
     model = nn.Sequential(layer, LexGrouping(layer.output_size, 4))
 
@@ -289,7 +289,7 @@ def test_modgrouping_mapping_integration():
         input_size=2,
         n_photons=2,
         builder=builder,
-        measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=ML.MeasurementStrategy.probs(),
     )
     model = nn.Sequential(layer, ModGrouping(layer.output_size, 3))
 
@@ -315,7 +315,7 @@ def test_mapping_gradient_flow():
             input_size=2,
             n_photons=2,
             builder=builder,
-            measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
         )
         model = torch.nn.Sequential(layer, grouping_policy(layer.output_size, 3))
 
@@ -349,7 +349,7 @@ def test_mapping_output_bounds():
         input_size=2,
         n_photons=2,
         builder=builder,
-        measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=ML.MeasurementStrategy.probs(),
     )
     model_lex = nn.Sequential(layer_lex, LexGrouping(layer_lex.output_size, 3))
     output_lex = model_lex(x)
@@ -360,7 +360,7 @@ def test_mapping_output_bounds():
         input_size=2,
         n_photons=2,
         builder=builder,
-        measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=ML.MeasurementStrategy.probs(),
     )
     model_mod = nn.Sequential(layer_mod, ModGrouping(layer_mod.output_size, 3))
     output_mod = model_mod(x)
@@ -380,7 +380,7 @@ def test_large_dimension_mappings():
         input_size=4,
         n_photons=3,
         builder=builder,
-        measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=ML.MeasurementStrategy.probs(),
     )
     model = nn.Sequential(layer, LexGrouping(layer.output_size, 8))
 
@@ -404,7 +404,7 @@ def test_mapping_determinism():
         input_size=2,
         n_photons=2,
         builder=builder,
-        measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
+        measurement_strategy=ML.MeasurementStrategy.probs(),
     )
     model = nn.Sequential(layer, ModGrouping(layer.output_size, 3))
 


### PR DESCRIPTION
<!--
Thank you for contributing to MerLin!
Please fill out the sections below to help us review your PR efficiently.

NOTE: this repo is a public repository, therefore, do NOT paste Jira URLs. Use the Jira issue key only (e.g., PML-126).
The Jira–GitHub integration will link PRs/commits automatically when the key is present.
-->

<!-- Add the Jira issue key in the title -->
<!-- e.g., PML-126 Updating PR template -->

## Summary
<!-- What does this PR do? A clear, concise description. -->
- default of computation_space in probs() and mode_expectations() is now UNBUNCHED to reflect former values of `computation_space` in constructor
- replaced old API in the tests by the new API, while keeping the legacy backward tests for compatibility

**One unrelated test was failing on GPU** : related to the `simple()` method on kernels : I removed the deprecated inputs `n_photons` and `trainable`, maybe @LF-Vigneux can approve this change

## Related Issue
   <!-- For internal contributors: Use Jira key (e.g., Related Jira: PML-126)
        For external contributors: Link to GitHub issue if applicable -->
Related Jira: PML-165

## Type of change
- [x] Refactor / Cleanup


## Proposed changes
<!-- Bulleted list of key changes. If API changes, list them explicitly. -->
When changing the tests in `measurement/test_measurement_strategies.py`, some redundancy appear and therefore, some tests were removed. This includes:
- Remove `test_linear_equivalent` (already covered by `test_measurement_distribution` + `test_new_api_probabilities_backprop`)
- Remove `test_mode_expectations` (covered by `test_new_api_mode_expectations_output_size`).
- In `test_amplitude_vector`, drop the second layer instantiation (the one that re-tests output size and normalization)

Tests cover by these changes are:
- tests/algorithms/test_all_apis.py
- tests/algorithms/test_amplitude_encoding.py
- tests/algorithms/test_compute_ebs_simultaneously.py
- tests/algorithms/test_cuda.py
- tests/algorithms/test_dtype_propagation.py
- tests/algorithms/test_feed_forward_block.py
- tests/algorithms/test_ff_perceval_integration.py
- tests/algorithms/test_kernels.py
- tests/algorithms/test_layer.py
- tests/algorithms/test_layer_utils.py
- tests/algorithms/test_robustness.py
- tests/algorithms/test_statevector_input.py
- tests/algorithms/test_superposition_state.py
- tests/builder/test_circuit_builder.py
- tests/core/test_no_bunching.py
- tests/measurement/test_deprecations.py
- tests/measurement/test_detectors.py
- tests/measurement/test_detectors_partial.py
- tests/measurement/test_mappers.py
- tests/measurement/test_measurement_strategy.py
- tests/measurement/test_photon_loss.py
- tests/measurement/test_sampling.py
- tests/memory_benchmark.py
- tests/pcvl_pytorch/test_perceval_comparison.py
- tests/utils/test_grouping.py

## How to test / How to run
<!-- Describe test plan and steps for reviewers to validate and run your changes locally. Include datasets if relevant. -->

1. Command lines

```
pytest --cov
```

## Screenshots / Logs (optional)
<!-- Add images or paste relevant logs for UI/Doc changes or failures you fixed. -->


## Performance considerations (optional)
<!-- Note expected speed/memory impact and how you measured it. -->


## Checklist
- [x] PR title includes Jira issue key (e.g., PML-126)
- [x] "Related Jira ticket" section includes the Jira issue key (no URL)
- [x] Code formatted (ruff format)
- [x] Lint passes (ruff)
- [x] Static typing passes (mypy) if applicable
- [x] Unit tests added/updated (pytest)
- [x] Tests pass locally (pytest)
- [x] Tests pass on GPU (pytest)
- [x] Test coverage not decreased significantly
- [x] Dependencies updated (if needed) and pinned appropriately
- [x] PR description explains what changed and how to validate it

<!-- Helpful local commands – run from repo root:

# Lint & format
ruff format && ruff check .

# Type check (if used)
mypy .

# Tests with coverage
pytest

# Build docs
pip install -e .[docs] && make -C docs html

-->