### PR TITLE
PML-265 Relax amplitude input length

### DIFF
--- a/merlin/algorithms/feed_forward_legacy.py
+++ b/merlin/algorithms/feed_forward_legacy.py
@@ -441,9 +441,7 @@ class FeedForwardBlockLegacy(torch.nn.Module):
                     )
 
                 # Set input quantum state for the layer
-                layer.computation_process.input_state = remaining_amplitudes[
-                    :, match_idx
-                ]
+                layer.set_input_state(remaining_amplitudes[:, match_idx])
                 start, end = self.input_segments[current_key]
 
                 # Execute layer with or without classical input

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -43,7 +43,7 @@ from ..core.partial_measurement import PartialMeasurement
 from ..core.probability_distribution import ProbabilityDistribution
 from ..core.process import ComputationProcessFactory
 from ..core.state import StatePattern, generate_state
-from ..core.state_vector import StateVector
+from ..core.state_vector import StateVector, embed_tensor_in_fock_basis
 from ..measurement import OutputMapper
 from ..measurement.autodiff import AutoDiffProcess
 from ..measurement.detectors import DetectorTransform
@@ -390,7 +390,9 @@ class QuantumLayer(MerlinModule):
             resolved_n_photons = (
                 n_photons  # n_photons must be provided for tensor input
             )
-            process_input_state = self.input_state
+            process_input_state = self._embed_amplitude_tensor(
+                self._validate_amplitude_input(self.input_state)
+            )
         elif isinstance(self.input_state, pcvl.BasicState):
             resolved_n_photons = (
                 n_photons if n_photons is not None else sum(self.input_state)
@@ -421,7 +423,9 @@ class QuantumLayer(MerlinModule):
                 sv_tensor = sv_tensor.to(self.device)
             if sv_tensor.dtype != self.complex_dtype:
                 sv_tensor = sv_tensor.to(self.complex_dtype)
-            self.computation_process.input_state = sv_tensor
+            self.computation_process.input_state = self._embed_amplitude_tensor(
+                sv_tensor
+            )
 
         # Setup PhotonLossTransform & DetectorTransform
         self.n_photons = self.computation_process.n_photons
@@ -654,14 +658,6 @@ class QuantumLayer(MerlinModule):
                 "Amplitude-encoded inputs must be 1D (single state) or 2D (batch of states) tensors"
             )
 
