### PR TITLE
PML-162:  Breaking change - deprecation of no bunching for computation_space support

### DIFF
--- a/benchmarks/benchmark_layer.py
+++ b/benchmarks/benchmark_layer.py
@@ -255,15 +255,15 @@ def test_output_mapping_strategies_benchmark(benchmark, config: dict, device: st
     """Benchmark different output mapping strategies."""
     strategies = [
         {
-            "measurement_strategy": ML.MeasurementStrategy.PROBABILITIES,
+            "measurement_strategy": ML.MeasurementStrategy.probs(),
             "grouping_policy": None,
         },
         {
-            "measurement_strategy": ML.MeasurementStrategy.PROBABILITIES,
+            "measurement_strategy": ML.MeasurementStrategy.probs(),
             "grouping_policy": ML.LexGrouping,
         },
         {
-            "measurement_strategy": ML.MeasurementStrategy.PROBABILITIES,
+            "measurement_strategy": ML.MeasurementStrategy.probs(),
             "grouping_policy": ML.ModGrouping,
         },
     ]

--- a/benchmarks/benchmark_no_bunching.py
+++ b/benchmarks/benchmark_no_bunching.py
@@ -35,6 +35,7 @@ import pytest
 import torch
 
 import merlin as ML
+from merlin.core.computation_space import ComputationSpace
 from merlin.core.generators import CircuitGenerator, StateGenerator
 from merlin.core.process import ComputationProcessFactory
 
@@ -105,13 +106,12 @@ def test_no_bunching_computation_benchmark(benchmark, config: dict, device: str)
         n_modes, n_photons, ML.StatePattern.SEQUENTIAL
     )
 
-    # Create computation process with no_bunching=True
+    # Create computation process with default (UNBUNCHED) computation space
     process = ComputationProcessFactory.create(
         circuit=circuit,
         input_state=input_state,
         trainable_parameters=["phi_"],
         input_parameters=["pl"],
-        no_bunching=True,
     )
 
     # Create dummy parameters
@@ -156,7 +156,6 @@ def test_fock_space_comparison_benchmark(benchmark, config: dict, device: str):
             input_state=input_state,
             trainable_parameters=["phi_"],
             input_parameters=["pl"],
-            no_bunching=True,
         )
 
         # Full Fock space process
@@ -165,7 +164,7 @@ def test_fock_space_comparison_benchmark(benchmark, config: dict, device: str):
             input_state=input_state,
             trainable_parameters=["phi_"],
             input_parameters=["pl"],
-            no_bunching=False,
+            computation_space=ComputationSpace.FOCK,
         )
 
         # Create dummy parameters
@@ -220,7 +219,6 @@ def test_compute_with_keys_benchmark(benchmark, config: dict, device: str):
         input_state=input_state,
         trainable_parameters=["phi_"],
         input_parameters=["pl"],
-        no_bunching=True,
     )
 
     spec_mappings = process_no_bunching.converter.spec_mappings
@@ -266,7 +264,6 @@ class TestNoBunchingPerformanceRegression:
             input_state=input_state,
             trainable_parameters=["phi_"],
             input_parameters=["pl"],
-            no_bunching=True,
         )
 
         spec_mappings = process.converter.spec_mappings
@@ -337,7 +334,6 @@ if __name__ == "__main__":
         input_state=input_state,
         trainable_parameters=["phi_"],
         input_parameters=["pl"],
-        no_bunching=True,
     )
 
     spec_mappings = process.converter.spec_mappings

--- a/merlin/algorithms/feed_forward.py
+++ b/merlin/algorithms/feed_forward.py
@@ -1341,9 +1341,11 @@ class FeedForwardBlock(MerlinModule):
                 input_size=0,
                 circuit=pcvl.Circuit(n_modes),
                 n_photons=n_photons,
-                computation_space=self.computation_space,
                 device=self.device,
                 dtype=self.dtype,
+                measurement_strategy=MeasurementStrategy.probs(
+                    computation_space=self.computation_space
+                ),
             )
             basis = tuple(layer.computation_process.simulation_graph.mapped_keys)
             self._basis_cache[cache_key] = basis

--- a/merlin/algorithms/feed_forward_legacy.py
+++ b/merlin/algorithms/feed_forward_legacy.py
@@ -634,17 +634,21 @@ class PoolingFeedForwardLegacy(torch.nn.Module):
             0,
             circuit=pcvl.Circuit(n_modes),
             n_photons=n_photons,
-            computation_space=ComputationSpace.UNBUNCHED
-            if no_bunching
-            else ComputationSpace.FOCK,
+            measurement_strategy=MeasurementStrategy.probs(
+                computation_space=ComputationSpace.coerce(
+                    ComputationSpace.UNBUNCHED if no_bunching else ComputationSpace.FOCK
+                )
+            ),
         ).computation_process.simulation_graph.mapped_keys
         keys_out = QuantumLayer(
             0,
             circuit=pcvl.Circuit(n_output_modes),
             n_photons=n_photons,
-            computation_space=ComputationSpace.UNBUNCHED
-            if no_bunching
-            else ComputationSpace.FOCK,
+            measurement_strategy=MeasurementStrategy.probs(
+                computation_space=ComputationSpace.coerce(
+                    ComputationSpace.UNBUNCHED if no_bunching else ComputationSpace.FOCK
+                )
+            ),
         ).computation_process.simulation_graph.mapped_keys
 
         # If no pooling structure is provided, construct a balanced one

--- a/merlin/algorithms/feed_forward_legacy.py
+++ b/merlin/algorithms/feed_forward_legacy.py
@@ -29,6 +29,7 @@ from perceval.components import BS, PS
 from ..core.computation_space import ComputationSpace
 from ..core.generators import StateGenerator, StatePattern
 from ..measurement.strategies import MeasurementStrategy
+from ..utils.deprecations import raise_no_bunching_deprecated
 from .layer import QuantumLayer
 
 
@@ -600,9 +601,8 @@ class PoolingFeedForwardLegacy(torch.nn.Module):
         Specifies how input modes are grouped (pooled) into output modes.
         Each sublist contains the indices of input modes to pool together
         for one output mode. If None, an even pooling scheme is automatically generated.
-    no_bunching : bool, default=True
-        Whether to restrict to Fock states without photon bunching
-        (i.e., no two photons occupy the same mode).
+    no_bunching : bool | None, optional (deprecated)
+        Deprecated and now removed; use computation_space in MeasurementStrategy instead.
 
     Attributes
     ----------
@@ -623,9 +623,13 @@ class PoolingFeedForwardLegacy(torch.nn.Module):
         n_photons: int,
         n_output_modes: int,
         pooling_modes: list[list[int]] = None,
-        no_bunching=True,
+        no_bunching: bool | None = None,
     ):
         super().__init__()
