### PR TITLE
PML-264 encodingspace class + 267 + 269

### DIFF
--- a/docs/source/api_reference/api/merlin.core.encoding_space.rst
+++ b/docs/source/api_reference/api/merlin.core.encoding_space.rst
@@ -1,0 +1,15 @@
+merlin.core.encoding_space
+==========================
+
+.. automodule:: merlin.core.encoding_space
+   :no-members:
+
+.. currentmodule:: merlin.core.encoding_space
+
+EncodingSpace
+-------------
+
+.. autoclass:: EncodingSpace
+   :members: qloq, parameters, n_modes, n_photons, basis_size, resolved_modes_per_photon, logical_basis_states, fock_basis_states, logical_to_fock_map, logical_to_fock_indices
+   :member-order: bysource
+   :show-inheritance:

--- a/docs/source/api_reference/api/merlin.core.rst
+++ b/docs/source/api_reference/api/merlin.core.rst
@@ -19,6 +19,8 @@ Modules
      - Public circuit-component dataclasses such as rotations, beam splitters, and interferometers.
    * - :doc:`merlin.core.computation_space`
      - Computation-space enums and coercion helpers for Fock and related bases.
+   * - :doc:`merlin.core.encoding_space`
+     - Input encoding definitions and logical-to-Fock mapping helpers.
    * - :doc:`merlin.core.generators`
      - Legacy state and circuit generator helpers kept for compatibility.
    * - :doc:`merlin.core.partial_measurement`
@@ -43,6 +45,7 @@ Modules
    merlin.core.circuit
    merlin.core.components
    merlin.core.computation_space