-        expected_dim = len(self.output_keys)
-        feature_dim = amplitude.shape[-1]
-        if feature_dim != expected_dim:
-            raise ValueError(
-                f"Amplitude input expects {expected_dim} components, received {feature_dim}."
-            )
-            # TODO: suggest/implement zero-padding or sparsity tensor format
-
         if amplitude.dtype not in (
             torch.float32,
             torch.float64,
@@ -681,6 +677,21 @@ class QuantumLayer(MerlinModule):
             amplitude = amplitude.to(self.dtype)
 
         return amplitude
+
+    def _embed_amplitude_tensor(self, amplitude: torch.Tensor) -> torch.Tensor:
+        try:
+            return embed_tensor_in_fock_basis(
+                amplitude,
+                n_modes=self.circuit.m,
+                n_photons=self.n_photons,
+                computation_space=self.computation_space,
+            )
+        except ValueError as exc:
+            expected_dim = len(self.output_keys)
+            feature_dim = amplitude.shape[-1]
+            raise ValueError(
+                f"Amplitude input expects {expected_dim} components, received {feature_dim}."
+            ) from exc
 
     def set_input_state(self, input_state):
         """Set the layer input state for subsequent evaluations.
@@ -703,6 +714,24 @@ class QuantumLayer(MerlinModule):
             basic = pcvl.BasicState(tuple(input_state))
             self.input_state = basic
             self.computation_process.input_state = list(basic)
+            return
+
+        if isinstance(input_state, StateVector):
+            tensor_state = input_state.to_dense()
+            if tensor_state.device != self.device:
+                tensor_state = tensor_state.to(self.device)
+            if tensor_state.dtype != self.complex_dtype:
+                tensor_state = tensor_state.to(self.complex_dtype)
+            embedded = self._embed_amplitude_tensor(tensor_state)
+            self.input_state = input_state
+            self.computation_process.input_state = embedded
+            return
+
+        if isinstance(input_state, torch.Tensor):
+            validated = self._validate_amplitude_input(input_state)
+            embedded = self._embed_amplitude_tensor(validated)
+            self.input_state = input_state
+            self.computation_process.input_state = embedded
             return
 
         self.input_state = input_state
@@ -817,15 +846,10 @@ class QuantumLayer(MerlinModule):
                     "Use either tensor inputs (angle encoding) or StateVector (amplitude encoding)."
                 )
             sv = input_parameters[0]
-            # Convert to dense for computation pipeline (sparse not supported downstream).
-            # StateVector's sparse representation is still valuable for memory-efficient
-            # construction and manipulation; we only densify at computation time.
             amplitude_tensor = sv.to_dense()
-            if amplitude_tensor.device != self.device:
-                amplitude_tensor = amplitude_tensor.to(self.device)
-            if amplitude_tensor.dtype != self.complex_dtype:
-                amplitude_tensor = amplitude_tensor.to(self.complex_dtype)
-            amplitude_input = self._validate_amplitude_input(amplitude_tensor)
+            amplitude_input = self._embed_amplitude_tensor(
+                self._validate_amplitude_input(amplitude_tensor)
+            )
             original_input_state = getattr(
                 self.computation_process, "input_state", None
             )
@@ -838,7 +862,9 @@ class QuantumLayer(MerlinModule):
             and isinstance(input_parameters[0], torch.Tensor)
             and input_parameters[0].is_complex()
         ):
-            amplitude_input = self._validate_amplitude_input(input_parameters[0])
+            amplitude_input = self._embed_amplitude_tensor(
+                self._validate_amplitude_input(input_parameters[0])
+            )
             original_input_state = getattr(
                 self.computation_process, "input_state", None
             )
@@ -1019,7 +1045,9 @@ class QuantumLayer(MerlinModule):
             raise ValueError(
                 "QuantumLayer configured with amplitude_encoding=True expects an amplitude tensor input."
             )
-        amplitude_input = self._validate_amplitude_input(inputs[0])
+        amplitude_input = self._embed_amplitude_tensor(
+            self._validate_amplitude_input(inputs[0])
+        )
         original_input_state = getattr(self.computation_process, "input_state", None)
         return amplitude_input, inputs[1:], original_input_state
 
@@ -1037,7 +1065,8 @@ class QuantumLayer(MerlinModule):
             yield
         finally:
             if original_input_state is not None:
-                self.set_input_state(original_input_state)
+                self.input_state = original_input_state
+                self.computation_process.input_state = original_input_state
 
     def _prepare_classical_parameters(
         self, inputs: list[torch.Tensor]

--- a/merlin/core/partial_measurement.py
+++ b/merlin/core/partial_measurement.py
@@ -167,8 +167,9 @@ class PartialMeasurement:
         assert grouped_probas.shape == (self.probability_tensor_shape), (
             "Inconsistent grouped probability tensor shape after grouping"
         )
+        batch_size = int(probas.size(0))
         assert self.probability_tensor_shape == (
-            probas.shape[0],
+            batch_size,
             output_size,
         ), "Inconsistent grouped probability tensor shape after grouping"
         return grouped_probas

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -24,7 +24,6 @@
 Quantum computation processes and factories.
 """
 
-import math
 from typing import Literal, overload
 
 import perceval as pcvl
@@ -137,6 +136,10 @@ class ComputationProcess(AbstractComputationProcess):
             state_tensor: torch.Tensor = self.input_state
             self._validate_superposition_state_shape(state_tensor)
 
+    def _input_basis_states(self) -> list[tuple[int, ...]]:
+        """Enumerate the full Fock basis used for superposition inputs."""
+        return Combinadics("fock", self.n_photons, self.m).enumerate_states()
+
     def _setup_computation_graphs(self):
         """Setup unitary and simulation computation graphs."""
         # Determine parameter specs
@@ -229,8 +232,9 @@ class ComputationProcess(AbstractComputationProcess):
 
         masked_input_state = (~mask).int().tolist()
 
+        fock_basis_states = self._input_basis_states()
         input_states = [
-            (k, self.simulation_graph.mapped_keys[k])
+            (k, fock_basis_states[k])
             for k, mask in enumerate(masked_input_state)
             if mask == 1
         ]
@@ -321,8 +325,8 @@ class ComputationProcess(AbstractComputationProcess):
               ``self.input_state`` live on the same device.
         """
 
-        # input state was validated by _prepare_superposition_tensor, ie: renormalized, typed, and converted from logical basis to fock basis (if shape did not match)
-        # we don't want anymore the logical basis but normalization and typing cannot hurt even if it is a small overhead
+        # The layer now hands ComputationProcess a full-Fock superposition
+        # tensor, so this step only validates, normalizes, and casts it.
         prepared_state = self._prepare_superposition_tensor()
 
         unitary = self.converter.to_tensor(*parameters)
@@ -335,8 +339,9 @@ class ComputationProcess(AbstractComputationProcess):
         # Find non-zero input states - for efficient processing of only not zero amplitude states
         mask = (prepared_state.real**2 + prepared_state.imag**2 < 1e-13).all(dim=0)
         masked_input_state = (~mask).int().tolist()
+        fock_basis_states = self._input_basis_states()
         input_states = [
-            (k, self.simulation_graph.mapped_keys[k])
+            (k, fock_basis_states[k])
             for k, mask in enumerate(masked_input_state)
             if mask == 1
         ]
@@ -409,30 +414,8 @@ class ComputationProcess(AbstractComputationProcess):
 
         return keys, amplitudes
 
-    def _expected_superposition_size(self) -> int:
-        """Expected number of Fock states given current computation space."""
-        if self.n_photons < 0:
-            raise ValueError("Number of photons must be non-negative.")
-        if self.computation_space is ComputationSpace.DUAL_RAIL:
-            if self.n_photons is None:
-                raise ValueError("Dual-rail encoding requires 'n_photons'.")
-            if self.m != 2 * self.n_photons:
-                raise ValueError(
-                    "Dual-rail encoding requires the number of modes to equal 2 * n_photons."
-                )
-            # Dual-rail limits to 2**n logical states (one photon per rail pair).
-            return 2**self.n_photons
-        if self.computation_space is ComputationSpace.UNBUNCHED:
-            if self.n_photons > self.m:
-                raise ValueError(
-                    "Invalid configuration: ComputationSpace.UNBUNCHED requires "
-                    "n_photons to be less than or equal to the number of modes."
-                )
-            return math.comb(self.m, self.n_photons)
-        return math.comb(self.m + self.n_photons - 1, self.n_photons)
-
     def _validate_superposition_state_shape(self, input_state: torch.Tensor) -> None:
-        """Ensure the provided superposition state matches the configured computation space."""
+        """Ensure the provided superposition state matches the full Fock basis."""
         if not isinstance(input_state, torch.Tensor):
             raise TypeError("Input state should be a tensor")
 
@@ -445,96 +428,13 @@ class ComputationProcess(AbstractComputationProcess):
                 f"Superposed input state must be 1D or 2D tensor, got shape {tuple(input_state.shape)}"
             )
 
-        expected = self._expected_superposition_size()
+        expected = Combinadics("fock", self.n_photons, self.m).compute_space_size()
         if state_dim != expected:
-            if (
-                self.computation_space is ComputationSpace.DUAL_RAIL
-                and state_dim == len(self.simulation_graph.mapped_keys)
-            ):
-                return
-            if self.computation_space is ComputationSpace.DUAL_RAIL:
-                explanation = (
-                    f"expected 2**n_photons = 2**{self.n_photons} = {expected}"
-                )
-            elif self.computation_space is ComputationSpace.UNBUNCHED:
-                explanation = f"expected C(m, n_photons) = C({self.m}, {self.n_photons}) = {expected}"
-            else:
-                explanation = (
-                    f"expected C(m + n_photons - 1, n_photons) = "
-                    f"C({self.m + self.n_photons - 1}, {self.n_photons}) = {expected}"
-                )
             raise ValueError(
-                "Input state dimension mismatch for computation_space "
-                f"'{self.computation_space}': got {state_dim}, {explanation}."
+                "Input state dimension mismatch for Fock basis: "
+                f"got {state_dim}, expected C(m + n_photons - 1, n_photons) = "
+                f"C({self.m + self.n_photons - 1}, {self.n_photons}) = {expected}."
             )
-
-    def _should_defer_state_validation(self, tensor: torch.Tensor) -> bool:
-        """Detect amplitude tensors that will be validated after configuring dual-rail space."""
-        if tensor.dim() == 1:
-            state_dim = tensor.shape[0]
-        elif tensor.dim() == 2:
-            state_dim = tensor.shape[1]
-        else:
-            return False
-
-        if self.n_photons is None or self.m is None:
-            return False
-
-        return (
-            self.computation_space is ComputationSpace.UNBUNCHED
-            and self.m == 2 * self.n_photons
-            and state_dim == 2**self.n_photons
-        )
-
-    def _coerce_superposition_tensor_shape(
-        self, tensor: torch.Tensor
-    ) -> torch.Tensor | None:
-        """Attempt to reconcile tensors encoded in a smaller logical basis."""
-        if self.computation_space is not ComputationSpace.FOCK:
-            return None
-
-        if self.n_photons is None or self.m is None:
-            return None
-
-        if tensor.dim() == 1:
-            feature_dim = tensor.shape[0]
-        elif tensor.dim() == 2:
-            feature_dim = tensor.shape[1]
-        else:
-            return None
-
-        # Detect tensors encoded in the UNBUNCHED basis and lift them to the Fock basis.
-        unbunched_size = math.comb(self.m, self.n_photons)
-        if feature_dim != unbunched_size:
-            return None
-
-        mapped_keys = [
-            tuple(key)
-            for key in self.simulation_graph.mapped_keys  # type: ignore[attr-defined]
-        ]
-        key_to_index = {state: idx for idx, state in enumerate(mapped_keys)}
-
-        try:
-            combinator = Combinadics("unbunched", self.n_photons, self.m)
-        except ValueError:
-            return None
-
-        indices: list[int] = []
-        for state in combinator.iter_states():
-            index = key_to_index.get(state)
-            if index is None:
-                return None
-            indices.append(index)
-
-        target_dim = len(mapped_keys)
-        if tensor.dim() == 1:
-            expanded = tensor.new_zeros(target_dim)
-            expanded[indices] = tensor
-        else:
-            expanded = tensor.new_zeros(tensor.shape[0], target_dim)
-            expanded[:, indices] = tensor
-
-        return expanded
 
     def _prepare_superposition_tensor(self) -> torch.Tensor:
         """Validate, normalise, and convert the stored superposition state to the correct dtype."""
@@ -542,10 +442,6 @@ class ComputationProcess(AbstractComputationProcess):
             raise TypeError("Input state should be a tensor")
 
         tensor = self.input_state
-
-        coerced = self._coerce_superposition_tensor_shape(tensor)
-        if coerced is not None:
-            tensor = coerced
 
         self._validate_superposition_state_shape(tensor)
 

--- a/merlin/core/state_vector.py
+++ b/merlin/core/state_vector.py
@@ -41,6 +41,7 @@ import torch
 
 from ..utils.combinadics import Combinadics
 from ..utils.dtypes import complex_dtype_for
+from .computation_space import ComputationSpace
 
 Scalar = float | int | complex
 
@@ -153,6 +154,128 @@ def _ensure_last_dim(tensor: torch.Tensor, expected: int) -> None:
         raise ValueError(
             f"Tensor last dimension {tensor.shape[-1]} does not match basis size {expected}."
         )
+
+
+def _remap_last_dim(
+    tensor: torch.Tensor, indices: list[int], target_dim: int
+) -> torch.Tensor:
+    if tensor.is_sparse:
+        coalesced = tensor.coalesce()
+        sparse_indices = coalesced.indices().clone()
+        sparse_values = coalesced.values()
+        if sparse_indices.numel() == 0:
+            shape = list(coalesced.shape)
+            shape[-1] = target_dim
+            return torch.sparse_coo_tensor(
+                sparse_indices,
+                sparse_values,
+                tuple(shape),
+                device=coalesced.device,
+            )
+        index_lookup = torch.tensor(indices, dtype=torch.long, device=coalesced.device)
+        sparse_indices[-1] = index_lookup[sparse_indices[-1]]
+        shape = list(coalesced.shape)
+        shape[-1] = target_dim
+        return torch.sparse_coo_tensor(
+            sparse_indices,
+            sparse_values,
+            tuple(shape),
+            device=coalesced.device,
+        )
+
+    expanded_shape = list(tensor.shape)
+    expanded_shape[-1] = target_dim
+    expanded = tensor.new_zeros(tuple(expanded_shape))
+    index_tensor = torch.tensor(indices, dtype=torch.long, device=tensor.device)
+    expanded.index_copy_(-1, index_tensor, tensor)
+    return expanded
+
+
+def embed_tensor_in_fock_basis(
+    tensor: torch.Tensor,
+    *,
+    n_modes: int,
+    n_photons: int,
+    computation_space: ComputationSpace | str,
+) -> torch.Tensor:
+    """Embed a compact logical tensor into the full Fock basis when applicable.
+
+    Parameters
+    ----------
+    tensor : torch.Tensor
+        Dense or sparse amplitude tensor in either Fock ordering or a compact
+        logical ordering compatible with the provided computation space.
+    n_modes : int
+        Number of photonic modes.
+    n_photons : int
+        Total number of photons.
+    computation_space : ComputationSpace | str
+        Logical ordering associated with ``tensor``.
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor expressed in the full Fock basis. If ``tensor`` is already in
+        Fock ordering, it is returned unchanged.
+
+    Raises
+    ------
+    ValueError
+        If the tensor shape is not compatible with a supported compact input
+        ordering.
+    """
+    if tensor.dim() == 0:
+        raise ValueError("Amplitude input must be at least one-dimensional.")
+
+    feature_dim = tensor.shape[-1]
+    fock_basis = Combinadics("fock", n_photons, n_modes)
+    fock_size = fock_basis.compute_space_size()
+    if feature_dim == fock_size:
+        return tensor
+
+    space = ComputationSpace.coerce(computation_space)
+    candidate_schemes: list[str] = []
+    if space is ComputationSpace.UNBUNCHED:
+        candidate_schemes.append("unbunched")
+    elif space is ComputationSpace.DUAL_RAIL:
+        candidate_schemes.append("dual_rail")
+    elif space is ComputationSpace.FOCK:
+        # Preserve the current compact-input behaviour for collision-free
+        # states in Fock mode until explicit encoding selection lands.
+        candidate_schemes.append("unbunched")
+
+    for scheme in candidate_schemes:
+        try:
+            logical_basis = Combinadics(scheme, n_photons, n_modes)
+        except ValueError:
+            continue
+        if feature_dim != logical_basis.compute_space_size():
+            continue
+        indices = [fock_basis.fock_to_index(state) for state in logical_basis]
+        return _remap_last_dim(tensor, indices, fock_size)
+
+    if space is ComputationSpace.FOCK:
+        detail = (
+            f"expected either Fock size {fock_size} or compact unbunched size "
+            f"{Combinadics('unbunched', n_photons, n_modes).compute_space_size()}"
+            if n_photons <= n_modes
+            else f"expected Fock size {fock_size}"
+        )
+    elif space is ComputationSpace.UNBUNCHED:
+        detail = (
+            f"expected compact unbunched size "
+            f"{Combinadics('unbunched', n_photons, n_modes).compute_space_size()} "
+            f"or full Fock size {fock_size}"
+        )
+    else:
+        detail = (
+            f"expected compact dual_rail size "
+            f"{Combinadics('dual_rail', n_photons, n_modes).compute_space_size()} "
+            f"or full Fock size {fock_size}"
+        )
+    raise ValueError(
+        f"Amplitude input dimension mismatch: got {feature_dim}, {detail}."
+    )
 
 
 def _basic_state_counts(state: Sequence[int] | pcvl.BasicState) -> tuple[int, ...]:

--- a/tests/algorithms/test_amplitude_encoding.py
+++ b/tests/algorithms/test_amplitude_encoding.py
@@ -23,6 +23,7 @@ import torch
 
 from merlin import ComputationSpace
 from merlin.algorithms.layer import QuantumLayer
+from merlin.core.state_vector import StateVector
 from merlin.measurement.strategies import MeasurementStrategy
 
 
@@ -596,6 +597,61 @@ def test_amplitude_encoding_superposition_matches_basis_sum():
 
     with pytest.raises(ValueError, match="Amplitude input expects"):
         layer(torch.ones(layer.input_size + 1, dtype=torch.complex64))
+
+
+def test_fock_amplitude_encoding_accepts_compact_unbunched_tensor():
+    m, n = 4, 2
+    layer = QuantumLayer(
+        circuit=pcvl.Circuit(m),
+        n_photons=n,
+        measurement_strategy=MeasurementStrategy.amplitudes(
+            computation_space=ComputationSpace.FOCK
+        ),
+    )
+
+    logical = torch.zeros(math.comb(m, n), dtype=torch.complex64)
+    logical[0] = 1.0 + 0.0j
+
+    embedded, _, _ = layer._prepare_amplitude_input([logical])
+    out = layer(logical)
+
+    assert out.shape[-1] == len(layer.output_keys)
+    assert embedded.shape[-1] == math.comb(m + n - 1, n)
+
+
+def test_fock_amplitude_encoding_accepts_compact_unbunched_statevector():
+    m, n = 4, 2
+    layer = QuantumLayer(
+        circuit=pcvl.Circuit(m),
+        n_photons=n,
+        measurement_strategy=MeasurementStrategy.amplitudes(
+            computation_space=ComputationSpace.FOCK
+        ),
+    )
+
+    logical = torch.zeros(math.comb(m, n), dtype=torch.complex64)
+    logical[0] = 1.0 + 0.0j
+    sv = StateVector(logical, n_modes=m, n_photons=n)
+
+    out = layer(sv)
+
+    assert out.shape[-1] == len(layer.output_keys)
+
+
+def test_fock_amplitude_encoding_rejects_non_coercible_compact_shape():
+    m, n = 4, 2
+    layer = QuantumLayer(
+        circuit=pcvl.Circuit(m),
+        n_photons=n,
+        measurement_strategy=MeasurementStrategy.amplitudes(
+            computation_space=ComputationSpace.FOCK
+        ),
+    )
+
+    invalid = torch.zeros(math.comb(m, n) + 1, dtype=torch.complex64)
+
+    with pytest.raises(ValueError, match="Amplitude input expects"):
+        layer(invalid)
 
 
 @pytest.mark.parametrize(

--- a/tests/algorithms/test_compute_ebs_simultaneously.py
+++ b/tests/algorithms/test_compute_ebs_simultaneously.py
@@ -19,6 +19,7 @@ import torch
 from merlin import QuantumLayer
 from merlin.core.computation_space import ComputationSpace
 from merlin.core.process import ComputationProcess
+from merlin.core.state_vector import embed_tensor_in_fock_basis
 from merlin.measurement.strategies import MeasurementStrategy
 
 
@@ -69,6 +70,12 @@ class TestComputeEbsSimultaneously:
         self.input_state_tensor = torch.rand(2, expected_states, dtype=torch.float64)
         sum_values = self.input_state_tensor.abs().pow(2).sum(dim=1).sqrt().unsqueeze(1)
         self.input_state_tensor = self.input_state_tensor / sum_values
+        self.embedded_input_state = embed_tensor_in_fock_basis(
+            self.input_state_tensor,
+            n_modes=self.circuit.m,
+            n_photons=2,
+            computation_space=ComputationSpace.UNBUNCHED,
+        )
         # Set up parameters
         self.trainable_parameters = ["phi"]
         self.input_parameters = []
@@ -89,7 +96,7 @@ class TestComputeEbsSimultaneously:
         )
         # Create computation process
         self.process = self.layer.computation_process
-        self.process.input_state = self.input_state_tensor
+        self.process.input_state = self.embedded_input_state
 
         # Create test parameters
         self.test_parameters = self.layer.prepare_parameters([])
@@ -149,10 +156,16 @@ class TestComputeEbsSimultaneously:
 
     def test_edge_case_single_state(self):
         """Test with input state that has only one non-zero component."""
-        # Create input state with only one non-zero component
-        expected_states = math.comb(self.circuit.m, self.n_photons)
-        single_state = torch.zeros(1, expected_states, dtype=torch.float64)
-        single_state[0, 0] = 1.0
+        compact_state = torch.zeros(
+            1, math.comb(self.circuit.m, self.n_photons), dtype=torch.float64
+        )
+        compact_state[0, 0] = 1.0
+        single_state = embed_tensor_in_fock_basis(
+            compact_state,
+            n_modes=self.circuit.m,
+            n_photons=self.n_photons,
+            computation_space=ComputationSpace.UNBUNCHED,
+        )
 
         process_single = ComputationProcess(
             circuit=self.circuit,
@@ -174,7 +187,7 @@ class TestComputeEbsSimultaneously:
     def test_dtype_consistency(self):
         """Test that dtype is handled correctly."""
         # Test with float32
-        input_state_f32 = self.input_state_tensor.to(torch.float32)
+        input_state_f32 = self.embedded_input_state.to(torch.float32)
         process_f32 = ComputationProcess(
             circuit=self.circuit,
             input_state=input_state_f32,
@@ -195,8 +208,8 @@ class TestComputeEbsSimultaneously:
     def test_invalid_superposition_dimension_no_bunching(self):
         """Input state with mismatched dimension should raise a ValueError."""
         invalid_state = torch.rand(
-            self.input_state_tensor.shape[0],
-            self.input_state_tensor.shape[1] - 1,
+            self.embedded_input_state.shape[0],
+            self.embedded_input_state.shape[1] - 1,
             dtype=self.input_state_tensor.dtype,
             device=self.input_state_tensor.device,
         )

--- a/tests/algorithms/test_superposition_state.py
+++ b/tests/algorithms/test_superposition_state.py
@@ -367,6 +367,7 @@ class TestOutputSuperposedState:
         coefficients = amplitude_layer.computation_process.input_state.to(output.dtype)
         if coefficients.dim() == 1:
             coefficients = coefficients.unsqueeze(0)
+        fock_basis = Combinadics("fock", n_photons, n_modes)
 
         shared_state = amplitude_layer.state_dict()
         amplitude_params = amplitude_layer.prepare_parameters([dummy_input])
@@ -379,7 +380,7 @@ class TestOutputSuperposedState:
         amplitude_params_dict = dict(amplitude_layer.named_parameters())
 
         expected_amplitudes = torch.zeros_like(output, dtype=output.dtype)
-        for idx, state in enumerate(amplitude_layer.output_keys):
+        for state in amplitude_layer.output_keys:
             basis_layer = QuantumLayer(
                 circuit=copy.deepcopy(circuit),
                 n_photons=n_photons,
@@ -419,7 +420,9 @@ class TestOutputSuperposedState:
                 basis_output = basis_output.unsqueeze(0).unsqueeze(1)
             basis_output = basis_output.to(expected_amplitudes.dtype)
 
-            coefficient = coefficients[:, idx].to(expected_amplitudes.dtype)
+            coefficient = coefficients[:, fock_basis.index(state)].to(
+                expected_amplitudes.dtype
+            )
             weight = coefficient.unsqueeze(0).unsqueeze(-1)
             if weight.abs().max() < 1e-10:
                 continue


### PR DESCRIPTION
<!--
Thank you for contributing to MerLin!
Please fill out the sections below to help us review your PR efficiently.

NOTE: this repo is a public repository, therefore, do NOT paste Jira URLs. Use the Jira issue key only (e.g., PML-126).
The Jira–GitHub integration will link PRs/commits automatically when the key is present.
-->

<!-- Add the Jira issue key in the title -->
<!-- e.g., PML-126 Updating PR template -->

## Summary
Relaxes early amplitude-length validation so compact logical amplitudes can flow through the shared embedding path before execution.

## Related Issue
Related Jira: PML-265

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor / Cleanup
- [ ] Performance improvement
- [ ] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)

## Proposed changes
- Updates `QuantumLayer` amplitude handling to accept coercible compact logical tensors.
- Routes amplitude inputs through the shared embedding path instead of ad hoc process coercion.
- Removes redundant logical-to-Fock coercion from `ComputationProcess`.
- Preserves compatibility for existing `StateVector` and complex tensor inputs.

## How to test / How to run
1. Command lines

```bash
pytest tests/algorithms/test_amplitude_encoding.py tests/algorithms/test_compute_ebs_simultaneously.py tests/algorithms/test_superposition_state.py -q
ruff format --check merlin/algorithms/layer.py merlin/core/process.py tests/algorithms/test_amplitude_encoding.py tests/algorithms/test_compute_ebs_simultaneously.py tests/algorithms/test_superposition_state.py
ruff check merlin/algorithms/layer.py merlin/core/process.py tests/algorithms/test_amplitude_encoding.py tests/algorithms/test_compute_ebs_simultaneously.py tests/algorithms/test_superposition_state.py
mypy --ignore-missing-imports --no-strict-optional --allow-untyped-defs --disable-error-code=no-redef merlin/algorithms/layer.py merlin/core/process.py
```

## Screenshots / Logs (optional)
No UI changes.

## Performance considerations (optional)
This is mostly a contract cleanup. Any performance improvement comes indirectly from removing redundant coercion.

## Documentation
- [ ] User docs updated (Sphinx)
- [ ] Examples / notebooks updated
- [x] Docstrings updated
- [ ] Updated the API

## Checklist
- [x] PR title includes Jira issue key (e.g., PML-126)
- [x] "Related Jira ticket" section includes the Jira issue key (no URL)
- [x] Code formatted (ruff format)
- [x] Lint passes (ruff)
- [x] Static typing passes (mypy) if applicable
- [x] Unit tests added/updated (pytest)
- [x] Tests pass locally (pytest)
- [ ] Tests pass on GPU (pytest)
- [x] Test coverage not decreased significantly
- [ ] Docs build locally if affected (sphinx)
- [ ] With this command:

        > SPHINXOPTS="-W --keep-going -n" make -C docs clean html

    the docs are built without any warning or errors.
- [ ] New public classes/methods/packages are added in the API following the methodology presented in other files.
- [ ] Dependencies updated (if needed) and pinned appropriately
- [x] PR description explains what changed and how to validate it


<!-- Helpful local commands – run from repo root:

# Lint & format
ruff format && ruff check .

# Type check (if used)
mypy .

# Tests with coverage
pytest

# Build docs
pip install -e .[docs] && make -C docs html

-->