+        if no_bunching is not None:
+            raise_no_bunching_deprecated(stacklevel=2)
+        if no_bunching is None:
+            no_bunching = True
         keys_in = QuantumLayer(
             0,
             circuit=pcvl.Circuit(n_modes),

--- a/merlin/algorithms/kernels.py
+++ b/merlin/algorithms/kernels.py
@@ -907,7 +907,8 @@ class FidelityKernel(MerlinModule):
             ])
             if isinstance(x2, torch.Tensor):
                 U_adjoint = torch.stack([
-                    self.feature_map.compute_unitary(x)
+                    self.feature_map
+                    .compute_unitary(x)
                     .transpose(0, 1)
                     .conj()
                     .to(x1.device)

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -928,9 +928,13 @@ class QuantumLayer(MerlinModule):
 
         if (
             self.return_object is True
-            and not self.measurement_strategy == MeasurementStrategy.MODE_EXPECTATIONS
+            and _resolve_measurement_kind(self.measurement_strategy)
+            != MeasurementKind.MODE_EXPECTATIONS
         ):
-            if self.measurement_strategy == MeasurementStrategy.PROBABILITIES:
+            if (
+                _resolve_measurement_kind(self.measurement_strategy)
+                == MeasurementKind.PROBABILITIES
+            ):
                 return ProbabilityDistribution(
                     self.measurement_mapping(results),
                     n_modes=len(self.input_state),

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -1322,6 +1322,11 @@ class QuantumLayer(MerlinModule):
             # Trainable entangling layer after encoding
             builder.add_entangling_layer(trainable=True, name="RI_simple")
 
+        # new API forces explicit measurement strategy definition, so we set it here to match the old default behavior of returning probabilities
+        measurement_strategy = MeasurementStrategy.probs(
+            computation_space=ComputationSpace.coerce(computation_space)
+        )
+
         quantum_layer_kwargs = {
             "input_size": input_size,
             "input_state": input_state,
@@ -1329,7 +1334,7 @@ class QuantumLayer(MerlinModule):
             "n_photons": n_photons,
             "device": device,
             "dtype": dtype,
-            "computation_space": computation_space,
+            "measurement_strategy": measurement_strategy,
         }
 
         # mypy: quantum_layer_kwargs is constructed dynamically; cast to satisfy

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -202,8 +202,7 @@ class QuantumLayer(MerlinModule):
             ``amplitude_encoding=True`` and ``input_size`` is set; if
             ``amplitude_encoding=True`` and ``n_photons`` is not provided; if
             classical ``input_parameters`` are combined with
-            ``amplitude_encoding=True``; if ``no_bunching`` conflicts with the
-            selected ``computation_space``; if an ``experiment`` is not unitary or
+            ``amplitude_encoding=True``; if an ``experiment`` is not unitary or
             uses post-selection/heralding; if neither ``input_state`` nor
             ``n_photons`` is provided when required; or if an annotated
             ``BasicState`` is passed (annotations are not supported).

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -65,8 +65,7 @@ class ComputationProcess(AbstractComputationProcess):
             raise_no_bunching_deprecated(stacklevel=2)
 
         if computation_space is None:
-            # Default computation space based on deprecated no_bunching flag
-            computation_space = ComputationSpace.default(no_bunching=no_bunching)
+            computation_space = ComputationSpace.UNBUNCHED
 
         self.computation_space = computation_space
         self.output_map_func = output_map_func

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -32,6 +32,7 @@ import torch
 
 from ..pcvl_pytorch import CircuitConverter, build_slos_distribution_computegraph
 from ..utils.combinadics import Combinadics
+from ..utils.deprecations import raise_no_bunching_deprecated
 from .base import AbstractComputationProcess
 from .computation_space import ComputationSpace
 
@@ -59,6 +60,9 @@ class ComputationProcess(AbstractComputationProcess):
         self.input_parameters = input_parameters
         self.dtype = dtype
         self.device = device
+
+        if no_bunching is not None:
+            raise_no_bunching_deprecated(stacklevel=2)
 
         if computation_space is None:
             # Default computation space based on deprecated no_bunching flag

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -222,6 +222,7 @@ class MeasurementStrategy(metaclass=_MeasurementStrategyMeta):
         grouping: LexGrouping | ModGrouping | None = None,
     ) -> MeasurementStrategy:
         # Full measurement returning a probability distribution.
+        computation_space = ComputationSpace.coerce(computation_space)
         return MeasurementStrategy(
             type=MeasurementKind["PROBABILITIES"],
             computation_space=computation_space,
@@ -234,6 +235,7 @@ class MeasurementStrategy(metaclass=_MeasurementStrategyMeta):
     ) -> MeasurementStrategy:
         # Mode_expectations
         # Per-mode expectation values from the measured distribution.
+        computation_space = ComputationSpace.coerce(computation_space)
         return MeasurementStrategy(
             type=MeasurementKind.MODE_EXPECTATIONS,
             computation_space=computation_space,
@@ -244,6 +246,7 @@ class MeasurementStrategy(metaclass=_MeasurementStrategyMeta):
         computation_space: ComputationSpace = ComputationSpace.UNBUNCHED,
     ) -> MeasurementStrategy:
         # Raw amplitudes without detector/noise/sampling processing.
+        computation_space = ComputationSpace.coerce(computation_space)
         return MeasurementStrategy(
             type=MeasurementKind.AMPLITUDES,
             computation_space=computation_space,
@@ -267,6 +270,7 @@ class MeasurementStrategy(metaclass=_MeasurementStrategyMeta):
             raise ValueError("Negative mode index")
 
         # Partial measurement is explicit and validated; modes drive processing.
+        computation_space = ComputationSpace.coerce(computation_space)
         return MeasurementStrategy(
             type=MeasurementKind.PARTIAL,
             measured_modes=tuple(modes),

--- a/merlin/pcvl_pytorch/slos_torchscript.py
+++ b/merlin/pcvl_pytorch/slos_torchscript.py
@@ -985,7 +985,7 @@ def build_slos_distribution_computegraph(
         raise_no_bunching_deprecated(stacklevel=2)
 
     if computation_space is None:
-        computation_space = ComputationSpace.FOCK
+        computation_space = ComputationSpace.UNBUNCHED
 
     compute_graph = SLOSComputeGraph(
         m,

--- a/merlin/pcvl_pytorch/slos_torchscript.py
+++ b/merlin/pcvl_pytorch/slos_torchscript.py
@@ -37,6 +37,7 @@ import torch
 import torch.jit as jit
 
 from merlin.core.computation_space import ComputationSpace
+from merlin.utils.deprecations import raise_no_bunching_deprecated
 from merlin.utils.dtypes import resolve_float_complex
 
 
@@ -980,11 +981,11 @@ def build_slos_distribution_computegraph(
         Pre-built computation graph ready for repeated evaluations.
     """
 
-    # backward compatibility for deprecated no_bunching parameter
+    if no_bunching is not None:
+        raise_no_bunching_deprecated(stacklevel=2)
+
     if computation_space is None:
-        computation_space = (
-            ComputationSpace.UNBUNCHED if no_bunching else ComputationSpace.FOCK
-        )
+        computation_space = ComputationSpace.FOCK
 
     compute_graph = SLOSComputeGraph(
         m,

--- a/merlin/utils/deprecations.py
+++ b/merlin/utils/deprecations.py
@@ -245,10 +245,12 @@ def normalize_measurement_strategy(
     Rules:
     1. If MeasurementStrategy instance (new API) + constructor computation_space provided
        → ERROR: user must move computation_space into the factory method
-    2. If legacy enum (PROBABILITIES, etc) + constructor computation_space
+    2. If measurement_strategy is None and computation_space provided
+       → OK with deprecation warning (default to MeasurementStrategy.probs(computation_space))
+    3. If legacy enum (PROBABILITIES, etc) + constructor computation_space
        → OK with deprecation warning (backward compat)
-    3. If MeasurementStrategy instance only → use its computation_space
-    4. If legacy enum only → wrap with computation_space param
+    4. If MeasurementStrategy instance only → use its computation_space
+    5. If legacy enum only → wrap with computation_space param
     """
     from ..measurement.strategies import (
         MeasurementKind,
@@ -264,6 +266,13 @@ def normalize_measurement_strategy(
             computation_space = ComputationSpace.UNBUNCHED
         else:
             computation_space = ComputationSpace.coerce(computation_space)
+            warnings.warn(
+                "Passing 'computation_space' without an explicit measurement_strategy is deprecated. "
+                "Use MeasurementStrategy.probs(computation_space=...) instead. "
+                "Will be removed in 0.4 (v0.4).",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         measurement_strategy = MeasurementStrategy.probs(computation_space)
         return measurement_strategy, computation_space
 

--- a/merlin/utils/deprecations.py
+++ b/merlin/utils/deprecations.py
@@ -22,7 +22,8 @@ _MEASUREMENT_STRATEGY_ENUM_MIGRATIONS = {
 
 _NO_BUNCHING_REMOVED_MESSAGE = (
     "The 'no_bunching' parameter is removed. "
-    "Use measurement_strategy=MeasurementStrategy.probs(computation_space=...) instead."
+    "Use measurement_strategy=MeasurementStrategy.probs(computation_space=ComputationSpace.UNBUNCHED) "
+    "for no_bunching=True or computation_space=ComputationSpace.FOCK for no_bunching=False."
 )
 
 
@@ -33,7 +34,7 @@ def raise_no_bunching_deprecated(*, stacklevel: int = 2) -> None:
         DeprecationWarning,
         stacklevel=stacklevel,
     )
-    raise TypeError(_NO_BUNCHING_REMOVED_MESSAGE)
+    raise ValueError(_NO_BUNCHING_REMOVED_MESSAGE)
 
 
 def _reject_no_bunching_init(

--- a/merlin/utils/deprecations.py
+++ b/merlin/utils/deprecations.py
@@ -168,6 +168,11 @@ DEPRECATION_REGISTRY: dict[
         False,
         _remove_FidelityKernel_simple_n_photons,
     ),
+    "FidelityKernel.simple.no_bunching": (
+        None,
+        None,
+        _reject_no_bunching_init,
+    ),
     "FidelityKernel.simple.trainable": (
         "Since merlin >= 0.3, input parameter allocation is automatically inferred from input dimensionality, following Gan et al. (2022) on Fock-space expressivity. Manual control of input/trainable parameters is deprecated.",
         False,
@@ -177,6 +182,18 @@ DEPRECATION_REGISTRY: dict[
         "Since merlin >= 0.3, The input state is alway going to be a [0,1,0,1,...] state depending on input size.",
         False,
         _remove_FidelityKernel_input_state,
+    ),
+    # FidelityKernel.__init__ deprecations
+    "FidelityKernel.__init__.no_bunching": (
+        None,
+        None,
+        _reject_no_bunching_init,
+    ),
+    # KernelCircuitBuilder.build_fidelity_kernel deprecations
+    "KernelCircuitBuilder.build_fidelity_kernel.no_bunching": (
+        None,
+        None,
+        _reject_no_bunching_init,
     ),
 }
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,7 @@ testpaths = tests benchmarks
 python_files = test_*.py benchmark_*.py
 filterwarnings =
     error
+    # TODO: These warnings are kept for backprop on the cloud tests/ but should be removed once cloud tests are updated
     ignore:MeasurementStrategy\.PROBABILITIES is deprecated.*:DeprecationWarning
     ignore:MeasurementStrategy\.AMPLITUDES is deprecated.*:DeprecationWarning
     ignore:MeasurementStrategy\.MODE_EXPECTATIONS is deprecated.*:DeprecationWarning
@@ -11,7 +12,9 @@ filterwarnings =
     ignore:Parameter 'computation_space' is deprecated.*:DeprecationWarning
     ignore:Passing 'computation_space' as a separate argument with legacy.*:DeprecationWarning
     ignore:Passing 'computation_space' without an explicit measurement_strategy is deprecated.*:DeprecationWarning
+    
     # Allow PML-142 deprecation warnings
+    # TODO: Remove these once the tests reflect the new API
     ignore:amplitude_encoding=True is deprecated:DeprecationWarning
     ignore:Passing torch.Tensor as input_state is deprecated:DeprecationWarning
     ignore:Passing real-valued tensor with amplitude_encoding=True is deprecated:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,6 +10,7 @@ filterwarnings =
     ignore:measurement_strategy default behavior changed in v0.3*:DeprecationWarning
     ignore:Parameter 'computation_space' is deprecated.*:DeprecationWarning
     ignore:Passing 'computation_space' as a separate argument with legacy.*:DeprecationWarning
+    ignore:Passing 'computation_space' without an explicit measurement_strategy is deprecated.*:DeprecationWarning
     # Allow PML-142 deprecation warnings
     ignore:amplitude_encoding=True is deprecated:DeprecationWarning
     ignore:Passing torch.Tensor as input_state is deprecated:DeprecationWarning

--- a/tests/algorithms/test_computation_space.py
+++ b/tests/algorithms/test_computation_space.py
@@ -39,10 +39,13 @@ def test_computation_space_members():
     assert ComputationSpace.DUAL_RAIL.value == "dual_rail"
 
 
-def test_computation_space_default_mapping():
-    """Legacy no_bunching flag maps onto the appropriate enum member."""
-    assert ComputationSpace.default(no_bunching=True) is ComputationSpace.UNBUNCHED
-    assert ComputationSpace.default(no_bunching=False) is ComputationSpace.FOCK
+def test_computation_space_coerce_accepts_enum_members():
+    """Enum inputs are returned unchanged."""
+    assert ComputationSpace.coerce(ComputationSpace.FOCK) is ComputationSpace.FOCK
+    assert (
+        ComputationSpace.coerce(ComputationSpace.UNBUNCHED)
+        is ComputationSpace.UNBUNCHED
+    )
 
 
 def test_computation_space_coerce_accepts_strings():

--- a/tests/algorithms/test_compute_ebs_simultaneously.py
+++ b/tests/algorithms/test_compute_ebs_simultaneously.py
@@ -161,7 +161,6 @@ class TestComputeEbsSimultaneously:
             input_parameters=self.input_parameters,
             n_photons=self.n_photons,
             dtype=torch.float64,
-            no_bunching=True,
         )
 
         result = process_single.compute_ebs_simultaneously(
@@ -183,7 +182,6 @@ class TestComputeEbsSimultaneously:
             input_parameters=self.input_parameters,
             n_photons=self.n_photons,
             dtype=torch.float32,
-            no_bunching=True,
         )
 
         params_f32 = [p.to(torch.float32) for p in self.test_parameters]
@@ -226,7 +224,7 @@ class TestComputeEbsSimultaneously:
             input_parameters=self.input_parameters,
             n_photons=self.n_photons,
             dtype=torch.float64,
-            no_bunching=False,
+            computation_space=ComputationSpace.FOCK,
         )
 
         invalid_state = torch.rand(
@@ -250,7 +248,6 @@ class TestComputeEbsSimultaneously:
                 input_parameters=self.input_parameters,
                 n_photons=self.n_photons,
                 dtype=torch.float64,
-                no_bunching=True,
             )
             process_invalid.compute_ebs_simultaneously(
                 self.test_parameters, simultaneous_processes=1

--- a/tests/algorithms/test_feed_forward_block.py
+++ b/tests/algorithms/test_feed_forward_block.py
@@ -33,7 +33,9 @@ def _basis_states(n_modes: int, n_photons: int) -> list[tuple[int, ...]]:
             input_size=0,
             circuit=pcvl.Circuit(n_modes),
             n_photons=n_photons,
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
         _BASIS_CACHE[cache_key] = layer.computation_process.simulation_graph.mapped_keys
     return _BASIS_CACHE[cache_key]

--- a/tests/algorithms/test_feed_forward_legacy.py
+++ b/tests/algorithms/test_feed_forward_legacy.py
@@ -245,11 +245,9 @@ class TestPoolingFeedForwardLegacy:
         assert isinstance(pff.match_indices, torch.Tensor)
         assert isinstance(pff.exclude_indices, torch.Tensor)
 
-    def test_init_with_bunching(self):
-        """Test PoolingFeedForwardLegacy initialization with bunching allowed."""
-        pff = PoolingFeedForwardLegacy(
-            n_modes=8, n_photons=2, n_output_modes=4, no_bunching=False
-        )
+    def test_init_with_default_space(self):
+        """Test PoolingFeedForwardLegacy initialization with default computation space."""
+        pff = PoolingFeedForwardLegacy(n_modes=8, n_photons=2, n_output_modes=4)
         assert pff.n_modes == 8
         assert isinstance(pff.match_indices, torch.Tensor)
 

--- a/tests/algorithms/test_kernels.py
+++ b/tests/algorithms/test_kernels.py
@@ -10,6 +10,7 @@ from sklearn.svm import SVC
 from merlin.algorithms.kernels import FeatureMap, FidelityKernel, KernelCircuitBuilder
 from merlin.algorithms.loss import NKernelAlignment
 from merlin.builder import CircuitBuilder
+from merlin.core.computation_space import ComputationSpace
 
 
 class TestFeatureMap:
@@ -106,14 +107,14 @@ class TestFidelityKernel:
         self.quantum_kernel = FidelityKernel(
             feature_map=self.feature_map,
             input_state=[2, 0],
-            no_bunching=False,
+            computation_space=ComputationSpace.FOCK,
         )
 
     def test_fidelity_kernel_initialization(self):
         assert self.quantum_kernel.input_state == [2, 0]
         assert self.quantum_kernel.shots == 0
         assert self.quantum_kernel.sampling_method == "multinomial"
-        assert not self.quantum_kernel.no_bunching
+        assert self.quantum_kernel.computation_space is ComputationSpace.FOCK
         assert self.quantum_kernel.force_psd
         assert not self.quantum_kernel.is_trainable
 
@@ -138,7 +139,7 @@ class TestFidelityKernel:
         kernel = FidelityKernel(
             feature_map=feature_map,
             input_state=[1, 0],
-            no_bunching=False,
+            computation_space=ComputationSpace.FOCK,
         )
 
         assert kernel.is_trainable
@@ -197,12 +198,16 @@ class TestFidelityKernel:
     def test_no_bunching_validation(self):
         with pytest.raises(ValueError, match="Bunching must be enabled"):
             FidelityKernel(
-                feature_map=self.feature_map, input_state=[2, 0], no_bunching=True
+                feature_map=self.feature_map,
+                input_state=[2, 0],
+                computation_space=ComputationSpace.UNBUNCHED,
             )
 
         with pytest.raises(ValueError, match="kernel value will always be 1"):
             FidelityKernel(
-                feature_map=self.feature_map, input_state=[1, 1], no_bunching=True
+                feature_map=self.feature_map,
+                input_state=[1, 1],
+                computation_space=ComputationSpace.UNBUNCHED,
             )
 
     def test_input_state_circuit_size_mismatch(self):
@@ -220,7 +225,7 @@ class TestFidelityKernel:
             FidelityKernel(
                 feature_map=feature_map,
                 input_state=[2, 0],  # Only 2 modes
-                no_bunching=False,
+                computation_space=ComputationSpace.FOCK,
             )
 
     def test_psd_projection(self):
@@ -279,13 +284,13 @@ class TestFidelityKernel:
         unbunching_kernel = FidelityKernel(
             feature_map,
             input_state,
-            no_bunching=True,
+            computation_space=ComputationSpace.UNBUNCHED,
             force_psd=False,
         )
         quantum_kernel = FidelityKernel(
             feature_map,
             input_state,
-            no_bunching=False,
+            computation_space=ComputationSpace.FOCK,
         )
 
         rng = np.random.default_rng(42)
@@ -735,13 +740,15 @@ class TestKernelCircuitBuilder:
             builder.input_size(2)
             .n_modes(4)
             .build_fidelity_kernel(
-                shots=1000, sampling_method="multinomial", no_bunching=True
+                shots=1000,
+                sampling_method="multinomial",
+                computation_space=ComputationSpace.UNBUNCHED,
             )
         )
 
         assert kernel.shots == 1000
         assert kernel.sampling_method == "multinomial"
-        assert kernel.no_bunching
+        assert kernel.computation_space is ComputationSpace.UNBUNCHED
 
     def test_builder_default_values(self):
         """Test builder with default values for optional parameters."""
@@ -918,7 +925,7 @@ class TestKernelIntegration:
         quantum_kernel = FidelityKernel(
             feature_map=feature_map,
             input_state=[2, 0],
-            no_bunching=False,
+            computation_space=ComputationSpace.FOCK,
         )
 
         # Compute kernel matrices
@@ -958,7 +965,7 @@ class TestKernelIntegration:
         quantum_kernel = FidelityKernel(
             feature_map=feature_map,
             input_state=[2, 0],
-            no_bunching=False,
+            computation_space=ComputationSpace.FOCK,
         )
 
         optimizer = torch.optim.Adam(quantum_kernel.parameters(), lr=0.1)
@@ -1024,7 +1031,12 @@ def create_quantum_circuit(m, size=400):
     return c
 
 
-def get_quantum_kernel(modes=10, input_size=10, photons=4, no_bunching=False):
+def get_quantum_kernel(
+    modes=10,
+    input_size=10,
+    photons=4,
+    computation_space=ComputationSpace.FOCK,
+):
     circuit = create_quantum_circuit(m=modes, size=input_size)
     feature_map = FeatureMap(
         circuit=circuit,
@@ -1039,7 +1051,7 @@ def get_quantum_kernel(modes=10, input_size=10, photons=4, no_bunching=False):
     quantum_kernel = FidelityKernel(
         feature_map=feature_map,
         input_state=input_state,
-        no_bunching=no_bunching,
+        computation_space=computation_space,
     )
     return quantum_kernel
 

--- a/tests/algorithms/test_kernels.py
+++ b/tests/algorithms/test_kernels.py
@@ -145,6 +145,27 @@ class TestFidelityKernel:
         assert kernel.is_trainable
         assert "theta" in dict(kernel.named_parameters())
 
+    def test_kernel_rejects_no_bunching(self):
+        with pytest.warns(DeprecationWarning):
+            with pytest.raises(ValueError) as exc_info:
+                FidelityKernel(
+                    feature_map=self.feature_map,
+                    input_state=[2, 0],
+                    no_bunching=True,
+                )
+        assert "no_bunching" in str(exc_info.value)
+
+        with pytest.warns(DeprecationWarning):
+            with pytest.raises(ValueError) as exc_info:
+                FidelityKernel.simple(input_size=2, no_bunching=True)
+        assert "no_bunching" in str(exc_info.value)
+
+        builder = KernelCircuitBuilder().input_size(2).n_modes(4)
+        with pytest.warns(DeprecationWarning):
+            with pytest.raises(ValueError) as exc_info:
+                builder.build_fidelity_kernel(no_bunching=True)
+        assert "no_bunching" in str(exc_info.value)
+
     def test_kernel_scalar_computation(self):
         x1 = torch.tensor([0.5, 1.0])
         x2 = torch.tensor([1.0, 0.5])

--- a/tests/algorithms/test_layer.py
+++ b/tests/algorithms/test_layer.py
@@ -997,7 +997,9 @@ class TestQuantumLayer:
         bs1 = pcvl.BasicState("|1,0,1>")
         ML.QuantumLayer(
             circuit=pcvl.Circuit(bs1.m),
-            computation_space=ML.ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ML.ComputationSpace.FOCK
+            ),
             input_state=bs1,
         )
         # An annotated BasicState should raise as annotations are not supported
@@ -1007,7 +1009,9 @@ class TestQuantumLayer:
         ):
             _ = ML.QuantumLayer(
                 circuit=pcvl.Circuit(bs_annot.m),
-                computation_space=ML.ComputationSpace.FOCK,
+                measurement_strategy=ML.MeasurementStrategy.probs(
+                    computation_space=ML.ComputationSpace.FOCK
+                ),
                 input_state=bs_annot,
             )
 

--- a/tests/algorithms/test_layer_deprecation.py
+++ b/tests/algorithms/test_layer_deprecation.py
@@ -6,22 +6,19 @@ from merlin.core.computation_space import ComputationSpace
 
 
 def test_no_bunching_deprecation_in_init():
-    """Passing no_bunching explicitly to QuantumLayer.__init__ must issue a DeprecationWarning."""
+    """Passing no_bunching explicitly to QuantumLayer.__init__ must warn + fail."""
     circuit = pcvl.Circuit(2)
     # Provide an explicit input_state so the layer can initialize from the custom circuit
     with pytest.warns(DeprecationWarning):
-        layer = QuantumLayer(circuit=circuit, input_state=[1, 0], no_bunching=True)
-    assert layer.computation_space is ComputationSpace.UNBUNCHED
+        with pytest.raises(TypeError):
+            QuantumLayer(circuit=circuit, input_state=[1, 0], no_bunching=True)
 
 
 def test_simple_no_bunching_deprecation_and_conversion():
-    """QuantumLayer.simple should warn on no_bunching and convert to computation_space."""
+    """QuantumLayer.simple should warn + fail on no_bunching."""
     with pytest.warns(DeprecationWarning):
-        # Use n_params matching the entangling budget to avoid unrelated RuntimeWarning.
-        model = QuantumLayer.simple(input_size=2, no_bunching=True)
-
-    qlayer = model.quantum_layer
-    assert qlayer.computation_space == ComputationSpace.UNBUNCHED
+        with pytest.raises(TypeError):
+            QuantumLayer.simple(input_size=2, no_bunching=True)
 
 
 def test_simple_accepts_computation_space_with_deprecation_warning():

--- a/tests/algorithms/test_layer_deprecation.py
+++ b/tests/algorithms/test_layer_deprecation.py
@@ -3,6 +3,7 @@ import pytest
 
 from merlin.algorithms.layer import QuantumLayer
 from merlin.core.computation_space import ComputationSpace
+from merlin.measurement.strategies import MeasurementStrategy
 
 
 def test_init_defaults_to_unbunched():
@@ -19,17 +20,16 @@ def test_simple_defaults_to_unbunched():
     assert model.quantum_layer.computation_space is ComputationSpace.UNBUNCHED
 
 
-def test_simple_accepts_computation_space_with_deprecation_warning():
-    with pytest.warns(
-        DeprecationWarning,
-        match=r"Parameter 'computation_space' is deprecated",
-    ):
-        model = QuantumLayer.simple(
-            input_size=2,
-            computation_space=ComputationSpace.FOCK,
-        )
-
-    assert model.quantum_layer.computation_space == ComputationSpace.FOCK
+def test_init_accepts_measurement_strategy_fock():
+    circuit = pcvl.Circuit(2)
+    layer = QuantumLayer(
+        circuit=circuit,
+        input_state=[1, 0],
+        measurement_strategy=MeasurementStrategy.probs(
+            computation_space=ComputationSpace.FOCK
+        ),
+    )
+    assert layer.computation_space is ComputationSpace.FOCK
 
 
 def test_simple_warns_on_n_params():

--- a/tests/algorithms/test_layer_deprecation.py
+++ b/tests/algorithms/test_layer_deprecation.py
@@ -5,20 +5,18 @@ from merlin.algorithms.layer import QuantumLayer
 from merlin.core.computation_space import ComputationSpace
 
 
-def test_no_bunching_deprecation_in_init():
-    """Passing no_bunching explicitly to QuantumLayer.__init__ must warn + fail."""
+def test_init_defaults_to_unbunched():
+    """QuantumLayer.__init__ defaults to UNBUNCHED computation space."""
     circuit = pcvl.Circuit(2)
     # Provide an explicit input_state so the layer can initialize from the custom circuit
-    with pytest.warns(DeprecationWarning):
-        with pytest.raises(TypeError):
-            QuantumLayer(circuit=circuit, input_state=[1, 0], no_bunching=True)
+    layer = QuantumLayer(circuit=circuit, input_state=[1, 0])
+    assert layer.computation_space is ComputationSpace.UNBUNCHED
 
 
-def test_simple_no_bunching_deprecation_and_conversion():
-    """QuantumLayer.simple should warn + fail on no_bunching."""
-    with pytest.warns(DeprecationWarning):
-        with pytest.raises(TypeError):
-            QuantumLayer.simple(input_size=2, no_bunching=True)
+def test_simple_defaults_to_unbunched():
+    """QuantumLayer.simple defaults to UNBUNCHED computation space."""
+    model = QuantumLayer.simple(input_size=2)
+    assert model.quantum_layer.computation_space is ComputationSpace.UNBUNCHED
 
 
 def test_simple_accepts_computation_space_with_deprecation_warning():

--- a/tests/bridge/test_quantum_bridge.py
+++ b/tests/bridge/test_quantum_bridge.py
@@ -4,8 +4,8 @@ import perceval as pcvl
 import pytest
 import torch
 
-from merlin import QuantumLayer
-from merlin.bridge.quantum_bridge import ComputationSpace, QuantumBridge
+from merlin import ComputationSpace, MeasurementStrategy, QuantumLayer
+from merlin.bridge.quantum_bridge import QuantumBridge
 
 
 def make_identity_layer(
@@ -15,10 +15,12 @@ def make_identity_layer(
     layer = QuantumLayer(
         circuit=c,
         n_photons=n_photons,
-        computation_space=ComputationSpace.default(no_bunching=no_bunching),
         device=torch.device("cpu"),
         dtype=torch.float32,
         amplitude_encoding=True,
+        measurement_strategy=MeasurementStrategy.probs(
+            computation_space=ComputationSpace.default(no_bunching=no_bunching)
+        ),
     )
     return layer
 

--- a/tests/bridge/test_quantum_bridge_gpu.py
+++ b/tests/bridge/test_quantum_bridge_gpu.py
@@ -2,8 +2,8 @@ import perceval as pcvl
 import pytest
 import torch
 
-from merlin import QuantumLayer
-from merlin.bridge.quantum_bridge import ComputationSpace, QuantumBridge
+from merlin import ComputationSpace, MeasurementStrategy, QuantumLayer
+from merlin.bridge.quantum_bridge import QuantumBridge
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="CUDA GPU not available"
@@ -15,9 +15,11 @@ def make_identity_layer(m: int, n_photons: int, device: torch.device) -> Quantum
     return QuantumLayer(
         circuit=c,
         n_photons=n_photons,
-        computation_space=ComputationSpace.UNBUNCHED,
         device=device,
         dtype=torch.float32,
+        measurement_strategy=MeasurementStrategy.probs(
+            computation_space=ComputationSpace.UNBUNCHED
+        ),
         amplitude_encoding=True,
     )
 

--- a/tests/core/test_unbunched.py
+++ b/tests/core/test_unbunched.py
@@ -147,7 +147,6 @@ class TestNoBunchingFunctionality:
             input_state=input_state,
             trainable_parameters=["phi_"],
             input_parameters=["pl"],
-            computation_space=ComputationSpace.UNBUNCHED,
         )
 
         # Create dummy parameters
@@ -236,7 +235,6 @@ class TestNoBunchingFunctionality:
                 input_state=input_state,
                 trainable_parameters=["phi_"],
                 input_parameters=["pl"],
-                computation_space=ComputationSpace.UNBUNCHED,
             )
 
             # Test with full Fock space
@@ -292,7 +290,6 @@ class TestNoBunchingFunctionality:
             input_state=input_state,
             trainable_parameters=["phi_"],
             input_parameters=["pl"],
-            computation_space=ComputationSpace.UNBUNCHED,
         )
 
         # The calculation shows this should be 0, but the system might handle it differently
@@ -394,7 +391,6 @@ class TestNoBunchingFunctionality:
                 input_state=input_state,
                 trainable_parameters=["phi_"],
                 input_parameters=["pl"],
-                computation_space=ComputationSpace.UNBUNCHED,
             )
 
             # Process with full Fock space

--- a/tests/core/test_unbunched.py
+++ b/tests/core/test_unbunched.py
@@ -516,6 +516,40 @@ class TestNoBunchingFunctionality:
                 )
 
 
+@pytest.mark.parametrize("no_bunching", [True, False])
+def test_quantum_layer_rejects_no_bunching(no_bunching: bool):
+    circuit, _ = CircuitGenerator.generate_circuit(CircuitType.SERIES, 4, 2)
+    input_state = StateGenerator.generate_state(4, 2, StatePattern.PERIODIC)
+
+    with pytest.warns(DeprecationWarning):
+        with pytest.raises(ValueError) as exc_info:
+            QuantumLayer(
+                input_size=3,
+                circuit=circuit,
+                input_state=input_state,
+                trainable_parameters=["phi_"],
+                input_parameters=["pl"],
+                no_bunching=no_bunching,
+            )
+
+    message = str(exc_info.value)
+    assert "MeasurementStrategy.probs" in message
+    assert "ComputationSpace.UNBUNCHED" in message
+    assert "ComputationSpace.FOCK" in message
+
+
+@pytest.mark.parametrize("no_bunching", [True, False])
+def test_quantum_layer_simple_rejects_no_bunching(no_bunching: bool):
+    with pytest.warns(DeprecationWarning):
+        with pytest.raises(ValueError) as exc_info:
+            QuantumLayer.simple(input_size=2, no_bunching=no_bunching)
+
+    message = str(exc_info.value)
+    assert "MeasurementStrategy.probs" in message
+    assert "ComputationSpace.UNBUNCHED" in message
+    assert "ComputationSpace.FOCK" in message
+
+
 if __name__ == "__main__":
     # Run a quick demonstration
     print("=== No-Bunching Test Demonstration ===")

--- a/tests/core/test_unbunched.py
+++ b/tests/core/test_unbunched.py
@@ -21,11 +21,12 @@
 # SOFTWARE.
 
 """
-Tests for no_bunching functionality in quantum computation.
+Tests for UNBUNCHED vs FOCK computation-space behavior in quantum computation.
 """
 
 import math
 
+import pytest
 import torch
 
 from merlin.algorithms.layer import QuantumLayer
@@ -57,10 +58,10 @@ def calculate_no_bunching_size(n_modes: int, n_photons: int) -> int:
 
 
 class TestNoBunchingFunctionality:
-    """Test suite for no_bunching parameter in quantum computation."""
+    """Test suite for computation-space handling in quantum computation."""
 
     def test_fock_space_vs_no_bunching_sizes(self):
-        """Test that Fock space and no-bunching space sizes are calculated correctly."""
+        """Test that Fock space and UNBUNCHED space sizes are calculated correctly."""
         # Test cases: (n_modes, n_photons)
         test_cases = [
             (3, 1),  # 3 modes, 1 photon
@@ -75,17 +76,17 @@ class TestNoBunchingFunctionality:
 
             print(f"n_modes={n_modes}, n_photons={n_photons}")
             print(f"  Fock space size: {fock_size}")
-            print(f"  No-bunching size: {no_bunching_size}")
+            print(f"  UNBUNCHED size: {no_bunching_size}")
 
-            # No-bunching space should be smaller than or equal to Fock space
+            # UNBUNCHED space should be smaller than or equal to Fock space
             assert no_bunching_size <= fock_size
 
-            # For single photon, no-bunching size should equal n_modes
+            # For single photon, UNBUNCHED size should equal n_modes
             if n_photons == 1:
                 assert no_bunching_size == n_modes
 
-    def test_computation_process_with_no_bunching_false(self):
-        """Test computation process with no_bunching=False (full Fock space)."""
+    def test_computation_process_with_fock_space(self):
+        """Test computation process with full Fock space."""
         n_modes = 4
         n_photons = 2
 
@@ -97,7 +98,7 @@ class TestNoBunchingFunctionality:
             n_modes, n_photons, StatePattern.SEQUENTIAL
         )
 
-        # Create computation process with no_bunching=False
+        # Create computation process with full Fock space
         process = ComputationProcessFactory.create(
             circuit=circuit,
             input_state=input_state,
@@ -127,8 +128,8 @@ class TestNoBunchingFunctionality:
             f"Expected Fock space size {expected_size}, got {actual_size}"
         )
 
-    def test_computation_process_with_no_bunching_true(self):
-        """Test computation process with no_bunching=True (single photon states only)."""
+    def test_computation_process_with_unbunched_space(self):
+        """Test computation process with UNBUNCHED space (single photon states only)."""
         n_modes = 4
         n_photons = 2
 
@@ -140,7 +141,7 @@ class TestNoBunchingFunctionality:
             n_modes, n_photons, StatePattern.SEQUENTIAL
         )
 
-        # Create computation process with no_bunching=True
+        # Create computation process with UNBUNCHED space
         process = ComputationProcessFactory.create(
             circuit=circuit,
             input_state=input_state,
@@ -165,27 +166,27 @@ class TestNoBunchingFunctionality:
         expected_size = calculate_no_bunching_size(n_modes, n_photons)
         actual_size = distribution.shape[-1]
 
-        print(f"No-bunching space - Expected: {expected_size}, Actual: {actual_size}")
+        print(f"UNBUNCHED space - Expected: {expected_size}, Actual: {actual_size}")
         assert actual_size == expected_size, (
             f"Expected no-bunching size {expected_size}, got {actual_size}"
         )
 
-    def test_quantum_layer_with_no_bunching_parameter(self):
-        """Test QuantumLayer integration with no_bunching parameter."""
+    def test_quantum_layer_with_computation_space(self):
+        """Test QuantumLayer integration with computation_space."""
 
         n_modes = 5
         n_photons = 2
 
         # Test both cases
-        for no_bunching in [False, True]:
+        for computation_space in (
+            ComputationSpace.FOCK,
+            ComputationSpace.UNBUNCHED,
+        ):
             circuit, _ = CircuitGenerator.generate_circuit(
                 CircuitType.SERIES, n_modes, 2
             )
             input_state = StateGenerator.generate_state(
                 n_modes, n_photons, StatePattern.PERIODIC
-            )
-            computation_space = (
-                ComputationSpace.UNBUNCHED if no_bunching else ComputationSpace.FOCK
             )
             q_layer = QuantumLayer(
                 input_size=3,
@@ -203,7 +204,7 @@ class TestNoBunchingFunctionality:
 
             distribution = q_layer.computation_process.compute(dummy_params)
 
-            if no_bunching:
+            if computation_space is ComputationSpace.UNBUNCHED:
                 expected_size = calculate_no_bunching_size(n_modes, n_photons)
             else:
                 expected_size = calculate_fock_space_size(n_modes, n_photons)
@@ -211,12 +212,12 @@ class TestNoBunchingFunctionality:
             actual_size = distribution.shape[-1]
 
             print(
-                f"no_bunching={no_bunching}: Expected {expected_size}, Actual {actual_size}"
+                f"computation_space={computation_space}: Expected {expected_size}, Actual {actual_size}"
             )
             assert actual_size == expected_size
 
     def test_different_photon_numbers(self):
-        """Test no_bunching with different numbers of photons."""
+        """Test computation space behavior with different numbers of photons."""
         n_modes = 6
 
         for n_photons in [1, 2, 3]:
@@ -229,26 +230,26 @@ class TestNoBunchingFunctionality:
                 n_modes, n_photons, StatePattern.SPACED
             )
 
-            # Test with no_bunching=True
-            process_no_bunching = ComputationProcessFactory.create(
+            # Test with UNBUNCHED
+            process_unbunched = ComputationProcessFactory.create(
                 circuit=circuit,
                 input_state=input_state,
                 trainable_parameters=["phi_"],
                 input_parameters=["pl"],
-                no_bunching=True,
+                computation_space=ComputationSpace.UNBUNCHED,
             )
 
-            # Test with no_bunching=False
+            # Test with full Fock space
             process_full_fock = ComputationProcessFactory.create(
                 circuit=circuit,
                 input_state=input_state,
                 trainable_parameters=["phi_"],
                 input_parameters=["pl"],
-                no_bunching=False,
+                computation_space=ComputationSpace.FOCK,
             )
 
             # Create dummy parameters
-            spec_mappings = process_no_bunching.converter.spec_mappings
+            spec_mappings = process_unbunched.converter.spec_mappings
             dummy_params = []
 
             for spec in ["phi_", "pl"]:
@@ -257,28 +258,28 @@ class TestNoBunchingFunctionality:
                     dummy_params.append(torch.randn(param_count))
 
             # Compute distributions
-            dist_no_bunching = process_no_bunching.compute(dummy_params)
+            dist_unbunched = process_unbunched.compute(dummy_params)
             dist_full_fock = process_full_fock.compute(dummy_params)
 
             # Check sizes
-            expected_no_bunching = calculate_no_bunching_size(n_modes, n_photons)
+            expected_unbunched = calculate_no_bunching_size(n_modes, n_photons)
             expected_full_fock = calculate_fock_space_size(n_modes, n_photons)
 
             print(
-                f"  No-bunching: {dist_no_bunching.shape[-1]} (expected {expected_no_bunching})"
+                f"  UNBUNCHED: {dist_unbunched.shape[-1]} (expected {expected_unbunched})"
             )
             print(
                 f"  Full Fock: {dist_full_fock.shape[-1]} (expected {expected_full_fock})"
             )
 
-            assert dist_no_bunching.shape[-1] == expected_no_bunching
+            assert dist_unbunched.shape[-1] == expected_unbunched
             assert dist_full_fock.shape[-1] == expected_full_fock
 
-            # No-bunching should be smaller
-            assert dist_no_bunching.shape[-1] <= dist_full_fock.shape[-1]
+            # UNBUNCHED should be smaller
+            assert dist_unbunched.shape[-1] <= dist_full_fock.shape[-1]
 
-    def test_impossible_no_bunching_case(self):
-        """Test case where no_bunching is impossible (more photons than modes)."""
+    def test_impossible_unbunched_case(self):
+        """Test case where UNBUNCHED is impossible (more photons than modes)."""
         n_modes = 3
         n_photons = 4  # More photons than modes
 
@@ -291,13 +292,13 @@ class TestNoBunchingFunctionality:
             input_state=input_state,
             trainable_parameters=["phi_"],
             input_parameters=["pl"],
-            no_bunching=True,
+            computation_space=ComputationSpace.UNBUNCHED,
         )
 
         # The calculation shows this should be 0, but the system might handle it differently
         expected_size = calculate_no_bunching_size(n_modes, n_photons)
         print(f"Impossible case: {n_photons} photons in {n_modes} modes")
-        print(f"Expected no-bunching size: {expected_size}")
+        print(f"Expected UNBUNCHED size: {expected_size}")
 
         # This might raise an error or return empty distribution
         # Let's see what actually happens
@@ -330,13 +331,16 @@ class TestNoBunchingFunctionality:
             n_modes, n_photons, StatePattern.SEQUENTIAL
         )
 
-        for no_bunching in [False, True]:
+        for computation_space in (
+            ComputationSpace.FOCK,
+            ComputationSpace.UNBUNCHED,
+        ):
             process = ComputationProcessFactory.create(
                 circuit=circuit,
                 input_state=input_state,
                 trainable_parameters=["phi_"],
                 input_parameters=["pl"],
-                no_bunching=no_bunching,
+                computation_space=computation_space,
             )
 
             spec_mappings = process.converter.spec_mappings
@@ -349,23 +353,20 @@ class TestNoBunchingFunctionality:
 
             distribution = process.compute(dummy_params)
 
-            if no_bunching:
-                # For single photon, no-bunching space = n_modes (each mode can have the photon)
-                expected = n_modes
-            else:
-                # For single photon, Fock space = n_modes (same as no-bunching)
-                expected = n_modes
+            # For single photon, UNBUNCHED and FOCK spaces are the same size
+            expected = n_modes
 
             print(
-                f"Single photon, no_bunching={no_bunching}: size={distribution.shape[-1]}, expected={expected}"
+                "Single photon, computation_space="
+                f"{computation_space}: size={distribution.shape[-1]}, expected={expected}"
             )
             assert distribution.shape[-1] == expected
 
     def test_compute_with_keys_functionality(self):
         """
-        Test that compute_with_keys works with no_bunching and on full Fock space.
+        Test that compute_with_keys works with UNBUNCHED and full Fock space.
         Test sizes of keys and  distributions.
-        Test values of distributions (convert from full Fock space to no_bunching).
+        Test values of distributions (convert from full Fock space to UNBUNCHED).
         """
         # Test cases: (n_modes, n_photons)
         test_cases = [
@@ -387,13 +388,13 @@ class TestNoBunchingFunctionality:
                 n_modes, n_photons, StatePattern.PERIODIC
             )
 
-            # Process with no_bunching
-            process_no_bunching = ComputationProcessFactory.create(
+            # Process with UNBUNCHED
+            process_unbunched = ComputationProcessFactory.create(
                 circuit=circuit,
                 input_state=input_state,
                 trainable_parameters=["phi_"],
                 input_parameters=["pl"],
-                no_bunching=True,
+                computation_space=ComputationSpace.UNBUNCHED,
             )
 
             # Process with full Fock space
@@ -402,10 +403,10 @@ class TestNoBunchingFunctionality:
                 input_state=input_state,
                 trainable_parameters=["phi_"],
                 input_parameters=["pl"],
-                no_bunching=False,
+                computation_space=ComputationSpace.FOCK,
             )
 
-            spec_mappings_no_bunching = process_no_bunching.converter.spec_mappings
+            spec_mappings_unbunched = process_unbunched.converter.spec_mappings
             spec_mappings_full_fock_space = (
                 process_full_fock_space.converter.spec_mappings
             )
@@ -413,49 +414,49 @@ class TestNoBunchingFunctionality:
 
             # Replace parameters by the same random values for the two circuits
             for spec in ["phi_", "pl"]:
-                if spec in spec_mappings_no_bunching:
-                    param_count_n_b = len(spec_mappings_no_bunching[spec])
+                if spec in spec_mappings_unbunched:
+                    param_count_n_b = len(spec_mappings_unbunched[spec])
                     if spec in spec_mappings_full_fock_space:
                         param_count_f_f_s = len(spec_mappings_full_fock_space[spec])
                         assert param_count_n_b == param_count_f_f_s, (
-                            "Different circuits for no_bunching and full_fock_space"
+                            "Different circuits for UNBUNCHED and full_fock_space"
                         )
                         dummy_params.append(torch.randn(param_count_f_f_s))
                     else:
                         raise Exception(
-                            "Different circuits for no_bunching and full_fock_space"
+                            "Different circuits for UNBUNCHED and full_fock_space"
                         )
                 else:
                     if spec in spec_mappings_full_fock_space:
                         raise Exception(
-                            "Different circuits for no_bunching and full_fock_space"
+                            "Different circuits for UNBUNCHED and full_fock_space"
                         )
 
-            # Test compute_with_keys with no_bunching
-            keys_no_bunching, amplitudes_no_bunching = (
-                process_no_bunching.compute_with_keys(dummy_params)
+            # Test compute_with_keys with UNBUNCHED
+            keys_unbunched, amplitudes_unbunched = process_unbunched.compute_with_keys(
+                dummy_params
             )
-            distribution_no_bunching = (
-                amplitudes_no_bunching.real**2 + amplitudes_no_bunching.imag**2
+            distribution_unbunched = (
+                amplitudes_unbunched.real**2 + amplitudes_unbunched.imag**2
             )
-            sum_probs = distribution_no_bunching.sum(dim=1, keepdim=True)
+            sum_probs = distribution_unbunched.sum(dim=1, keepdim=True)
 
             # Only normalize when sum > 0 to avoid division by zero
             valid_entries = sum_probs > 0
             if valid_entries.any():
-                distribution_no_bunching = torch.where(
+                distribution_unbunched = torch.where(
                     valid_entries,
-                    distribution_no_bunching
+                    distribution_unbunched
                     / torch.where(valid_entries, sum_probs, torch.ones_like(sum_probs)),
-                    distribution_no_bunching,
+                    distribution_unbunched,
                 )
             # Should have the same distribution size
             expected_size = calculate_no_bunching_size(n_modes, n_photons)
-            assert distribution_no_bunching.shape[-1] == expected_size
+            assert distribution_unbunched.shape[-1] == expected_size
 
             # Keys should correspond to the states
-            assert len(keys_no_bunching) == expected_size
-            print("Correct distribution and keys size with no_bunching")
+            assert len(keys_unbunched) == expected_size
+            print("Correct distribution and keys size with UNBUNCHED")
 
             # Test compute_with_keys on full Fock space
             keys_full_fock_space, amplitudes_full_fock_space = (
@@ -472,10 +473,10 @@ class TestNoBunchingFunctionality:
             assert len(keys_full_fock_space) == expected_size
             print("Correct distribution and keys size on full Fock state")
 
-            # We can convert the full Fock space distribution to the no_bunching distribution by removing any state
+            # We can convert the full Fock space distribution to the UNBUNCHED distribution by removing any state
             # that has a mode with more than 1 photon followed by renormalization.
-            new_keys = [0] * len(keys_no_bunching)
-            new_distribution = [0] * len(keys_no_bunching)
+            new_keys = [0] * len(keys_unbunched)
+            new_distribution = [0] * len(keys_unbunched)
 
             for key, proba in zip(
                 keys_full_fock_space, distribution_full_fock_space[0], strict=False
@@ -483,7 +484,7 @@ class TestNoBunchingFunctionality:
                 if any(key_elem > 1 for key_elem in key):
                     continue
                 else:
-                    index = keys_no_bunching.index(key)
+                    index = keys_unbunched.index(key)
                     new_keys[index] = key
 
                     new_distribution[index] = proba
@@ -492,14 +493,31 @@ class TestNoBunchingFunctionality:
                 torch.tensor(new_distribution)
             )
 
-            # new_distribution must be close to distribution_no_bunching
+            # new_distribution must be close to distribution_unbunched
             assert torch.isclose(torch.sum(new_distribution), torch.tensor(1.0))
-            assert torch.isclose(torch.sum(distribution_no_bunching), torch.tensor(1.0))
-            assert new_keys == keys_no_bunching
-            assert torch.allclose(new_distribution, distribution_no_bunching)
+            assert torch.isclose(torch.sum(distribution_unbunched), torch.tensor(1.0))
+            assert new_keys == keys_unbunched
+            assert torch.allclose(new_distribution, distribution_unbunched)
             print(
-                "Conversion from distribution_full_fock_space to distribution_no_bunching completed successfully"
+                "Conversion from distribution_full_fock_space to distribution_unbunched completed successfully"
             )
+
+    def test_no_bunching_deprecation_warning_and_error(self):
+        """Passing no_bunching should warn and raise a TypeError."""
+        circuit, _ = CircuitGenerator.generate_circuit(
+            CircuitType.PARALLEL_COLUMNS, 2, 1
+        )
+        input_state = StateGenerator.generate_state(2, 1, StatePattern.SEQUENTIAL)
+
+        with pytest.warns(DeprecationWarning):
+            with pytest.raises(TypeError):
+                ComputationProcessFactory.create(
+                    circuit=circuit,
+                    input_state=input_state,
+                    trainable_parameters=["phi_"],
+                    input_parameters=["pl"],
+                    no_bunching=True,
+                )
 
 
 if __name__ == "__main__":
@@ -512,17 +530,17 @@ if __name__ == "__main__":
     test.test_fock_space_vs_no_bunching_sizes()
 
     print("\n2. Testing computation process...")
-    test.test_computation_process_with_no_bunching_false()
-    test.test_computation_process_with_no_bunching_true()
+    test.test_computation_process_with_fock_space()
+    test.test_computation_process_with_unbunched_space()
 
     print("\n3. Testing quantum layer...")
-    test.test_quantum_layer_with_no_bunching_parameter()
+    test.test_quantum_layer_with_computation_space()
 
     print("\n4. Testing different photon numbers...")
     test.test_different_photon_numbers()
 
-    print("\n5. Testing impossible no_bunching case...")
-    test.test_impossible_no_bunching_case()
+    print("\n5. Testing impossible UNBUNCHED case...")
+    test.test_impossible_unbunched_case()
 
     print("\n6. Testing single photon case...")
     test.test_single_photon_case()

--- a/tests/core/test_unbunched.py
+++ b/tests/core/test_unbunched.py
@@ -499,14 +499,14 @@ class TestNoBunchingFunctionality:
             )
 
     def test_no_bunching_deprecation_warning_and_error(self):
-        """Passing no_bunching should warn and raise a TypeError."""
+        """Passing no_bunching should warn and raise a ValueError."""
         circuit, _ = CircuitGenerator.generate_circuit(
             CircuitType.PARALLEL_COLUMNS, 2, 1
         )
         input_state = StateGenerator.generate_state(2, 1, StatePattern.SEQUENTIAL)
 
         with pytest.warns(DeprecationWarning):
-            with pytest.raises(TypeError):
+            with pytest.raises(ValueError):
                 ComputationProcessFactory.create(
                     circuit=circuit,
                     input_state=input_state,

--- a/tests/measurement/test_detectors.py
+++ b/tests/measurement/test_detectors.py
@@ -141,7 +141,9 @@ class TestDetectorsWithQuantumLayer:
             input_size=0,
             experiment=experiment,
             input_state=[1, 0, 1],
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         output = layer()
@@ -198,7 +200,9 @@ class TestDetectorsWithQuantumLayer:
             input_size=0,
             circuit=circuit,
             input_state=[1, 1],
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         experiment = pcvl.Experiment(circuit)
@@ -209,7 +213,9 @@ class TestDetectorsWithQuantumLayer:
             input_size=0,
             experiment=experiment,
             input_state=[1, 1],
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         probs_default = default_layer()
@@ -232,14 +238,18 @@ class TestDetectorsWithQuantumLayer:
             input_size=0,
             experiment=experiment,
             input_state=[4, 0],
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         layer_threshold = ML.QuantumLayer(
             input_size=0,
             experiment=experiment_threshold,
             input_state=[4, 0],
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         output = layer()
@@ -270,7 +280,9 @@ class TestDetectorsWithQuantumLayer:
             input_size=0,
             experiment=experiment,
             input_state=[3, 4, 1, 0],
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         output = layer()
@@ -297,7 +309,9 @@ class TestDetectorsWithQuantumLayer:
             input_size=0,
             experiment=experiment,
             input_state=[1, 1, 1, 0],
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         output = layer()
@@ -343,7 +357,9 @@ class TestDetectorsWithQuantumLayer:
             input_size=0,
             experiment=experiment,
             input_state=[0, 0, 2],
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         output = layer()
@@ -366,7 +382,9 @@ class TestDetectorsWithQuantumLayer:
             input_size=0,
             experiment=experiment,
             input_state=input_state,
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         output = layer().squeeze(0)
@@ -405,7 +423,9 @@ class TestDetectorsWithQuantumLayer:
             input_size=0,
             experiment=experiment,
             input_state=input_state,
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         output = layer().squeeze(0)
@@ -439,7 +459,9 @@ class TestDetectorsWithQuantumLayer:
             input_size=0,
             circuit=circuit,
             input_state=input_state,
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         pnr_output_size = pnr_layer.output_size
@@ -454,7 +476,9 @@ class TestDetectorsWithQuantumLayer:
             input_size=0,
             experiment=experiment,
             input_state=input_state,
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         threshold_output_size = threshold_layer.output_size
@@ -480,7 +504,9 @@ class TestDetectorsWithQuantumLayer:
             input_state=[1, 0],
             input_parameters=["phi"],
             trainable_parameters=["theta"],
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
         model = torch.nn.Sequential(layer, torch.nn.Linear(layer.output_size, 1))
 
@@ -510,7 +536,9 @@ class TestDetectorsWithQuantumLayer:
             input_size=0,
             experiment=experiment,
             input_state=input_state,
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         output = layer().squeeze(0)
@@ -546,7 +574,9 @@ class TestDetectorsWithQuantumLayer:
             input_size=0,
             experiment=exp,
             input_state=[1, 1, 1, 1],
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         layer_probs = layer()
@@ -599,19 +629,22 @@ class TestDetectorsWithQuantumLayer:
             input_size=0,
             experiment=experiment,
             input_state=[1, 1, 1, 1],
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
         layer_unbunched = ML.QuantumLayer(
             input_size=0,
             experiment=experiment,
             input_state=[1, 1, 1, 1],
-            computation_space=ComputationSpace.UNBUNCHED,
         )
         ML.QuantumLayer(
             input_size=0,
             experiment=experiment_pnr_detector,
             input_state=[1, 1, 1, 1],
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         with pytest.warns(UserWarning):
@@ -619,33 +652,34 @@ class TestDetectorsWithQuantumLayer:
                 input_size=0,
                 experiment=experiment_pnr_detector,
                 input_state=[1, 1, 1, 1],
-                computation_space=ComputationSpace.UNBUNCHED,
             )
         ML.QuantumLayer(
             input_size=0,
             experiment=experiment_threshold_detector,
             input_state=[1, 1, 1, 1],
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
         with pytest.warns(UserWarning):
             layer_threshold_unbunched = ML.QuantumLayer(
                 input_size=0,
                 experiment=experiment_threshold_detector,
                 input_state=[1, 1, 1, 1],
-                computation_space=ComputationSpace.UNBUNCHED,
             )
         ML.QuantumLayer(
             input_size=0,
             experiment=experiment_ppnr_detector,
             input_state=[1, 1, 1, 1],
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
         with pytest.warns(UserWarning):
             layer_ppnr_unbunched = ML.QuantumLayer(
                 input_size=0,
                 experiment=experiment_ppnr_detector,
                 input_state=[1, 1, 1, 1],
-                computation_space=ComputationSpace.UNBUNCHED,
             )
 
         result_unbunched = layer_unbunched()
@@ -675,7 +709,9 @@ class TestDetectorsWithQuantumLayer:
             input_size=0,
             experiment=layer_experiment,
             input_state=INPUT_STATE,
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
         probabilities = layer().squeeze(0)
         keys = [_normalize_key(key) for key in layer.output_keys]
@@ -762,13 +798,11 @@ class TestDetectorsWithQuantumLayer:
                 input_size=0,
                 experiment=experiment_threshold,
                 input_state=INPUT_STATE,
-                computation_space=ML.ComputationSpace.UNBUNCHED,
             )
         layer_reference = ML.QuantumLayer(
             input_size=0,
             experiment=experiment_reference,
             input_state=INPUT_STATE,
-            computation_space=ML.ComputationSpace.UNBUNCHED,
         )
 
         probs_threshold = layer_threshold().squeeze(0)

--- a/tests/measurement/test_detectors.py
+++ b/tests/measurement/test_detectors.py
@@ -570,7 +570,7 @@ class TestDetectorsWithQuantumLayer:
         assert torch.allclose(layer_probs, reference, atol=1e-6)
 
     def test_detector_plus_no_bunching_warning(self):
-        """Using detectors with no_bunching=True should raise a warning, and ignore the detectors."""
+        """Using detectors with UNBUNCHED space should raise a warning, and ignore the detectors."""
         random_unitary = pcvl.Unitary(pcvl.Matrix.random_unitary(4))
 
         # Define Experiment without Detector

--- a/tests/measurement/test_mappers.py
+++ b/tests/measurement/test_mappers.py
@@ -251,7 +251,7 @@ class TestModeExpectationsMapping:
     """Unit tests for ModeExpectations mapper."""
 
     def test_no_bunching_probability(self):
-        """no_bunching=True should compute per-mode occupancy probability."""
+        """UNBUNCHED space should compute per-mode occupancy probability."""
         keys = [(1, 0), (0, 1), (1, 1)]
         mapper = ML.ModeExpectations(
             computation_space=ML.ComputationSpace.UNBUNCHED, keys=keys
@@ -264,7 +264,7 @@ class TestModeExpectationsMapping:
         assert torch.allclose(output, expected, atol=1e-6)
 
     def test_expectation_counts(self):
-        """no_bunching=False should compute expected photon counts per mode."""
+        """FOCK space should compute expected photon counts per mode."""
         keys = [(2, 0), (0, 2), (1, 1)]
         mapper = ML.ModeExpectations(
             computation_space=ML.ComputationSpace.FOCK, keys=keys

--- a/tests/measurement/test_measurement_strategy.py
+++ b/tests/measurement/test_measurement_strategy.py
@@ -442,18 +442,19 @@ class TestQuantumLayerMeasurementStrategy:
 
 
 def test_resolve_measurement_strategy():
-    assert isinstance(
-        resolve_measurement_strategy(MeasurementStrategy.PROBABILITIES),
-        ProbabilitiesStrategy,
-    )
-    assert isinstance(
-        resolve_measurement_strategy(MeasurementStrategy.MODE_EXPECTATIONS),
-        ModeExpectationsStrategy,
-    )
-    assert isinstance(
-        resolve_measurement_strategy(MeasurementStrategy.AMPLITUDES),
-        AmplitudesStrategy,
-    )
+    with pytest.warns(DeprecationWarning):
+        assert isinstance(
+            resolve_measurement_strategy(MeasurementStrategy.PROBABILITIES),
+            ProbabilitiesStrategy,
+        )
+        assert isinstance(
+            resolve_measurement_strategy(MeasurementStrategy.MODE_EXPECTATIONS),
+            ModeExpectationsStrategy,
+        )
+        assert isinstance(
+            resolve_measurement_strategy(MeasurementStrategy.AMPLITUDES),
+            AmplitudesStrategy,
+        )
     assert isinstance(
         resolve_measurement_strategy(MeasurementStrategy.probs()),
         ProbabilitiesStrategy,

--- a/tests/measurement/test_measurement_strategy.py
+++ b/tests/measurement/test_measurement_strategy.py
@@ -237,11 +237,11 @@ class TestQuantumLayerMeasurementStrategy:
         output.sum().backward()
         assert x.grad is not None
 
-        # By default, no_bunching=True so output values cannot surpass 1
+        # By default, UNBUNCHED computation space so output values cannot surpass 1
         assert torch.all(output <= 1.0 + 1e-6)
         assert torch.all(output >= -1e-6)  # No negative values
 
-        # ModeExpectations with explicit no_bunching=True
+        # ModeExpectations with explicit UNBUNCHED space
         layer = ML.QuantumLayer(
             input_size=2,
             n_photons=n_photons,
@@ -258,7 +258,7 @@ class TestQuantumLayerMeasurementStrategy:
         assert torch.all(output <= 1.0 + 1e-6)
         assert torch.all(output >= -1e-6)  # No negative values
 
-        # ModeExpectations with no_bunching=False (has some output values > 1)
+        # ModeExpectations with FOCK space (has some output values > 1)
         builder = ML.CircuitBuilder(n_modes=n_modes)
         builder.add_superpositions((0, 1), name="BS")
         builder.add_angle_encoding(modes=[0, 1], name="input")
@@ -280,7 +280,7 @@ class TestQuantumLayerMeasurementStrategy:
         assert torch.all(
             output <= n_photons + 1e-6
         )  # Values cannot surpass the number of photons
-        # output[:, 0] and output[:, 1] should have values superior to 1 because their expected number of photons is higher than 1 with no_bunching=False
+        # output[:, 0] and output[:, 1] should have values superior to 1 because their expected number of photons is higher than 1 with FOCK space
         assert torch.all(output[:, 0] > torch.ones_like(output[:, 0]))
 
         assert torch.all(output[:, 1] > torch.ones_like(output[:, 1]))

--- a/tests/measurement/test_photon_loss.py
+++ b/tests/measurement/test_photon_loss.py
@@ -218,7 +218,9 @@ class TestPhotonLossWithQuantumLayer:
             input_size=0,
             circuit=circuit,
             input_state=[1, 4],
-            computation_space=ML.ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         output = layer()
@@ -240,13 +242,17 @@ class TestPhotonLossWithQuantumLayer:
             input_size=0,
             circuit=circuit,
             input_state=[1, 0],
-            computation_space=ML.ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
         layer_experiment = ML.QuantumLayer(
             input_size=0,
             experiment=experiment,
             input_state=[1, 0],
-            computation_space=ML.ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
         layer_experiment_unbunched = ML.QuantumLayer(
             input_size=0,
@@ -270,7 +276,9 @@ class TestPhotonLossWithQuantumLayer:
             input_size=0,
             circuit=circuit,
             input_state=[1, 1],
-            computation_space=ML.ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         experiment_brightness = pcvl.Experiment(circuit)
@@ -280,7 +288,9 @@ class TestPhotonLossWithQuantumLayer:
             input_size=0,
             experiment=experiment_brightness,
             input_state=[1, 1],
-            computation_space=ML.ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         experiment_transmittance = pcvl.Experiment(circuit)
@@ -290,7 +300,9 @@ class TestPhotonLossWithQuantumLayer:
             input_size=0,
             experiment=experiment_transmittance,
             input_state=[1, 1],
-            computation_space=ML.ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         keys = base_layer.output_keys
@@ -325,7 +337,9 @@ class TestPhotonLossWithQuantumLayer:
             input_size=0,
             experiment=experiment,
             input_state=[1, 0],
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         output = layer()
@@ -343,7 +357,9 @@ class TestPhotonLossWithQuantumLayer:
             input_size=0,
             experiment=experiment,
             input_state=[4, 0],
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         output_4 = layer_4_photons()
@@ -370,7 +386,9 @@ class TestPhotonLossWithQuantumLayer:
             input_size=0,
             circuit=circuit,
             input_state=[1, 1],
-            computation_space=ML.ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         experiment = pcvl.Experiment(circuit)
@@ -379,7 +397,9 @@ class TestPhotonLossWithQuantumLayer:
             input_size=0,
             experiment=experiment,
             input_state=[1, 1],
-            computation_space=ML.ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         base_output = base_layer()
@@ -418,7 +438,9 @@ class TestPhotonLossWithQuantumLayer:
             experiment=experiment,
             input_state=[1, 1],
             input_parameters=["phi"],
-            computation_space=ML.ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         x = torch.rand(3, 1, requires_grad=True)
@@ -447,7 +469,9 @@ class TestPhotonLossWithQuantumLayer:
             experiment=experiment,
             input_state=[1, 1],
             trainable_parameters=["phi"],
-            computation_space=ML.ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         # Check that it has trainable parameters
@@ -482,7 +506,9 @@ class TestPhotonLossWithQuantumLayer:
             input_size=0,
             experiment=experiment,
             input_state=input_state,
-            computation_space=ML.ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         output = loss_layer()
@@ -523,7 +549,9 @@ class TestPhotonLossWithQuantumLayer:
             input_size=0,
             experiment=experiment,
             input_state=input_state,
-            computation_space=ML.ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         output = loss_layer()

--- a/tests/measurement/test_photon_loss.py
+++ b/tests/measurement/test_photon_loss.py
@@ -47,13 +47,14 @@ class TestPhotonLossWithQuantumLayer:
             transmittance=0.9,
         )
 
-        with pytest.warns():  # no_bunching will issue a warning
-            layer = ML.QuantumLayer(
-                input_size=0,
-                experiment=experiment,
-                input_state=[1, 1],
-                no_bunching=False,
-            )
+        layer = ML.QuantumLayer(
+            input_size=0,
+            experiment=experiment,
+            input_state=[1, 1],
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
+        )
 
         output = layer()
         keys = layer.output_keys
@@ -87,7 +88,9 @@ class TestPhotonLossWithQuantumLayer:
             input_size=0,
             experiment=experiment_perfect,
             input_state=[1, 1],
-            computation_space=ComputationSpace.FOCK,
+            measurement_strategy=ML.MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
         )
 
         output = layer()
@@ -563,7 +566,7 @@ class TestPhotonLossWithFidelityKernel:
         kernel = ML.FidelityKernel(
             feature_map=feature_map,
             input_state=[1],
-            no_bunching=False,
+            computation_space=ComputationSpace.FOCK,
         )
 
         x = torch.tensor([0.0])
@@ -587,7 +590,7 @@ class TestPhotonLossWithFidelityKernel:
         kernel = ML.FidelityKernel(
             feature_map=feature_map,
             input_state=[1],
-            no_bunching=False,
+            computation_space=ComputationSpace.FOCK,
         )
 
         x = torch.tensor([0.0])
@@ -606,7 +609,7 @@ class TestPhotonLossWithFidelityKernel:
         kernel_noiseless = ML.FidelityKernel(
             feature_map=feature_map_noiseless,
             input_state=[1],
-            no_bunching=False,
+            computation_space=ComputationSpace.FOCK,
         )
 
         x = torch.tensor([0.0])

--- a/tests/memory_benchmark.py
+++ b/tests/memory_benchmark.py
@@ -31,7 +31,7 @@ import torch
 from pynvml_utils import nvidia_smi
 from torch.amp import GradScaler, autocast
 
-from merlin import MeasurementStrategy, QuantumLayer
+from merlin import ComputationSpace, MeasurementStrategy, QuantumLayer
 
 parser = argparse.ArgumentParser(description="Test MerLin on your GPU !")
 parser.add_argument(
@@ -128,9 +128,10 @@ def benchmark_bs(MODES=8, PHOTONS=4, BS=32, TYPE=torch.float32, set_hp=False):
         input_state=input_state,
         trainable_parameters=[],
         input_parameters=["phase", "theta"],
-        measurement_strategy=MeasurementStrategy.probs(),
+        measurement_strategy=MeasurementStrategy.probs(
+            computation_space=ComputationSpace.UNBUNCHED
+        ),
         device=device,
-        no_bunching=True,
     )
     print(f"Checking device of qlayer = {q_model.device}")
     t_end_layer = time.time() - t_start_layer

--- a/tests/utils/test_combinadics.py
+++ b/tests/utils/test_combinadics.py
@@ -3,7 +3,7 @@ import math
 import perceval as pcvl
 import pytest
 
-from merlin import QuantumLayer
+from merlin import ComputationSpace, MeasurementStrategy, QuantumLayer
 from merlin.utils.combinadics import Combinadics
 
 
@@ -105,12 +105,26 @@ def test_dual_rail_requires_twice_as_many_modes():
 def test_iteration_order_matches_quantum_layer(scheme: str):
     print("Testing scheme:", scheme)
     n, m = 4, 8
-    ql = QuantumLayer(
-        input_size=0,
-        circuit=pcvl.Circuit(m),
-        n_photons=n,
-        computation_space=scheme,
-    )
+    if scheme == "unbunched":
+        ql = QuantumLayer(
+            input_size=0,
+            circuit=pcvl.Circuit(m),
+            n_photons=n,
+        )
+    else:
+        computation_space = (
+            ComputationSpace.DUAL_RAIL
+            if scheme == "dual_rail"
+            else ComputationSpace.FOCK
+        )
+        ql = QuantumLayer(
+            input_size=0,
+            circuit=pcvl.Circuit(m),
+            n_photons=n,
+            measurement_strategy=MeasurementStrategy.probs(
+                computation_space=computation_space
+            ),
+        )
 
     mapped_keys = [
         tuple(state) for state in ql.computation_process.simulation_graph.mapped_keys


### PR DESCRIPTION
<!--
Thank you for contributing to MerLin!
Please fill out the sections below to help us review your PR efficiently.

NOTE: this repo is a public repository, therefore, do NOT paste Jira URLs. Use the Jira issue key only (e.g., PML-126).
The Jira–GitHub integration will link PRs/commits automatically when the key is present.
-->

<!-- Add the Jira issue key in the title -->
<!-- e.g., PML-126 Updating PR template -->

## Summary
<!-- What does this PR do? A clear, concise description. -->
Now, `no_bunching` input parameter is not supported anymore by the user-facing API
While it used to be mapped to a computation_space value, it now fails with an error message

What happens when no_bunching is used:
- It hard-fails: a `DeprecationWarning` is emitted and then a `ValueError` is raised with the same message. The helper is` raise_no_bunching_deprecated()`. The error message is explanatory and directs users to use `MeasurementStrategy.probs(computation_space=...)`

## Related Issue
   <!-- For internal contributors: Use Jira key (e.g., Related Jira: PML-126)
        For external contributors: Link to GitHub issue if applicable -->
Related Jira: PML-162

## Type of change
- [x] Breaking change (requires migration notes)


## Proposed changes
<!-- Bulleted list of key changes. If API changes, list them explicitly. -->

Direct API entry points that still accept no_bunching for backward compatibility explicitly call `raise_no_bunching_deprecated()` :
- `ComputationProcess.__init__ `in [process.py]
- `FidelityKernel` (and helpers in [kernels.py])
- SLOS graph creation in `TorchScript` utilities [slos_torchscript.py]
- Legacy feed-forward path in [feed_forward_legacy.py]

The next step would be a **complete removal of all `no_bunching` support** in the backend

Documentation should be updated accordingly -> this goes with the doc refactor on the new measurement API and should contain a migration guide

## How to test / How to run
<!-- Describe test plan and steps for reviewers to validate and run your changes locally. Include datasets if relevant. -->

1. Command lines

```
pytest
rg "no_bunching" -n tests
rg "no_bunching" -n merlin
```
Please note that cloud-related tests have not beed modified as they are handled in the PR regarding updates on the processor (151)

## Checklist
- [x] PR title includes Jira issue key (e.g., PML-126)
- [x] "Related Jira ticket" section includes the Jira issue key (no URL)
- [x] Code formatted (ruff format)
- [x] Lint passes (ruff)
- [x] Static typing passes (mypy) if applicable
- [x] Unit tests added/updated (pytest)
- [x] Tests pass locally (pytest)
- [x] Tests pass on GPU (pytest)
- [x] Test coverage not decreased significantly : after [77.19%] and before [77.12%]
- [x] Dependencies updated (if needed) and pinned appropriately
- [x] PR description explains what changed and how to validate it

<!-- Helpful local commands – run from repo root:

# Lint & format
ruff format && ruff check .

# Type check (if used)
mypy .

# Tests with coverage
pytest

# Build docs
pip install -e .[docs] && make -C docs html

-->