+   merlin.core.encoding_space
    merlin.core.generators
    merlin.core.partial_measurement
    merlin.core.photonicbackend

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -86,7 +86,7 @@ extensions = [
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "torch": ("https://pytorch.org/docs/stable", None),
+    "torch": ("https://docs.pytorch.org/docs/2.10/", None),
     "perceval": ("https://perceval.quandela.net/docs/v1.1/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "pandas": ("https://pandas.pydata.org/docs/", None),

--- a/merlin/__init__.py
+++ b/merlin/__init__.py
@@ -45,6 +45,7 @@ from .builder.circuit_builder import CircuitBuilder
 # Essential enums
 # Advanced components (for power users)
 from .core.computation_space import ComputationSpace
+from .core.encoding_space import EncodingSpace
 from .core.merlin_processor import MerlinProcessor
 from .core.process import ComputationProcess
 from .core.state import StatePattern, generate_state
@@ -75,6 +76,7 @@ __all__ = [
     "QuantumBridge",
     # Configuration enums
     "ComputationSpace",
+    "EncodingSpace",
     "MeasurementStrategy",
     "Combinadics",
     # Advanced components

--- a/merlin/core/__init__.py
+++ b/merlin/core/__init__.py
@@ -26,6 +26,7 @@ from .base import AbstractComputationProcess
 from .circuit import Circuit
 from .components import BeamSplitter, Component, EntanglingBlock, Rotation
 from .computation_space import ComputationSpace
+from .encoding_space import EncodingSpace
 from .probability_distribution import ProbabilityDistribution
 from .process import ComputationProcess, ComputationProcessFactory
 from .state import StatePattern, generate_state
@@ -36,6 +37,7 @@ __all__ = [
     "ComputationProcess",
     "ComputationProcessFactory",
     "ComputationSpace",
+    "EncodingSpace",
     "StatePattern",
     "generate_state",
     "Component",

--- a/merlin/core/encoding_space.py
+++ b/merlin/core/encoding_space.py
@@ -177,7 +177,14 @@ class EncodingSpace:
         n_modes: int | None = None,
         n_photons: int | None = None,
     ) -> tuple[TupleInt, ...]:
-        """Return logical basis labels in stable embedding order."""
+        """Return logical basis labels in stable embedding order.
+
+        For a partitioned encoding, each tuple stores the local mode selected
+        by each photon partition. For ``EncodingSpace(modes_per_photon=[2, 2])``,
+        the output is::
+
+            ((0, 0), (0, 1), (1, 0), (1, 1))
+        """
 
         resolved_modes_per_photon = self.resolved_modes_per_photon(
             n_modes=n_modes, n_photons=n_photons
@@ -206,7 +213,13 @@ class EncodingSpace:
         n_modes: int | None = None,
         n_photons: int | None = None,
     ) -> tuple[TupleInt, ...]:
-        """Return mapped Fock states in the same order as ``logical_basis_states``."""
+        """Return mapped Fock states in the same order as ``logical_basis_states``.
+
+        For a ``[2, 2]`` partitioned encoding, the first photon occupies one of
+        modes ``0`` or ``1`` and the second occupies one of modes ``2`` or ``3``::
+
+            ((1, 0, 1, 0), (1, 0, 0, 1), (0, 1, 1, 0), (0, 1, 0, 1))
+        """
 
         return tuple(
             self.logical_to_fock_map(n_modes=n_modes, n_photons=n_photons).values()
@@ -218,7 +231,19 @@ class EncodingSpace:
         n_modes: int | None = None,
         n_photons: int | None = None,
     ) -> dict[TupleInt, TupleInt]:
-        """Return the logical-to-Fock mapping in stable order."""
+        """Return the logical-to-Fock mapping in stable order.
+
+        The keys are compact logical labels and the values are occupation-count
+        Fock states in Merlin's canonical mode layout. For
+        ``EncodingSpace(modes_per_photon=[3, 2])``, the mapping order is::
+
+            (0, 0) -> (1, 0, 0, 1, 0)
+            (0, 1) -> (1, 0, 0, 0, 1)
+            (1, 0) -> (0, 1, 0, 1, 0)
+            (1, 1) -> (0, 1, 0, 0, 1)
+            (2, 0) -> (0, 0, 1, 1, 0)
+            (2, 1) -> (0, 0, 1, 0, 1)
+        """
 
         logical_states = self.logical_basis_states(n_modes=n_modes, n_photons=n_photons)
         resolved_modes_per_photon = self.resolved_modes_per_photon(
@@ -252,7 +277,14 @@ class EncodingSpace:
         n_modes: int | None = None,
         n_photons: int | None = None,
     ) -> dict[TupleInt, int]:
-        """Return full-Fock indices for each logical basis label."""
+        """Return full-Fock indices for each logical basis label.
+
+        The returned indices refer to the full Fock basis for the resolved
+        ``n_modes`` and ``n_photons``. For
+        ``EncodingSpace(modes_per_photon=[2, 2])``, the output is::
+
+            {(0, 0): 2, (0, 1): 3, (1, 0): 5, (1, 1): 6}
+        """
 
         resolved_modes, resolved_photons = self._resolve_dimensions(
             n_modes=n_modes, n_photons=n_photons

--- a/merlin/core/encoding_space.py
+++ b/merlin/core/encoding_space.py
@@ -141,9 +141,12 @@ class EncodingSpace:
     ) -> int:
         """Return the number of logical basis states for this encoding."""
 
-        if self.family == "partitioned" and self.modes_per_photon is not None:
+        resolved_modes_per_photon = self.resolved_modes_per_photon(
+            n_modes=n_modes, n_photons=n_photons
+        )
+        if resolved_modes_per_photon is not None:
             size = 1
-            for width in self.modes_per_photon:
+            for width in resolved_modes_per_photon:
                 size *= width
             return size
 
@@ -154,6 +157,20 @@ class EncodingSpace:
             self.kind, resolved_photons, resolved_modes
         ).compute_space_size()
 
+    def resolved_modes_per_photon(
+        self, *, n_modes: int | None = None, n_photons: int | None = None
+    ) -> tuple[int, ...] | None:
+        """Return the resolved partition layout when the encoding is partitioned."""
+
+        if self.family == "partitioned" and self.modes_per_photon is not None:
+            return self.modes_per_photon
+        if self.kind == "dual_rail":
+            _, resolved_photons = self._resolve_dimensions(
+                n_modes=n_modes, n_photons=n_photons
+            )
+            return (2,) * resolved_photons
+        return None
+
     def logical_basis_states(
         self,
         *,
@@ -162,14 +179,15 @@ class EncodingSpace:
     ) -> tuple[TupleInt, ...]:
         """Return logical basis labels in stable embedding order."""
 
-        if self.family == "partitioned" and self.modes_per_photon is not None:
-            return self._product_basis_states(self.modes_per_photon)
+        resolved_modes_per_photon = self.resolved_modes_per_photon(
+            n_modes=n_modes, n_photons=n_photons
+        )
+        if resolved_modes_per_photon is not None:
+            return self._product_basis_states(resolved_modes_per_photon)
 
         resolved_modes, resolved_photons = self._resolve_dimensions(
             n_modes=n_modes, n_photons=n_photons
         )
-        if self.kind == "dual_rail":
-            return self._product_basis_states((2,) * resolved_photons)
         if self.kind == "unbunched":
             return tuple(
                 tuple(index for index, count in enumerate(state) if count)
@@ -203,18 +221,17 @@ class EncodingSpace:
         """Return the logical-to-Fock mapping in stable order."""
 
         logical_states = self.logical_basis_states(n_modes=n_modes, n_photons=n_photons)
-        if self.family == "partitioned" and self.modes_per_photon is not None:
+        resolved_modes_per_photon = self.resolved_modes_per_photon(
+            n_modes=n_modes, n_photons=n_photons
+        )
+        if resolved_modes_per_photon is not None:
             return self._logical_states_to_partitioned_fock_map(
-                logical_states, self.modes_per_photon
+                logical_states, resolved_modes_per_photon
             )
 
         resolved_modes, resolved_photons = self._resolve_dimensions(
             n_modes=n_modes, n_photons=n_photons
         )
-        if self.kind == "dual_rail":
-            return self._logical_states_to_partitioned_fock_map(
-                logical_states, (2,) * resolved_photons
-            )
         if self.kind == "fock":
             return {state: state for state in logical_states}
 

--- a/merlin/core/encoding_space.py
+++ b/merlin/core/encoding_space.py
@@ -48,13 +48,20 @@ class EncodingSpace:
                     "Use EncodingSpace.FOCK, EncodingSpace.UNBUNCHED, "
                     "EncodingSpace.DUAL_RAIL, or EncodingSpace.qloq(...)."
                 )
-            if family != "builtin" or kind not in {"fock", "unbunched", "dual_rail"}:
+            if family == "builtin" and kind in {"fock", "unbunched"}:
+                object.__setattr__(self, "family", family)
+                object.__setattr__(self, "kind", kind)
+                object.__setattr__(self, "modes_per_photon", None)
+                object.__setattr__(self, "qubit_groups", None)
+                return
+            if family == "partitioned" and kind == "dual_rail":
+                object.__setattr__(self, "family", family)
+                object.__setattr__(self, "kind", kind)
+                object.__setattr__(self, "modes_per_photon", None)
+                object.__setattr__(self, "qubit_groups", None)
+                return
+            else:
                 raise ValueError("Invalid builtin encoding configuration.")
-            object.__setattr__(self, "family", family)
-            object.__setattr__(self, "kind", kind)
-            object.__setattr__(self, "modes_per_photon", None)
-            object.__setattr__(self, "qubit_groups", None)
-            return
 
         validated_modes = self._validate_positive_int_tuple(
             modes_per_photon, name="modes_per_photon"
@@ -134,9 +141,8 @@ class EncodingSpace:
     ) -> int:
         """Return the number of logical basis states for this encoding."""
 
-        if self.family == "partitioned":
+        if self.family == "partitioned" and self.modes_per_photon is not None:
             size = 1
-            assert self.modes_per_photon is not None
             for width in self.modes_per_photon:
                 size *= width
             return size
@@ -156,8 +162,7 @@ class EncodingSpace:
     ) -> tuple[TupleInt, ...]:
         """Return logical basis labels in stable embedding order."""
 
-        if self.family == "partitioned":
-            assert self.modes_per_photon is not None
+        if self.family == "partitioned" and self.modes_per_photon is not None:
             return self._product_basis_states(self.modes_per_photon)
 
         resolved_modes, resolved_photons = self._resolve_dimensions(
@@ -198,14 +203,10 @@ class EncodingSpace:
         """Return the logical-to-Fock mapping in stable order."""
 
         logical_states = self.logical_basis_states(n_modes=n_modes, n_photons=n_photons)
-        if self.family == "partitioned":
-            assert self.modes_per_photon is not None
+        if self.family == "partitioned" and self.modes_per_photon is not None:
             return self._logical_states_to_partitioned_fock_map(
                 logical_states, self.modes_per_photon
             )
-
-        if self.kind == "fock":
-            return {state: state for state in logical_states}
 
         resolved_modes, resolved_photons = self._resolve_dimensions(
             n_modes=n_modes, n_photons=n_photons
@@ -214,6 +215,8 @@ class EncodingSpace:
             return self._logical_states_to_partitioned_fock_map(
                 logical_states, (2,) * resolved_photons
             )
+        if self.kind == "fock":
+            return {state: state for state in logical_states}
 
         if self.kind == "unbunched":
             mapping: dict[TupleInt, TupleInt] = {}
@@ -251,19 +254,28 @@ class EncodingSpace:
         n_modes: int | None,
         n_photons: int | None,
     ) -> tuple[int, int]:
-        if self.family == "partitioned":
-            assert self.modes_per_photon is not None
+        if self.family == "partitioned" and self.modes_per_photon is not None:
             expected_modes = sum(self.modes_per_photon)
             expected_photons = len(self.modes_per_photon)
-            if n_modes is not None and n_modes != expected_modes:
+            resolved_modes = (
+                expected_modes
+                if n_modes is None
+                else self._validate_mode_count(n_modes)
+            )
+            resolved_photons = (
+                expected_photons
+                if n_photons is None
+                else self._validate_photon_count(n_photons)
+            )
+            if resolved_modes != expected_modes:
                 raise ValueError(
-                    f"EncodingSpace expects n_modes={expected_modes}, got {n_modes}."
+                    f"EncodingSpace expects n_modes={expected_modes}, got {resolved_modes}."
                 )
-            if n_photons is not None and n_photons != expected_photons:
+            if resolved_photons != expected_photons:
                 raise ValueError(
-                    f"EncodingSpace expects n_photons={expected_photons}, got {n_photons}."
+                    f"EncodingSpace expects n_photons={expected_photons}, got {resolved_photons}."
                 )
-            return expected_modes, expected_photons
+            return resolved_modes, resolved_photons
 
         resolved_modes = self._validate_mode_count(n_modes)
         resolved_photons = self._validate_photon_count(n_photons)
@@ -342,4 +354,4 @@ class EncodingSpace:
 
 EncodingSpace.FOCK = EncodingSpace(family="builtin", kind="fock")
 EncodingSpace.UNBUNCHED = EncodingSpace(family="builtin", kind="unbunched")
-EncodingSpace.DUAL_RAIL = EncodingSpace(family="builtin", kind="dual_rail")
+EncodingSpace.DUAL_RAIL = EncodingSpace(family="partitioned", kind="dual_rail")

--- a/merlin/core/encoding_space.py
+++ b/merlin/core/encoding_space.py
@@ -1,0 +1,345 @@
+"""Input encoding definitions and mapping helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from itertools import product
+from typing import ClassVar
+
+from merlin.utils.combinadics import Combinadics
+
+TupleInt = tuple[int, ...]
+
+
+@dataclass(frozen=True, init=False)
+class EncodingSpace:
+    """Validated input encoding definition.
+
+    Instances describe how a compact logical basis should be interpreted before it
+    is embedded into Merlin's canonical Fock ordering.
+    """
+
+    family: str
+    kind: str
+    modes_per_photon: tuple[int, ...] | None
+    qubit_groups: tuple[int, ...] | None
+
+    FOCK: ClassVar[EncodingSpace]
+    UNBUNCHED: ClassVar[EncodingSpace]
+    DUAL_RAIL: ClassVar[EncodingSpace]
+
+    def __init__(
+        self,
+        modes_per_photon: Iterable[int] | None = None,
+        *,
+        family: str | None = None,
+        kind: str | None = None,
+        qubit_groups: Iterable[int] | None = None,
+    ) -> None:
+        if modes_per_photon is None:
+            if qubit_groups is not None:
+                raise ValueError(
+                    "qubit_groups is only supported via EncodingSpace.qloq(...)."
+                )
+            if family is None or kind is None:
+                raise ValueError(
+                    "modes_per_photon is required for custom encodings. "
+                    "Use EncodingSpace.FOCK, EncodingSpace.UNBUNCHED, "
+                    "EncodingSpace.DUAL_RAIL, or EncodingSpace.qloq(...)."
+                )
+            if family != "builtin" or kind not in {"fock", "unbunched", "dual_rail"}:
+                raise ValueError("Invalid builtin encoding configuration.")
+            object.__setattr__(self, "family", family)
+            object.__setattr__(self, "kind", kind)
+            object.__setattr__(self, "modes_per_photon", None)
+            object.__setattr__(self, "qubit_groups", None)
+            return
+
+        validated_modes = self._validate_positive_int_tuple(
+            modes_per_photon, name="modes_per_photon"
+        )
+        validated_groups = (
+            None
+            if qubit_groups is None
+            else self._validate_positive_int_tuple(qubit_groups, name="qubit_groups")
+        )
+        resolved_family = "partitioned" if family is None else family
+        resolved_kind = "partitioned" if kind is None else kind
+
+        if resolved_family != "partitioned":
+            raise ValueError("Custom encodings must use family='partitioned'.")
+        if resolved_kind not in {"partitioned", "qloq"}:
+            raise ValueError(
+                "Custom encodings must use kind='partitioned' or kind='qloq'."
+            )
+
+        object.__setattr__(self, "family", resolved_family)
+        object.__setattr__(self, "kind", resolved_kind)
+        object.__setattr__(self, "modes_per_photon", validated_modes)
+        object.__setattr__(self, "qubit_groups", validated_groups)
+
+    def __repr__(self) -> str:
+        fields = [f"family={self.family!r}", f"kind={self.kind!r}"]
+        if self.modes_per_photon is not None:
+            fields.append(f"modes_per_photon={self.modes_per_photon!r}")
+        if self.qubit_groups is not None:
+            fields.append(f"qubit_groups={self.qubit_groups!r}")
+        return f"EncodingSpace({', '.join(fields)})"
+
+    @property
+    def parameters(self) -> dict[str, tuple[int, ...]]:
+        """Return a copy of the encoding parameters for introspection."""
+
+        params: dict[str, tuple[int, ...]] = {}
+        if self.modes_per_photon is not None:
+            params["modes_per_photon"] = self.modes_per_photon
+        if self.qubit_groups is not None:
+            params["qubit_groups"] = self.qubit_groups
+        return params
+
+    @property
+    def n_modes(self) -> int | None:
+        """Return the total mode count for partitioned encodings."""
+
+        if self.modes_per_photon is None:
+            return None
+        return sum(self.modes_per_photon)
+
+    @property
+    def n_photons(self) -> int | None:
+        """Return the photon count for partitioned encodings."""
+
+        if self.modes_per_photon is None:
+            return None
+        return len(self.modes_per_photon)
+
+    @classmethod
+    def qloq(cls, qubit_groups: Iterable[int]) -> EncodingSpace:
+        """Create a partitioned QLOQ encoding from qubit group sizes."""
+
+        validated_groups = cls._validate_positive_int_tuple(
+            qubit_groups, name="qubit_groups"
+        )
+        modes_per_photon = tuple(1 << group for group in validated_groups)
+        return cls(
+            modes_per_photon,
+            family="partitioned",
+            kind="qloq",
+            qubit_groups=validated_groups,
+        )
+
+    def basis_size(
+        self, *, n_modes: int | None = None, n_photons: int | None = None
+    ) -> int:
+        """Return the number of logical basis states for this encoding."""
+
+        if self.family == "partitioned":
+            size = 1
+            assert self.modes_per_photon is not None
+            for width in self.modes_per_photon:
+                size *= width
+            return size
+
+        resolved_modes, resolved_photons = self._resolve_dimensions(
+            n_modes=n_modes, n_photons=n_photons
+        )
+        return Combinadics(
+            self.kind, resolved_photons, resolved_modes
+        ).compute_space_size()
+
+    def logical_basis_states(
+        self,
+        *,
+        n_modes: int | None = None,
+        n_photons: int | None = None,
+    ) -> tuple[TupleInt, ...]:
+        """Return logical basis labels in stable embedding order."""
+
+        if self.family == "partitioned":
+            assert self.modes_per_photon is not None
+            return self._product_basis_states(self.modes_per_photon)
+
+        resolved_modes, resolved_photons = self._resolve_dimensions(
+            n_modes=n_modes, n_photons=n_photons
+        )
+        if self.kind == "dual_rail":
+            return self._product_basis_states((2,) * resolved_photons)
+        if self.kind == "unbunched":
+            return tuple(
+                tuple(index for index, count in enumerate(state) if count)
+                for state in Combinadics(
+                    self.kind, resolved_photons, resolved_modes
+                ).enumerate_states()
+            )
+
+        return tuple(
+            Combinadics(self.kind, resolved_photons, resolved_modes).enumerate_states()
+        )
+
+    def fock_basis_states(
+        self,
+        *,
+        n_modes: int | None = None,
+        n_photons: int | None = None,
+    ) -> tuple[TupleInt, ...]:
+        """Return mapped Fock states in the same order as ``logical_basis_states``."""
+
+        return tuple(
+            self.logical_to_fock_map(n_modes=n_modes, n_photons=n_photons).values()
+        )
+
+    def logical_to_fock_map(
+        self,
+        *,
+        n_modes: int | None = None,
+        n_photons: int | None = None,
+    ) -> dict[TupleInt, TupleInt]:
+        """Return the logical-to-Fock mapping in stable order."""
+
+        logical_states = self.logical_basis_states(n_modes=n_modes, n_photons=n_photons)
+        if self.family == "partitioned":
+            assert self.modes_per_photon is not None
+            return self._logical_states_to_partitioned_fock_map(
+                logical_states, self.modes_per_photon
+            )
+
+        if self.kind == "fock":
+            return {state: state for state in logical_states}
+
+        resolved_modes, resolved_photons = self._resolve_dimensions(
+            n_modes=n_modes, n_photons=n_photons
+        )
+        if self.kind == "dual_rail":
+            return self._logical_states_to_partitioned_fock_map(
+                logical_states, (2,) * resolved_photons
+            )
+
+        if self.kind == "unbunched":
+            mapping: dict[TupleInt, TupleInt] = {}
+            for logical_state in logical_states:
+                counts = [0] * resolved_modes
+                for occupied_mode in logical_state:
+                    counts[occupied_mode] = 1
+                mapping[logical_state] = tuple(counts)
+            return mapping
+
+        raise ValueError(f"Unsupported encoding kind '{self.kind}'.")
+
+    def logical_to_fock_indices(
+        self,
+        *,
+        n_modes: int | None = None,
+        n_photons: int | None = None,
+    ) -> dict[TupleInt, int]:
+        """Return full-Fock indices for each logical basis label."""
+
+        resolved_modes, resolved_photons = self._resolve_dimensions(
+            n_modes=n_modes, n_photons=n_photons
+        )
+        fock_basis = Combinadics("fock", resolved_photons, resolved_modes)
+        return {
+            logical_state: fock_basis.fock_to_index(fock_state)
+            for logical_state, fock_state in self.logical_to_fock_map(
+                n_modes=n_modes, n_photons=n_photons
+            ).items()
+        }
+
+    def _resolve_dimensions(
+        self,
+        *,
+        n_modes: int | None,
+        n_photons: int | None,
+    ) -> tuple[int, int]:
+        if self.family == "partitioned":
+            assert self.modes_per_photon is not None
+            expected_modes = sum(self.modes_per_photon)
+            expected_photons = len(self.modes_per_photon)
+            if n_modes is not None and n_modes != expected_modes:
+                raise ValueError(
+                    f"EncodingSpace expects n_modes={expected_modes}, got {n_modes}."
+                )
+            if n_photons is not None and n_photons != expected_photons:
+                raise ValueError(
+                    f"EncodingSpace expects n_photons={expected_photons}, got {n_photons}."
+                )
+            return expected_modes, expected_photons
+
+        resolved_modes = self._validate_mode_count(n_modes)
+        resolved_photons = self._validate_photon_count(n_photons)
+        if self.kind == "dual_rail":
+            if resolved_modes is None and resolved_photons is not None:
+                resolved_modes = 2 * resolved_photons
+            if resolved_photons is None and resolved_modes is not None:
+                if resolved_modes % 2 != 0:
+                    raise ValueError("dual_rail requires an even n_modes value.")
+                resolved_photons = resolved_modes // 2
+
+        if resolved_modes is None or resolved_photons is None:
+            raise ValueError(f"{self.kind} encoding requires n_modes and n_photons.")
+        return resolved_modes, resolved_photons
+
+    @staticmethod
+    def _partition_offsets(modes_per_photon: tuple[int, ...]) -> tuple[int, ...]:
+        offsets = []
+        start = 0
+        for width in modes_per_photon:
+            offsets.append(start)
+            start += width
+        return tuple(offsets)
+
+    @staticmethod
+    def _product_basis_states(widths: tuple[int, ...]) -> tuple[TupleInt, ...]:
+        ranges = (range(width) for width in widths)
+        return tuple(tuple(state) for state in product(*ranges))
+
+    @classmethod
+    def _logical_states_to_partitioned_fock_map(
+        cls,
+        logical_states: tuple[TupleInt, ...],
+        modes_per_photon: tuple[int, ...],
+    ) -> dict[TupleInt, TupleInt]:
+        offsets = cls._partition_offsets(modes_per_photon)
+        total_modes = sum(modes_per_photon)
+        mapping: dict[TupleInt, TupleInt] = {}
+        for logical_state in logical_states:
+            counts = [0] * total_modes
+            for index, local_mode in enumerate(logical_state):
+                counts[offsets[index] + local_mode] = 1
+            mapping[logical_state] = tuple(counts)
+        return mapping
+
+    @staticmethod
+    def _validate_positive_int_tuple(
+        values: Iterable[int], *, name: str
+    ) -> tuple[int, ...]:
+        validated = tuple(values)
+        if not validated:
+            raise ValueError(f"{name} must contain at least one value.")
+        for value in validated:
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise ValueError(f"{name} must contain integers only.")
+            if value <= 0:
+                raise ValueError(f"{name} must contain strictly positive integers.")
+        return validated
+
+    @staticmethod
+    def _validate_mode_count(value: int | None) -> int | None:
+        if value is None:
+            return None
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            raise ValueError("n_modes must be a strictly positive integer.")
+        return value
+
+    @staticmethod
+    def _validate_photon_count(value: int | None) -> int | None:
+        if value is None:
+            return None
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise ValueError("n_photons must be a non-negative integer.")
+        return value
+
+
+EncodingSpace.FOCK = EncodingSpace(family="builtin", kind="fock")
+EncodingSpace.UNBUNCHED = EncodingSpace(family="builtin", kind="unbunched")
+EncodingSpace.DUAL_RAIL = EncodingSpace(family="builtin", kind="dual_rail")

--- a/merlin/core/partial_measurement.py
+++ b/merlin/core/partial_measurement.py
@@ -167,8 +167,9 @@ class PartialMeasurement:
         assert grouped_probas.shape == (self.probability_tensor_shape), (
             "Inconsistent grouped probability tensor shape after grouping"
         )
+        batch_size = int(probas.size(0))
         assert self.probability_tensor_shape == (
-            probas.shape[0],
+            batch_size,
             output_size,
         ), "Inconsistent grouped probability tensor shape after grouping"
         return grouped_probas

--- a/tests/core/test_encoding_space.py
+++ b/tests/core/test_encoding_space.py
@@ -89,6 +89,31 @@ def test_partitioned_logical_to_fock_mapping_order():
     }
 
 
+def test_partitioned_two_by_two_order_matches_example():
+    enc = EncodingSpace(modes_per_photon=[2, 2])
+
+    expected_items = [
+        ((0, 0), (1, 0, 1, 0)),
+        ((0, 1), (1, 0, 0, 1)),
+        ((1, 0), (0, 1, 1, 0)),
+        ((1, 1), (0, 1, 0, 1)),
+    ]
+
+    assert enc.logical_basis_states() == tuple(
+        logical_state for logical_state, _ in expected_items
+    )
+    assert enc.fock_basis_states() == tuple(
+        fock_state for _, fock_state in expected_items
+    )
+    assert list(enc.logical_to_fock_map().items()) == expected_items
+
+    fock_basis = Combinadics("fock", 2, 4)
+    assert enc.logical_to_fock_indices() == {
+        logical_state: fock_basis.fock_to_index(fock_state)
+        for logical_state, fock_state in expected_items
+    }
+
+
 def test_dual_rail_builtin_mapping_order():
     mapping = EncodingSpace.DUAL_RAIL.logical_to_fock_map(n_modes=4, n_photons=2)
 

--- a/tests/core/test_encoding_space.py
+++ b/tests/core/test_encoding_space.py
@@ -10,7 +10,9 @@ def test_builtin_encoding_space_constants():
     assert EncodingSpace.FOCK.kind == "fock"
     assert EncodingSpace.FOCK.family == "builtin"
     assert EncodingSpace.UNBUNCHED.kind == "unbunched"
+    assert EncodingSpace.UNBUNCHED.family == "builtin"
     assert EncodingSpace.DUAL_RAIL.kind == "dual_rail"
+    assert EncodingSpace.DUAL_RAIL.family == "partitioned"
 
 
 def test_partitioned_modes_per_photon_validation():
@@ -123,3 +125,21 @@ def test_dual_rail_builtin_mapping_order():
         ((1, 0), (0, 1, 1, 0)),
         ((1, 1), (0, 1, 0, 1)),
     ]
+
+
+def test_dual_rail_builtin_matches_equivalent_partitioned_engine():
+    dual_rail = EncodingSpace.DUAL_RAIL
+    partitioned = EncodingSpace(modes_per_photon=[2, 2, 2])
+
+    assert dual_rail.logical_basis_states(n_modes=6, n_photons=3) == (
+        partitioned.logical_basis_states()
+    )
+    assert dual_rail.fock_basis_states(n_modes=6, n_photons=3) == (
+        partitioned.fock_basis_states()
+    )
+    assert dual_rail.logical_to_fock_map(n_modes=6, n_photons=3) == (
+        partitioned.logical_to_fock_map()
+    )
+    assert dual_rail.logical_to_fock_indices(n_modes=6, n_photons=3) == (
+        partitioned.logical_to_fock_indices()
+    )

--- a/tests/core/test_encoding_space.py
+++ b/tests/core/test_encoding_space.py
@@ -1,0 +1,100 @@
+import pytest
+
+from merlin import EncodingSpace
+from merlin.core import EncodingSpace as CoreEncodingSpace
+from merlin.utils.combinadics import Combinadics
+
+
+def test_builtin_encoding_space_constants():
+    assert CoreEncodingSpace is EncodingSpace
+    assert EncodingSpace.FOCK.kind == "fock"
+    assert EncodingSpace.FOCK.family == "builtin"
+    assert EncodingSpace.UNBUNCHED.kind == "unbunched"
+    assert EncodingSpace.DUAL_RAIL.kind == "dual_rail"
+
+
+def test_partitioned_modes_per_photon_validation():
+    enc = EncodingSpace(modes_per_photon=[3, 4, 2])
+
+    assert enc.family == "partitioned"
+    assert enc.kind == "partitioned"
+    assert enc.modes_per_photon == (3, 4, 2)
+    assert enc.parameters == {"modes_per_photon": (3, 4, 2)}
+    assert enc.n_photons == 3
+    assert enc.n_modes == 9
+    assert enc.basis_size() == 24
+
+
+def test_qloq_helper_expands_groups_to_modes_per_photon():
+    qloq = EncodingSpace.qloq(qubit_groups=[2, 1])
+
+    assert qloq.family == "partitioned"
+    assert qloq.kind == "qloq"
+    assert qloq.qubit_groups == (2, 1)
+    assert qloq.modes_per_photon == (4, 2)
+    assert qloq.parameters == {
+        "modes_per_photon": (4, 2),
+        "qubit_groups": (2, 1),
+    }
+
+
+def test_encoding_space_equality_hashability_and_repr():
+    left = EncodingSpace(modes_per_photon=[3, 2])
+    right = EncodingSpace(modes_per_photon=(3, 2))
+
+    assert left == right
+    assert hash(left) == hash(right)
+    assert {left: "ok"}[right] == "ok"
+    assert (
+        repr(EncodingSpace.qloq(qubit_groups=[2, 1]))
+        == "EncodingSpace(family='partitioned', kind='qloq', "
+        "modes_per_photon=(4, 2), qubit_groups=(2, 1))"
+    )
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: EncodingSpace(modes_per_photon=[]),
+        lambda: EncodingSpace(modes_per_photon=[3, 0]),
+        lambda: EncodingSpace(modes_per_photon=[True, 2]),
+        lambda: EncodingSpace.qloq(qubit_groups=[]),
+        lambda: EncodingSpace.qloq(qubit_groups=[2, 0]),
+        lambda: EncodingSpace.qloq(qubit_groups=[False, 1]),
+    ],
+)
+def test_invalid_encoding_space_inputs_raise_value_error(factory):
+    with pytest.raises(ValueError):
+        factory()
+
+
+def test_partitioned_logical_to_fock_mapping_order():
+    enc = EncodingSpace(modes_per_photon=[3, 2])
+
+    expected_items = [
+        ((0, 0), (1, 0, 0, 1, 0)),
+        ((0, 1), (1, 0, 0, 0, 1)),
+        ((1, 0), (0, 1, 0, 1, 0)),
+        ((1, 1), (0, 1, 0, 0, 1)),
+        ((2, 0), (0, 0, 1, 1, 0)),
+        ((2, 1), (0, 0, 1, 0, 1)),
+    ]
+
+    assert list(enc.logical_to_fock_map().items()) == expected_items
+
+    fock_basis = Combinadics("fock", 2, 5)
+    assert enc.logical_to_fock_indices() == {
+        logical_state: fock_basis.fock_to_index(fock_state)
+        for logical_state, fock_state in expected_items
+    }
+
+
+def test_dual_rail_builtin_mapping_order():
+    mapping = EncodingSpace.DUAL_RAIL.logical_to_fock_map(n_modes=4, n_photons=2)
+
+    assert list(mapping.items()) == [
+        ((0, 0), (1, 0, 1, 0)),
+        ((0, 1), (1, 0, 0, 1)),
+        ((1, 0), (0, 1, 1, 0)),
+        ((1, 1), (0, 1, 0, 1)),
+    ]

--- a/tests/core/test_encoding_space.py
+++ b/tests/core/test_encoding_space.py
@@ -143,3 +143,27 @@ def test_dual_rail_builtin_matches_equivalent_partitioned_engine():
     assert dual_rail.logical_to_fock_indices(n_modes=6, n_photons=3) == (
         partitioned.logical_to_fock_indices()
     )
+
+
+def test_dual_rail_resolves_modes_per_photon_at_embed_time():
+    dual_rail = EncodingSpace.DUAL_RAIL
+
+    assert dual_rail.family == "partitioned"
+    assert dual_rail.kind == "dual_rail"
+    assert dual_rail.parameters == {}
+    assert dual_rail.resolved_modes_per_photon(n_modes=6, n_photons=3) == (
+        2,
+        2,
+        2,
+    )
+    assert dual_rail.basis_size(n_modes=6, n_photons=3) == 8
+    assert dual_rail.logical_basis_states(n_modes=6, n_photons=3) == (
+        (0, 0, 0),
+        (0, 0, 1),
+        (0, 1, 0),
+        (0, 1, 1),
+        (1, 0, 0),
+        (1, 0, 1),
+        (1, 1, 0),
+        (1, 1, 1),
+    )


### PR DESCRIPTION
## Summary
Introduces the encoding stack for input encodings:
- `PML-264`: `EncodingSpace` core type and validation
- `PML-267`: partitioned encoding engine and ordering contract
- `PML-269`: built-in sentinels/factories on top of the partitioned engine

This PR keeps one shared compatibility fix for `mypy` at the end of the branch history.

## Related Issue
Related Jira: PML-264, PML-267, PML-269

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / Cleanup
- [ ] Performance improvement
- [ ] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)

## Proposed changes
- Adds `merlin/core/encoding_space.py`.
- Exports `EncodingSpace` from `merlin.core` and top-level `merlin`.
- Defines stable metadata, equality, hash, and repr semantics.
- Implements partitioned logical basis enumeration and logical-to-Fock mapping.
- Adds `DUAL_RAIL` and `qloq(...)` as built-in wrappers over the partitioned engine.
- Covers the combined type / ordering / built-in contract with focused unit tests.
- Includes one shared `mypy` compatibility fix for `merlin/core/partial_measurement.py`.

## How to test / How to run
1. Command lines

```bash
pytest tests/core/test_encoding_space.py -q
ruff format --check merlin/core/encoding_space.py tests/core/test_encoding_space.py merlin/core/partial_measurement.py
ruff check merlin/core/encoding_space.py tests/core/test_encoding_space.py merlin/core/partial_measurement.py
mypy merlin/ --ignore-missing-imports --no-strict-optional --allow-untyped-defs --disable-error-code=no-redef
```

## Screenshots / Logs (optional)
No UI changes.

## Performance considerations (optional)
No runtime impact beyond the new encoding metadata and mapping helpers; this is primarily a type-and-contract addition.


## Documentation
- [ ] User docs updated (Sphinx)
- [ ] Examples / notebooks updated
- [x] Docstrings updated
- [x] Updated the API

## Checklist
- [x] PR title includes Jira issue key (e.g., PML-126)
- [x] "Related Jira ticket" section includes the Jira issue key (no URL)
- [x] Code formatted (ruff format)
- [x] Lint passes (ruff)
- [x] Static typing passes (mypy) if applicable
- [x] Unit tests added/updated (pytest)
- [x] Tests pass locally (pytest)
- [ ] Tests pass on GPU (pytest)
- [x] Test coverage not decreased significantly
- [ ] Docs build locally if affected (sphinx)
- [ ] With this command: 

        > SPHINXOPTS="-W --keep-going -n" make -C docs clean html 

    the docs are built without any warning or errors.
- [ ] New public classes/methods/packages are added in the API following the methodology presented in other files.
- [ ] Dependencies updated (if needed) and pinned appropriately
- [ ] PR description explains what changed and how to validate it


<!-- Helpful local commands – run from repo root:

# Lint & format
ruff format && ruff check .

# Type check (if used)
mypy .

# Tests with coverage
pytest

# Build docs
pip install -e .[docs] && make -C docs html

-->
