### PR TITLE
PML-270 +271 from_tensor encodingspace + observability

### DIFF
--- a/benchmarks/benchmark_superposition_streaming.py
+++ b/benchmarks/benchmark_superposition_streaming.py
@@ -54,6 +54,12 @@ import torch
 import merlin.core.process as process_module
 from merlin import ComputationSpace, MeasurementStrategy, QuantumLayer
 
+try:
+    from merlin.core import EncodingSpace, StateVector
+except ImportError:  # pragma: no cover - supports running against older baselines
+    EncodingSpace = None  # type: ignore[assignment]
+    StateVector = None  # type: ignore[assignment]
+
 
 @dataclass(frozen=True)
 class Case:
@@ -217,6 +223,35 @@ def _make_dense_input(size: int, nnz: int) -> torch.Tensor:
     return state / state.abs().pow(2).sum().sqrt()
 
 
+def _make_logical_dual_rail_input(size: int) -> torch.Tensor:
+    """Create a normalized logical dual-rail vector with deterministic phases."""
+    values = torch.arange(1, size + 1, dtype=torch.float32)
+    state = torch.complex(values, torch.flip(values, dims=(0,)))
+    return state / state.abs().pow(2).sum().sqrt()
+
+
+def _manual_dual_rail_embedding(
+    logical: torch.Tensor, *, n_modes: int, n_photons: int
+) -> torch.Tensor:
+    """Embed dual-rail amplitudes using explicit zero-fill and index placement."""
+    if EncodingSpace is None:
+        raise RuntimeError("EncodingSpace is not available.")
+
+    fock_size = math.comb(n_modes + n_photons - 1, n_photons)
+    fock_indices = torch.tensor(
+        list(
+            EncodingSpace.DUAL_RAIL.logical_to_fock_indices(
+                n_modes=n_modes, n_photons=n_photons
+            ).values()
+        ),
+        dtype=torch.long,
+        device=logical.device,
+    )
+    embedded = logical.new_zeros((*logical.shape[:-1], fock_size))
+    embedded.index_copy_(-1, fock_indices, logical)
+    return embedded
+
+
 def _output_values(output: torch.Tensor) -> dict[str, Any]:
     """Return a JSON-serializable complex output vector for comparison."""
     flat = output.detach().cpu().reshape(-1)
@@ -282,6 +317,133 @@ def _run_case(
     return result
 
 
+def _mean_timed_call(runs: int, warmups: int, callback) -> tuple[float, list[float]]:
+    timings: list[float] = []
+    for index in range(warmups + runs):
+        start = time.perf_counter()
+        result = callback()
+        if isinstance(result, torch.Tensor):
+            # Force eager tensor work to complete before measuring the elapsed time.
+            _ = float(result.detach().abs().sum().cpu())
+        elapsed = time.perf_counter() - start
+        if index >= warmups:
+            timings.append(elapsed)
+        del result
+        gc.collect()
+    return mean(timings), timings
+
+
+def _run_encoding_api_check(runs: int, warmups: int) -> dict[str, Any]:
+    """Compare encoding-aware from_tensor with an explicitly embedded tensor."""
+    if EncodingSpace is None or StateVector is None:
+        return {
+            "name": "statevector_from_tensor_dual_rail_vs_manual",
+            "status": "skipped",
+            "reason": "EncodingSpace or StateVector is unavailable on this revision.",
+        }
+    if not hasattr(EncodingSpace.DUAL_RAIL, "logical_basis_size"):
+        return {
+            "name": "statevector_from_tensor_dual_rail_vs_manual",
+            "status": "skipped",
+            "reason": "EncodingSpace.logical_basis_size is unavailable on this revision.",
+        }
+
+    n_modes = 6
+    n_photons = 3
+    chunk_size = 4
+    logical_size = EncodingSpace.DUAL_RAIL.logical_basis_size(
+        n_modes=n_modes, n_photons=n_photons
+    )
+    fock_size = math.comb(n_modes + n_photons - 1, n_photons)
+    logical_input = _make_logical_dual_rail_input(logical_size)
+
+    try:
+        api_state = StateVector.from_tensor(
+            logical_input,
+            n_modes=n_modes,
+            n_photons=n_photons,
+            encoding=EncodingSpace.DUAL_RAIL,
+        )
+    except TypeError as exc:
+        return {
+            "name": "statevector_from_tensor_dual_rail_vs_manual",
+            "status": "skipped",
+            "reason": f"StateVector.from_tensor does not accept encoding: {exc}",
+        }
+
+    manual_tensor = _manual_dual_rail_embedding(
+        logical_input, n_modes=n_modes, n_photons=n_photons
+    )
+    tensor_diff = (api_state.tensor - manual_tensor).abs()
+
+    torch.manual_seed(1234)
+    layer = _make_layer(
+        Case(
+            "encoding_api_dual_rail_m6_p3_chunk4",
+            n_modes=n_modes,
+            n_photons=n_photons,
+            nnz=logical_size,
+            chunk_size=chunk_size,
+        )
+    )
+    api_output = layer(api_state, simultaneous_processes=chunk_size)
+    manual_output = layer(manual_tensor, simultaneous_processes=chunk_size)
+    output_diff = (api_output - manual_output).abs()
+    probability_diff = (api_output.abs().pow(2) - manual_output.abs().pow(2)).abs()
+
+    api_from_tensor_mean_s, api_from_tensor_times_s = _mean_timed_call(
+        runs,
+        warmups,
+        lambda: StateVector.from_tensor(
+            logical_input,
+            n_modes=n_modes,
+            n_photons=n_photons,
+            encoding=EncodingSpace.DUAL_RAIL,
+        ).tensor,
+    )
+    manual_embedding_mean_s, manual_embedding_times_s = _mean_timed_call(
+        runs,
+        warmups,
+        lambda: _manual_dual_rail_embedding(
+            logical_input, n_modes=n_modes, n_photons=n_photons
+        ),
+    )
+    api_forward_mean_s, api_forward_times_s = _mean_timed_call(
+        runs,
+        warmups,
+        lambda: layer(api_state, simultaneous_processes=chunk_size),
+    )
+    manual_forward_mean_s, manual_forward_times_s = _mean_timed_call(
+        runs,
+        warmups,
+        lambda: layer(manual_tensor, simultaneous_processes=chunk_size),
+    )
+
+    return {
+        "name": "statevector_from_tensor_dual_rail_vs_manual",
+        "status": "passed",
+        "encoding": "dual_rail",
+        "n_modes": n_modes,
+        "n_photons": n_photons,
+        "logical_size": logical_size,
+        "fock_size": fock_size,
+        "chunk_size": chunk_size,
+        "runs": runs,
+        "warmups": warmups,
+        "tensor_max_abs_diff": float(tensor_diff.max().item()),
+        "output_max_abs_diff": float(output_diff.max().item()),
+        "output_max_probability_diff": float(probability_diff.max().item()),
+        "api_from_tensor_mean_s": api_from_tensor_mean_s,
+        "api_from_tensor_times_s": api_from_tensor_times_s,
+        "manual_embedding_mean_s": manual_embedding_mean_s,
+        "manual_embedding_times_s": manual_embedding_times_s,
+        "api_forward_mean_s": api_forward_mean_s,
+        "api_forward_times_s": api_forward_times_s,
+        "manual_forward_mean_s": manual_forward_mean_s,
+        "manual_forward_times_s": manual_forward_times_s,
+    }
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--label", required=True, help="Human label for this run.")
@@ -307,6 +469,11 @@ def parse_args() -> argparse.Namespace:
         action="append",
         choices=[case.name for case in DEFAULT_CASES],
         help="Run one or more named cases. Defaults to all cases.",
+    )
+    parser.add_argument(
+        "--no-encoding-api-check",
+        action="store_true",
+        help="Skip the StateVector.from_tensor(..., encoding=...) benchmark check.",
     )
     return parser.parse_args()
 
@@ -334,6 +501,9 @@ def main() -> int:
         "platform": platform.platform(),
         "torch": torch.__version__,
         "pid": os.getpid(),
+        "encoding_api_check": None
+        if args.no_encoding_api_check
+        else _run_encoding_api_check(args.runs, args.warmups),
         "cases": [
             _run_case(
                 case,

--- a/docs/source/api_reference/api/merlin.core.encoding_space.rst
+++ b/docs/source/api_reference/api/merlin.core.encoding_space.rst
@@ -10,6 +10,6 @@ EncodingSpace
 -------------
 
 .. autoclass:: EncodingSpace
-   :members: qloq, parameters, n_modes, n_photons, basis_size, resolved_modes_per_photon, logical_basis_states, fock_basis_states, logical_to_fock_map, logical_to_fock_indices
+   :members: qloq, parameters, n_modes, n_photons, basis_size, resolved_modes_per_photon, logical_basis_size, embed, logical_basis_states, fock_basis_states, logical_to_fock_map, logical_to_fock_indices
    :member-order: bysource
    :show-inheritance:

--- a/docs/source/api_reference/api/merlin.core.state_vector.rst
+++ b/docs/source/api_reference/api/merlin.core.state_vector.rst
@@ -10,7 +10,7 @@ StateVector
 -----------
 
 .. autoclass:: StateVector
-   :members: from_basic_state, from_tensor, from_perceval, tensor_product, to_perceval, index, memory_bytes, __getitem__, __add__, __sub__, __mul__, to_dense, to, clone, detach, requires_grad_, normalize, basis, basis_size, is_sparse, is_normalized
+   :members: from_basic_state, from_tensor, from_perceval, tensor_product, to_perceval, index, logical_to_fock_map, memory_bytes, __getitem__, __add__, __sub__, __mul__, to_dense, to, clone, detach, requires_grad_, normalize, basis, basis_size, is_sparse, is_normalized
    :member-order: bysource
    :show-inheritance:
 
@@ -37,8 +37,8 @@ Constructors
    assert not sv_dense.is_sparse
 
 **from_tensor** — wrap a real or complex tensor with Fock metadata.
-Real data is auto-promoted to complex.  The last dimension must match the
-basis size :math:`\binom{n\_modes + n\_photons - 1}{n\_photons}`:
+Real data is auto-promoted to complex. By default, the last dimension must match
+the Fock basis size :math:`\binom{n\_modes + n\_photons - 1}{n\_photons}`:
 
 .. code-block:: python
 
@@ -53,6 +53,26 @@ basis size :math:`\binom{n\_modes + n\_photons - 1}{n\_photons}`:
    batch = torch.randn(32, 10)
    sv_batch = StateVector.from_tensor(batch, n_modes=4, n_photons=2)
    assert sv_batch.shape == (32, 10)
+
+Pass ``encoding=...`` to provide compact logical amplitudes and embed them into
+the Fock basis immediately:
+
+.. code-block:: python
+
+   import torch
+   from merlin.core import EncodingSpace
+   from merlin.core.state_vector import StateVector
+
+   logical = torch.zeros(4, dtype=torch.complex64)
+   logical[0] = 1.0
+   sv = StateVector.from_tensor(
+       logical,
+       n_modes=4,
+       n_photons=2,
+       encoding=EncodingSpace.DUAL_RAIL,
+   )
+   assert sv.tensor.shape[-1] == 10
+   assert sv.encoding is EncodingSpace.DUAL_RAIL
 
 **from_perceval** — convert from a Perceval ``StateVector``:
 
@@ -96,6 +116,23 @@ underlying tensor:
 
    sv.basis_size     # 10 for (4 modes, 2 photons)
    list(sv.basis)[:3]  # [(2,0,0,0), (1,1,0,0), (1,0,1,0)]
+
+``logical_to_fock_map()`` exposes the logical-to-Fock index assignment used by
+the stored encoding:
+
+.. code-block:: python
+
+   import torch
+   from merlin.core import EncodingSpace
+   from merlin.core.state_vector import StateVector
+
+   sv = StateVector.from_tensor(
+       torch.zeros(4, dtype=torch.complex64),
+       n_modes=4,
+       n_photons=2,
+       encoding=EncodingSpace.DUAL_RAIL,
+   )
+   sv.logical_to_fock_map()  # {(0, 0): 2, (0, 1): 3, (1, 0): 5, (1, 1): 6}
 
 
 Amplitude lookup

--- a/docs/source/api_reference/api/merlin.core.state_vector.rst
+++ b/docs/source/api_reference/api/merlin.core.state_vector.rst
@@ -55,7 +55,9 @@ the Fock basis size :math:`\binom{n\_modes + n\_photons - 1}{n\_photons}`:
    assert sv_batch.shape == (32, 10)
 
 Pass ``encoding=...`` to provide compact logical amplitudes and embed them into
-the Fock basis immediately:
+the Fock basis immediately. Structured encodings can infer their physical
+metadata from the encoding contract. Explicit ``n_modes`` and ``n_photons`` are
+also accepted, but they validate the contract rather than stretching it:
 
 .. code-block:: python
 
@@ -67,12 +69,23 @@ the Fock basis immediately:
    logical[0] = 1.0
    sv = StateVector.from_tensor(
        logical,
-       n_modes=4,
-       n_photons=2,
        encoding=EncodingSpace.DUAL_RAIL,
    )
+   assert sv.n_modes == 4
+   assert sv.n_photons == 2
    assert sv.tensor.shape[-1] == 10
    assert sv.encoding is EncodingSpace.DUAL_RAIL
+
+   # QLOQ dimensions are inferred from the qubit groups.
+   qloq = EncodingSpace.qloq(qubit_groups=[2, 1])
+   sv_qloq = StateVector.from_tensor(torch.zeros(8), encoding=qloq)
+   assert sv_qloq.n_modes == 6
+   assert sv_qloq.n_photons == 2
+
+   # Add auxiliary vacuum modes after constructing the encoded state.
+   padded = sv @ [0]
+   assert padded.n_modes == 5
+   assert padded.n_photons == 2
 
 **from_perceval** — convert from a Perceval ``StateVector``:
 
@@ -128,8 +141,6 @@ the stored encoding:
 
    sv = StateVector.from_tensor(
        torch.zeros(4, dtype=torch.complex64),
-       n_modes=4,
-       n_photons=2,
        encoding=EncodingSpace.DUAL_RAIL,
    )
    sv.logical_to_fock_map()  # {(0, 0): 2, (0, 1): 3, (1, 0): 5, (1, 1): 6}

--- a/docs/source/user_guide/angle_amplitude_encoding.rst
+++ b/docs/source/user_guide/angle_amplitude_encoding.rst
@@ -337,6 +337,39 @@ internally — and validates that the last dimension matches the Fock basis size
    normalizing upstream (e.g. via ``nn.functional.normalize``) can improve
    numerical stability during training.
 
+Structured input encodings can infer their own dimensions. For example,
+dual-rail infers ``n_photons`` from the logical tensor width and sets
+``n_modes = 2 * n_photons``. QLOQ and other partitioned encodings infer
+``n_modes`` and ``n_photons`` from their ``modes_per_photon`` contract. The
+resolved values are available on the returned object:
+
+.. code-block:: python
+
+    import torch
+    from merlin.core import EncodingSpace
+    from merlin.core.state_vector import StateVector
+
+    dual_rail = StateVector.from_tensor(
+        torch.zeros(4),
+        encoding=EncodingSpace.DUAL_RAIL,
+    )
+    assert dual_rail.n_modes == 4
+    assert dual_rail.n_photons == 2
+
+    qloq = EncodingSpace.qloq(qubit_groups=[2, 1])
+    qloq_state = StateVector.from_tensor(torch.zeros(8), encoding=qloq)
+    assert qloq_state.n_modes == 6
+    assert qloq_state.n_photons == 2
+
+If a circuit needs auxiliary vacuum modes, append them after constructing the
+encoded state:
+
+.. code-block:: python
+
+    padded = dual_rail @ [0]
+    assert padded.n_modes == 5
+    assert padded.n_photons == 2
+
 
 Using a complex tensor directly
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/merlin/algorithms/kernels.py
+++ b/merlin/algorithms/kernels.py
@@ -963,8 +963,7 @@ class FidelityKernel(MerlinModule):
             ])
             if isinstance(x2, torch.Tensor):
                 U_adjoint = torch.stack([
-                    self.feature_map
-                    .compute_unitary(x)
+                    self.feature_map.compute_unitary(x)
                     .transpose(0, 1)
                     .conj()
                     .to(x1.device)

--- a/merlin/core/encoding_space.py
+++ b/merlin/core/encoding_space.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from itertools import product
 from typing import ClassVar
 
+import torch
+
 from merlin.utils.combinadics import Combinadics
 
 TupleInt = tuple[int, ...]
@@ -170,6 +172,68 @@ class EncodingSpace:
             )
             return (2,) * resolved_photons
         return None
+
+    def logical_basis_size(
+        self, *, n_modes: int | None = None, n_photons: int | None = None
+    ) -> int:
+        """Return the logical tensor width expected before Fock embedding."""
+
+        return self.basis_size(n_modes=n_modes, n_photons=n_photons)
+
+    def embed(
+        self,
+        tensor: torch.Tensor,
+        *,
+        n_modes: int | None = None,
+        n_photons: int | None = None,
+    ) -> torch.Tensor:
+        """Embed a logical amplitude tensor into canonical full-Fock ordering."""
+
+        if tensor.dim() == 0:
+            raise ValueError("Amplitude tensor must be at least one-dimensional.")
+
+        logical_size = self.logical_basis_size(n_modes=n_modes, n_photons=n_photons)
+        if tensor.shape[-1] != logical_size:
+            raise ValueError(
+                "Tensor last dimension does not match the logical basis size "
+                f"for encoding '{self.kind}': got {tensor.shape[-1]}, expected {logical_size}."
+            )
+
+        resolved_modes, resolved_photons = self._resolve_dimensions(
+            n_modes=n_modes, n_photons=n_photons
+        )
+        fock_size = Combinadics(
+            "fock", resolved_photons, resolved_modes
+        ).compute_space_size()
+        if self.kind == "fock":
+            return tensor
+
+        fock_indices = torch.tensor(
+            list(
+                self.logical_to_fock_indices(
+                    n_modes=n_modes, n_photons=n_photons
+                ).values()
+            ),
+            dtype=torch.long,
+            device=tensor.device,
+        )
+
+        if tensor.is_sparse:
+            coalesced = tensor.coalesce()
+            indices = coalesced.indices().clone()
+            indices[-1] = fock_indices[indices[-1]]
+            return torch.sparse_coo_tensor(
+                indices,
+                coalesced.values(),
+                tuple(coalesced.shape[:-1]) + (fock_size,),
+                dtype=coalesced.dtype,
+                device=coalesced.device,
+            ).coalesce()
+
+        flat = tensor.reshape(-1, logical_size)
+        embedded = tensor.new_zeros((flat.shape[0], fock_size))
+        embedded.index_copy_(1, fock_indices, flat)
+        return embedded.view(*tensor.shape[:-1], fock_size)
 
     def logical_basis_states(
         self,

--- a/merlin/core/encoding_space.py
+++ b/merlin/core/encoding_space.py
@@ -445,11 +445,24 @@ class EncodingSpace:
         resolved_photons = self._validate_photon_count(n_photons)
         if self.kind == "dual_rail":
             if resolved_modes is None and resolved_photons is not None:
+                if resolved_photons <= 0:
+                    raise ValueError(
+                        "dual_rail encoding requires a positive n_photons value."
+                    )
                 resolved_modes = 2 * resolved_photons
             if resolved_photons is None and resolved_modes is not None:
                 if resolved_modes % 2 != 0:
                     raise ValueError("dual_rail requires an even n_modes value.")
                 resolved_photons = resolved_modes // 2
+            if (
+                resolved_modes is not None
+                and resolved_photons is not None
+                and resolved_modes != 2 * resolved_photons
+            ):
+                raise ValueError(
+                    "dual_rail encoding requires n_modes == 2 * n_photons; "
+                    f"got n_modes={resolved_modes} and n_photons={resolved_photons}."
+                )
 
         if resolved_modes is None or resolved_photons is None:
             raise ValueError(f"{self.kind} encoding requires n_modes and n_photons.")

--- a/merlin/core/encoding_space.py
+++ b/merlin/core/encoding_space.py
@@ -176,7 +176,29 @@ class EncodingSpace:
     def logical_basis_size(
         self, *, n_modes: int | None = None, n_photons: int | None = None
     ) -> int:
-        """Return the logical tensor width expected before Fock embedding."""
+        """Return the logical tensor width expected before Fock embedding.
+
+        Parameters
+        ----------
+        n_modes : int | None
+            Number of photonic modes used to resolve built-in encodings. If
+            omitted, custom partitioned encodings use their own configured
+            mode count. Default value is None.
+        n_photons : int | None
+            Number of photons used to resolve built-in encodings. If omitted,
+            custom partitioned encodings use their own configured photon
+            count. Default value is None.
+
+        Returns
+        -------
+        int
+            Number of logical amplitude components expected for this encoding.
+
+        Raises
+        ------
+        ValueError
+            If the encoding cannot resolve ``n_modes`` and ``n_photons``.
+        """
 
         return self.basis_size(n_modes=n_modes, n_photons=n_photons)
 
@@ -187,7 +209,36 @@ class EncodingSpace:
         n_modes: int | None = None,
         n_photons: int | None = None,
     ) -> torch.Tensor:
-        """Embed a logical amplitude tensor into canonical full-Fock ordering."""
+        """Embed a logical amplitude tensor into canonical full-Fock ordering.
+
+        Parameters
+        ----------
+        tensor : torch.Tensor
+            Logical amplitude tensor. The final dimension stores amplitudes in
+            this encoding's logical basis order; all leading dimensions are
+            preserved as batch axes.
+        n_modes : int | None
+            Number of photonic modes used to resolve built-in encodings. If
+            omitted, custom partitioned encodings use their own configured
+            mode count. Default value is None.
+        n_photons : int | None
+            Number of photons used to resolve built-in encodings. If omitted,
+            custom partitioned encodings use their own configured photon
+            count. Default value is None.
+
+        Returns
+        -------
+        torch.Tensor
+            Amplitude tensor with the same leading dimensions as ``tensor`` and
+            final dimension equal to the full Fock basis size.
+
+        Raises
+        ------
+        ValueError
+            If ``tensor`` is scalar, if its final dimension does not match the
+            logical basis size, or if the encoding cannot resolve
+            ``n_modes`` and ``n_photons``.
+        """
 
         if tensor.dim() == 0:
             raise ValueError("Amplitude tensor must be at least one-dimensional.")

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -24,7 +24,6 @@
 Quantum computation processes and factories.
 """
 
-import math
 from dataclasses import dataclass
 from typing import Literal, overload
 

--- a/merlin/core/state_vector.py
+++ b/merlin/core/state_vector.py
@@ -311,8 +311,12 @@ class StateVector:
         Number of modes in the Fock space.
     n_photons : int
         Total photon number represented by the state.
+    encoding : EncodingSpace
+        Logical encoding used to construct the stored tensor. Default value is
+        EncodingSpace.FOCK.
     _normalized : bool
-        Internal flag tracking whether the stored tensor is normalized.
+        Internal flag tracking whether the stored tensor is normalized. Default
+        value is False.
 
     Notes
     -----
@@ -454,6 +458,38 @@ class StateVector:
                 idx.numel() * idx.element_size() + vals.numel() * vals.element_size()
             )
         return int(self.tensor.numel() * self.tensor.element_size())
+
+    def logical_to_fock_map(self) -> dict[tuple[int, ...], int]:
+        """Return the logical-to-Fock index map for this state vector.
+
+        The returned dictionary exposes the exact embedding order implied by
+        ``self.encoding`` for this state vector's ``n_modes`` and
+        ``n_photons``. Keys are logical basis labels and values are indices in
+        Merlin's canonical full-Fock basis. For ``EncodingSpace.FOCK``, keys are
+        full Fock occupation tuples and values are their descending-lexicographic
+        Fock indices.
+
+        Parameters
+        ----------
+        None
+            This method uses the state vector metadata stored on ``self``.
+
+        Returns
+        -------
+        dict[tuple[int, ...], int]
+            Mapping from logical basis labels to canonical Fock-basis indices.
+
+        Raises
+        ------
+        ValueError
+            If the stored encoding cannot resolve a basis for this state
+            vector's ``n_modes`` and ``n_photons``.
+        """
+
+        return self.encoding.logical_to_fock_indices(
+            n_modes=self.n_modes,
+            n_photons=self.n_photons,
+        )
 
     def _tensor_coalesced(self) -> torch.Tensor:
         if not self.tensor.is_sparse:

--- a/merlin/core/state_vector.py
+++ b/merlin/core/state_vector.py
@@ -42,6 +42,7 @@ import torch
 from ..utils.combinadics import Combinadics
 from ..utils.dtypes import complex_dtype_for
 from .computation_space import ComputationSpace
+from .encoding_space import EncodingSpace
 
 Scalar = float | int | complex
 
@@ -326,11 +327,14 @@ class StateVector:
     tensor: torch.Tensor
     n_modes: int
     n_photons: int
+    encoding: EncodingSpace = EncodingSpace.FOCK
     _normalized: bool = field(default=False)
 
     def __setattr__(self, name: str, value) -> None:
-        if name in ("n_modes", "n_photons") and name in self.__dict__:
-            raise AttributeError("n_modes and n_photons are immutable once set")
+        if name in ("n_modes", "n_photons", "encoding") and name in self.__dict__:
+            raise AttributeError(
+                "n_modes, n_photons, and encoding are immutable once set"
+            )
         super().__setattr__(name, value)
 
     def __getattr__(self, name: str):
@@ -385,7 +389,11 @@ class StateVector:
         """
         new_tensor = self.tensor.to(*args, **kwargs)
         return StateVector(
-            new_tensor, self.n_modes, self.n_photons, _normalized=self._normalized
+            new_tensor,
+            self.n_modes,
+            self.n_photons,
+            encoding=self.encoding,
+            _normalized=self._normalized,
         )
 
     def clone(self) -> StateVector:
@@ -400,6 +408,7 @@ class StateVector:
             self.tensor.clone(),
             self.n_modes,
             self.n_photons,
+            encoding=self.encoding,
             _normalized=self._normalized,
         )
 
@@ -415,6 +424,7 @@ class StateVector:
             self.tensor.detach(),
             self.n_modes,
             self.n_photons,
+            encoding=self.encoding,
             _normalized=self._normalized,
         )
 
@@ -730,6 +740,7 @@ class StateVector:
         *,
         n_modes: int,
         n_photons: int,
+        encoding: EncodingSpace | None = None,
         dtype: torch.dtype | None = None,
         device: torch.device | None = None,
     ) -> StateVector:
@@ -743,6 +754,9 @@ class StateVector:
             Number of modes.
         n_photons : int
             Total photons.
+        encoding : EncodingSpace | None
+            Logical input encoding. When omitted, the tensor is treated as
+            canonical Fock-space amplitudes and stored unchanged.
         dtype : torch.dtype | None
             Optional target dtype.
         device : torch.device | None
@@ -758,10 +772,30 @@ class StateVector:
         ValueError
             If the last dimension does not match the basis size.
         """
-        basis_size = _basis_size(n_modes, n_photons)
-        _ensure_last_dim(tensor, basis_size)
+        resolved_encoding = encoding or EncodingSpace.FOCK
+        logical_basis_size = resolved_encoding.logical_basis_size(
+            n_modes=n_modes, n_photons=n_photons
+        )
+        if tensor.shape[-1] != logical_basis_size:
+            if resolved_encoding.kind == "fock":
+                _ensure_last_dim(tensor, logical_basis_size)
+            raise ValueError(
+                "Tensor last dimension does not match the logical basis size "
+                f"for encoding '{resolved_encoding.kind}': got {tensor.shape[-1]}, "
+                f"expected {logical_basis_size}."
+            )
         normalized = _to_complex(tensor, dtype=dtype, device=device)
-        return cls(normalized, n_modes, n_photons, _normalized=False)
+        if resolved_encoding.kind != "fock":
+            normalized = resolved_encoding.embed(
+                normalized, n_modes=n_modes, n_photons=n_photons
+            )
+        return cls(
+            normalized,
+            n_modes,
+            n_photons,
+            encoding=resolved_encoding,
+            _normalized=False,
+        )
 
     def tensor_product(
         self,

--- a/merlin/core/state_vector.py
+++ b/merlin/core/state_vector.py
@@ -150,11 +150,77 @@ def _normalize_tensor(tensor: torch.Tensor) -> torch.Tensor:
     return tensor / norm_safe
 
 
-def _ensure_last_dim(tensor: torch.Tensor, expected: int) -> None:
-    if tensor.shape[-1] != expected:
+def _infer_dual_rail_photon_count(logical_size: int) -> int:
+    """Infer a dual-rail photon count from a compact logical basis width.
+
+    Dual-rail has one binary choice per photon, so a valid logical tensor has a
+    final dimension of ``2 ** n_photons``. The zero-photon case is not inferred
+    because it would not determine a positive mode count.
+    """
+
+    if logical_size <= 1 or logical_size & (logical_size - 1):
         raise ValueError(
-            f"Tensor last dimension {tensor.shape[-1]} does not match basis size {expected}."
+            "dual_rail encoding requires tensor last dimension to be a power "
+            "of two greater than one when n_modes and n_photons are omitted."
         )
+    return logical_size.bit_length() - 1
+
+
+def _resolve_from_tensor_dimensions(
+    tensor: torch.Tensor,
+    *,
+    encoding: EncodingSpace,
+    n_modes: int | None,
+    n_photons: int | None,
+) -> tuple[int, int]:
+    """Resolve concrete Fock dimensions for ``StateVector.from_tensor``.
+
+    Structured encodings may infer their own dimensions, but explicit
+    dimensions are validation metadata rather than a request to stretch the
+    encoding layout.
+    """
+
+    if tensor.dim() == 0:
+        raise ValueError("Amplitude tensor must be at least one-dimensional.")
+
+    if encoding.kind == "dual_rail":
+        if n_modes is None and n_photons is None:
+            n_photons = _infer_dual_rail_photon_count(tensor.shape[-1])
+            n_modes = 2 * n_photons
+        elif n_modes is None:
+            if (
+                not isinstance(n_photons, int)
+                or isinstance(n_photons, bool)
+                or n_photons <= 0
+            ):
+                raise ValueError(
+                    "dual_rail encoding requires a positive n_photons value."
+                )
+            n_modes = 2 * n_photons
+        elif n_photons is None:
+            if (
+                not isinstance(n_modes, int)
+                or isinstance(n_modes, bool)
+                or n_modes <= 0
+            ):
+                raise ValueError("n_modes must be a strictly positive integer.")
+            if n_modes % 2 != 0:
+                raise ValueError("dual_rail requires an even n_modes value.")
+            n_photons = n_modes // 2
+        assert n_modes is not None
+        assert n_photons is not None
+        return n_modes, n_photons
+
+    if encoding.family == "partitioned" and encoding.modes_per_photon is not None:
+        resolved_modes = encoding.n_modes if n_modes is None else n_modes
+        resolved_photons = encoding.n_photons if n_photons is None else n_photons
+        assert resolved_modes is not None
+        assert resolved_photons is not None
+        return resolved_modes, resolved_photons
+
+    if n_modes is None or n_photons is None:
+        raise ValueError(f"{encoding.kind} encoding requires n_modes and n_photons.")
+    return n_modes, n_photons
 
 
 def _remap_last_dim(
@@ -484,6 +550,16 @@ class StateVector:
         ValueError
             If the stored encoding cannot resolve a basis for this state
             vector's ``n_modes`` and ``n_photons``.
+
+        Examples
+        --------
+        >>> import torch
+        >>> from merlin.core import EncodingSpace
+        >>> from merlin.core.state_vector import StateVector
+        >>> logical = torch.zeros(4, dtype=torch.complex64)
+        >>> sv = StateVector.from_tensor(logical, encoding=EncodingSpace.DUAL_RAIL)
+        >>> sv.logical_to_fock_map()
+        {(0, 0): 2, (0, 1): 3, (1, 0): 5, (1, 1): 6}
         """
 
         return self.encoding.logical_to_fock_indices(
@@ -774,8 +850,8 @@ class StateVector:
         cls,
         tensor: torch.Tensor,
         *,
-        n_modes: int,
-        n_photons: int,
+        n_modes: int | None = None,
+        n_photons: int | None = None,
         encoding: EncodingSpace | None = None,
         dtype: torch.dtype | None = None,
         device: torch.device | None = None,
@@ -786,17 +862,27 @@ class StateVector:
         ----------
         tensor : torch.Tensor
             Dense or sparse amplitude tensor.
-        n_modes : int
-            Number of modes.
-        n_photons : int
-            Total photons.
+        n_modes : int | None
+            Number of modes. Required for Fock and unbunched inputs. For
+            structured encodings, omitted values are inferred from the
+            encoding contract. If provided, the value must match that contract.
+            Default value is None.
+        n_photons : int | None
+            Total photons. Required for Fock and unbunched inputs. For
+            structured encodings, omitted values are inferred from the
+            encoding contract or, for dual rail, from the tensor's final
+            dimension. If provided, the value must match that contract. Default
+            value is None.
         encoding : EncodingSpace | None
             Logical input encoding. When omitted, the tensor is treated as
-            canonical Fock-space amplitudes and stored unchanged.
+            canonical Fock-space amplitudes and stored unchanged. Default value
+            is None.
         dtype : torch.dtype | None
-            Optional target dtype.
+            Target dtype. If omitted, complex inputs keep their dtype and real
+            inputs are promoted to ``torch.complex64``. Default value is None.
         device : torch.device | None
-            Optional target device.
+            Target device. If omitted, the input tensor's device is preserved.
+            Default value is None.
 
         Returns
         -------
@@ -806,15 +892,26 @@ class StateVector:
         Raises
         ------
         ValueError
-            If the last dimension does not match the basis size.
+            If the tensor is scalar, if required dimensions are missing, if
+            explicit dimensions do not match the encoding contract, or if the
+            last dimension does not match the resolved logical basis size.
         """
         resolved_encoding = encoding or EncodingSpace.FOCK
+        resolved_modes, resolved_photons = _resolve_from_tensor_dimensions(
+            tensor,
+            encoding=resolved_encoding,
+            n_modes=n_modes,
+            n_photons=n_photons,
+        )
         logical_basis_size = resolved_encoding.logical_basis_size(
-            n_modes=n_modes, n_photons=n_photons
+            n_modes=resolved_modes, n_photons=resolved_photons
         )
         if tensor.shape[-1] != logical_basis_size:
             if resolved_encoding.kind == "fock":
-                _ensure_last_dim(tensor, logical_basis_size)
+                raise ValueError(
+                    f"Tensor last dimension {tensor.shape[-1]} does not match "
+                    f"basis size {logical_basis_size}."
+                )
             raise ValueError(
                 "Tensor last dimension does not match the logical basis size "
                 f"for encoding '{resolved_encoding.kind}': got {tensor.shape[-1]}, "
@@ -823,12 +920,12 @@ class StateVector:
         normalized = _to_complex(tensor, dtype=dtype, device=device)
         if resolved_encoding.kind != "fock":
             normalized = resolved_encoding.embed(
-                normalized, n_modes=n_modes, n_photons=n_photons
+                normalized, n_modes=resolved_modes, n_photons=resolved_photons
             )
         return cls(
             normalized,
-            n_modes,
-            n_photons,
+            resolved_modes,
+            resolved_photons,
             encoding=resolved_encoding,
             _normalized=False,
         )

--- a/merlin/pcvl_pytorch/locirc_to_tensor.py
+++ b/merlin/pcvl_pytorch/locirc_to_tensor.py
@@ -405,8 +405,7 @@ class CircuitConverter:
         self.batch_size = batch_size
 
         converted_tensor = (
-            torch
-            .eye(self.circuit.m, dtype=self.tensor_cdtype, device=self.device)
+            torch.eye(self.circuit.m, dtype=self.tensor_cdtype, device=self.device)
             .unsqueeze(0)
             .repeat(batch_size, 1, 1)
         )
@@ -444,8 +443,7 @@ class CircuitConverter:
             Batched unitary tensor of shape (batch_size, comp_size, comp_size)
         """
         return (
-            torch
-            .tensor(
+            torch.tensor(
                 comp.compute_unitary(), dtype=self.tensor_cdtype, device=self.device
             )
             .unsqueeze(0)
@@ -514,8 +512,7 @@ class CircuitConverter:
             )
 
         unitary_tensor = (
-            unitary_tensor
-            .unsqueeze(0)
+            unitary_tensor.unsqueeze(0)
             .repeat(self.batch_size, 1, 1)
             .to(cos_theta.device)
         )

--- a/tests/algorithms/test_kernels.py
+++ b/tests/algorithms/test_kernels.py
@@ -332,8 +332,7 @@ class TestFidelityKernel:
         )
 
         feature_forward = (
-            feature_map
-            .compute_unitary(torch.as_tensor(X1, dtype=feature_map.dtype))
+            feature_map.compute_unitary(torch.as_tensor(X1, dtype=feature_map.dtype))
             .detach()
             .cpu()
             .numpy()
@@ -348,8 +347,7 @@ class TestFidelityKernel:
         )
 
         feature_backward = (
-            feature_map
-            .compute_unitary(torch.as_tensor(X2, dtype=feature_map.dtype))
+            feature_map.compute_unitary(torch.as_tensor(X2, dtype=feature_map.dtype))
             .detach()
             .cpu()
             .numpy()
@@ -681,8 +679,7 @@ class TestKernelCircuitBuilder:
         device = torch.device("cpu")
         builder = KernelCircuitBuilder()
         feature_map = (
-            builder
-            .input_size(2)
+            builder.input_size(2)
             .n_modes(4)
             .device(device)
             .dtype(torch.float64)
@@ -703,8 +700,7 @@ class TestKernelCircuitBuilder:
         assert not feature_map.is_trainable
 
         feature_map = (
-            builder
-            .input_size(2)
+            builder.input_size(2)
             .n_modes(4)
             .trainable(True, prefix="phi_")
             .build_feature_map()
@@ -729,8 +725,7 @@ class TestKernelCircuitBuilder:
         builder = KernelCircuitBuilder()
         custom_state = [2, 0, 0, 0]
         kernel = (
-            builder
-            .input_size(2)
+            builder.input_size(2)
             .n_modes(4)
             .build_fidelity_kernel(input_state=custom_state)
         )
@@ -741,8 +736,7 @@ class TestKernelCircuitBuilder:
         """Test building FidelityKernel with sampling configuration."""
         builder = KernelCircuitBuilder()
         kernel = (
-            builder
-            .input_size(2)
+            builder.input_size(2)
             .n_modes(4)
             .build_fidelity_kernel(
                 shots=1000,
@@ -767,8 +761,7 @@ class TestKernelCircuitBuilder:
     def test_builder_angle_encoding_configuration(self):
         builder = KernelCircuitBuilder()
         feature_map = (
-            builder
-            .input_size(3)
+            builder.input_size(3)
             .n_modes(4)
             .angle_encoding(scale=0.5)
             .build_feature_map()
@@ -871,8 +864,7 @@ class TestKernelConstructionConsistency:
         # Builder API
         builder_api = KernelCircuitBuilder()
         k_builder = (
-            builder_api
-            .input_size(2)
+            builder_api.input_size(2)
             .n_modes(4)
             .trainable(False)
             .build_fidelity_kernel()
@@ -1318,8 +1310,7 @@ def test_iris_with_supported_constructors():
         try:
             builder = KernelCircuitBuilder()
             kernel_builder = (
-                builder
-                .input_size(4)
+                builder.input_size(4)
                 .n_modes(4)
                 .trainable(trainable_flag)
                 .build_fidelity_kernel()

--- a/tests/core/cloud/test_parammapping.py
+++ b/tests/core/cloud/test_parammapping.py
@@ -116,7 +116,7 @@ def _make_perceval_layer_two_prefixes(prefixes: list[str], counts: list[int], m:
     c = pcvl.Circuit(m)
 
     mode = 0
-    for pref, n in zip(prefixes, counts):
+    for pref, n in zip(prefixes, counts, strict=False):
         for i in range(n):
             c.add(mode, pcvl.PS(pcvl.P(f"{pref}{i + 1}")))
             mode += 1
@@ -309,7 +309,7 @@ class TestBuilderDeclarative:
 
         # builder bookkeeping
         assert "px" in b2._angle_encoding_scales
-        assert b2._angle_encoding_scales["px"] == {i: 2.5 for i in range(10)}
+        assert b2._angle_encoding_scales["px"] == dict.fromkeys(range(10), 2.5)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_encoding_space.py
+++ b/tests/core/test_encoding_space.py
@@ -167,3 +167,8 @@ def test_dual_rail_resolves_modes_per_photon_at_embed_time():
         (1, 1, 0),
         (1, 1, 1),
     )
+
+
+def test_dual_rail_rejects_dimensions_outside_two_modes_per_photon_contract():
+    with pytest.raises(ValueError, match="n_modes == 2 \\* n_photons"):
+        EncodingSpace.DUAL_RAIL.logical_basis_size(n_modes=5, n_photons=2)

--- a/tests/core/test_state_vector_from_tensor_contract.py
+++ b/tests/core/test_state_vector_from_tensor_contract.py
@@ -227,3 +227,74 @@ def test_statevector_tensor_helpers_preserve_encoding_metadata():
     assert sv.clone().encoding is EncodingSpace.DUAL_RAIL
     assert sv.detach().encoding is EncodingSpace.DUAL_RAIL
     assert sv.to(dtype=torch.complex128).encoding is EncodingSpace.DUAL_RAIL
+
+
+def test_logical_to_fock_map_for_fock_encoding_is_identity_by_fock_order():
+    n_modes, n_photons = 4, 2
+    amplitudes = torch.zeros(
+        Combinadics("fock", n_photons, n_modes).compute_space_size()
+    )
+    sv = StateVector.from_tensor(amplitudes, n_modes=n_modes, n_photons=n_photons)
+
+    expected = {
+        tuple(state): index
+        for index, state in enumerate(Combinadics("fock", n_photons, n_modes))
+    }
+
+    assert sv.encoding is EncodingSpace.FOCK
+    assert sv.logical_to_fock_map() == expected
+
+
+def test_logical_to_fock_map_for_unbunched_encoding():
+    n_modes, n_photons = 4, 2
+    logical = torch.zeros(
+        EncodingSpace.UNBUNCHED.logical_basis_size(
+            n_modes=n_modes,
+            n_photons=n_photons,
+        )
+    )
+    sv = StateVector.from_tensor(
+        logical,
+        n_modes=n_modes,
+        n_photons=n_photons,
+        encoding=EncodingSpace.UNBUNCHED,
+    )
+
+    assert sv.logical_to_fock_map() == EncodingSpace.UNBUNCHED.logical_to_fock_indices(
+        n_modes=n_modes,
+        n_photons=n_photons,
+    )
+
+
+def test_logical_to_fock_map_for_dual_rail_encoding():
+    n_modes, n_photons = 4, 2
+    logical = torch.zeros(
+        EncodingSpace.DUAL_RAIL.logical_basis_size(
+            n_modes=n_modes,
+            n_photons=n_photons,
+        )
+    )
+    sv = StateVector.from_tensor(
+        logical,
+        n_modes=n_modes,
+        n_photons=n_photons,
+        encoding=EncodingSpace.DUAL_RAIL,
+    )
+
+    assert sv.logical_to_fock_map() == EncodingSpace.DUAL_RAIL.logical_to_fock_indices(
+        n_modes=n_modes,
+        n_photons=n_photons,
+    )
+
+
+def test_logical_to_fock_map_for_custom_partitioned_encoding():
+    encoding = EncodingSpace(modes_per_photon=[3, 2])
+    logical = torch.zeros(encoding.logical_basis_size())
+    sv = StateVector.from_tensor(
+        logical,
+        n_modes=5,
+        n_photons=2,
+        encoding=encoding,
+    )
+
+    assert sv.logical_to_fock_map() == encoding.logical_to_fock_indices()

--- a/tests/core/test_state_vector_from_tensor_contract.py
+++ b/tests/core/test_state_vector_from_tensor_contract.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 
+from merlin.core import EncodingSpace
 from merlin.core.state_vector import StateVector
 from merlin.utils.combinadics import Combinadics
 
@@ -32,6 +33,7 @@ def test_from_tensor_default_contract_dense_preserves_fock_basis_and_raw_tensor(
 
     assert sv.n_modes == n_modes
     assert sv.n_photons == n_photons
+    assert sv.encoding is EncodingSpace.FOCK
     assert sv.basis_size == basis_size
     assert list(sv.basis) == list(basis)
     assert not sv.tensor.is_sparse
@@ -64,6 +66,7 @@ def test_from_tensor_default_contract_sparse_preserves_layout_until_dense_view(
 
     assert sv.n_modes == n_modes
     assert sv.n_photons == n_photons
+    assert sv.encoding is EncodingSpace.FOCK
     assert sv.tensor.is_sparse
     assert not sv.is_normalized
     assert torch.equal(stored.indices(), original.indices())
@@ -102,3 +105,125 @@ def test_from_tensor_default_contract_real_inputs_default_to_complex64():
 
     assert sv.tensor.dtype == torch.complex64
     assert torch.allclose(sv.tensor, tensor.to(torch.complex64))
+
+
+def test_from_tensor_with_dual_rail_encoding_embeds_into_fock_space():
+    logical = torch.tensor([1.0, 2.0, 3.0, 4.0], requires_grad=True)
+    fock_basis_size = Combinadics("fock", 2, 4).compute_space_size()
+
+    sv = StateVector.from_tensor(
+        logical,
+        n_modes=4,
+        n_photons=2,
+        encoding=EncodingSpace.DUAL_RAIL,
+    )
+
+    mapping = EncodingSpace.DUAL_RAIL.logical_to_fock_indices(n_modes=4, n_photons=2)
+    expected = torch.zeros(fock_basis_size, dtype=torch.complex64)
+    for logical_idx, fock_idx in enumerate(mapping.values()):
+        expected[fock_idx] = complex(float(logical[logical_idx].item()))
+
+    assert sv.encoding is EncodingSpace.DUAL_RAIL
+    assert sv.tensor.shape == (fock_basis_size,)
+    assert torch.allclose(sv.tensor, expected)
+
+    loss = sv.tensor.real.sum()
+    loss.backward()
+    assert logical.grad is not None
+    assert torch.allclose(logical.grad, torch.ones_like(logical))
+
+
+def test_from_tensor_with_custom_partitioned_encoding_embeds_into_fock_space():
+    encoding = EncodingSpace(modes_per_photon=[3, 2])
+    logical = torch.arange(1, 7, dtype=torch.float32)
+    fock_basis_size = Combinadics("fock", 2, 5).compute_space_size()
+
+    sv = StateVector.from_tensor(
+        logical,
+        n_modes=5,
+        n_photons=2,
+        encoding=encoding,
+    )
+
+    expected = torch.zeros(fock_basis_size, dtype=torch.complex64)
+    for logical_idx, fock_idx in enumerate(encoding.logical_to_fock_indices().values()):
+        expected[fock_idx] = complex(float(logical[logical_idx].item()))
+
+    assert sv.encoding == encoding
+    assert sv.tensor.shape == (fock_basis_size,)
+    assert torch.allclose(sv.tensor, expected)
+
+
+def test_from_tensor_with_batched_encoding_preserves_batch_and_autograd():
+    logical = torch.arange(1, 9, dtype=torch.float32).reshape(2, 4)
+    logical.requires_grad_()
+    fock_basis_size = Combinadics("fock", 2, 4).compute_space_size()
+
+    sv = StateVector.from_tensor(
+        logical,
+        n_modes=4,
+        n_photons=2,
+        encoding=EncodingSpace.DUAL_RAIL,
+    )
+
+    assert sv.encoding is EncodingSpace.DUAL_RAIL
+    assert sv.tensor.shape == (2, fock_basis_size)
+
+    sv.tensor.real.sum().backward()
+    assert logical.grad is not None
+    assert torch.allclose(logical.grad, torch.ones_like(logical))
+
+
+def test_from_tensor_with_partitioned_encoding_preserves_sparse_layout():
+    indices = torch.tensor([[0, 3]])
+    values = torch.tensor([2.0 + 0j, 5.0 + 0j], dtype=torch.complex64)
+    logical = torch.sparse_coo_tensor(indices, values, (4,), dtype=torch.complex64)
+    fock_basis_size = Combinadics("fock", 2, 4).compute_space_size()
+
+    sv = StateVector.from_tensor(
+        logical,
+        n_modes=4,
+        n_photons=2,
+        encoding=EncodingSpace.DUAL_RAIL,
+    )
+
+    mapping = EncodingSpace.DUAL_RAIL.logical_to_fock_indices(n_modes=4, n_photons=2)
+    expected_indices = torch.tensor([[mapping[(0, 0)], mapping[(1, 1)]]])
+    expected = torch.sparse_coo_tensor(
+        expected_indices,
+        values,
+        (fock_basis_size,),
+        dtype=torch.complex64,
+    ).coalesce()
+
+    assert sv.encoding is EncodingSpace.DUAL_RAIL
+    assert sv.tensor.is_sparse
+    assert torch.equal(sv.tensor.coalesce().indices(), expected.indices())
+    assert torch.allclose(sv.tensor.coalesce().values(), expected.values())
+
+
+def test_from_tensor_with_encoding_rejects_logical_basis_size_mismatch():
+    tensor = torch.ones(5, dtype=torch.complex64)
+
+    with pytest.raises(ValueError, match="logical basis size"):
+        StateVector.from_tensor(
+            tensor,
+            n_modes=4,
+            n_photons=2,
+            encoding=EncodingSpace.DUAL_RAIL,
+        )
+
+
+def test_statevector_tensor_helpers_preserve_encoding_metadata():
+    logical = torch.zeros(4, dtype=torch.complex64)
+    logical[0] = 1.0
+    sv = StateVector.from_tensor(
+        logical,
+        n_modes=4,
+        n_photons=2,
+        encoding=EncodingSpace.DUAL_RAIL,
+    )
+
+    assert sv.clone().encoding is EncodingSpace.DUAL_RAIL
+    assert sv.detach().encoding is EncodingSpace.DUAL_RAIL
+    assert sv.to(dtype=torch.complex128).encoding is EncodingSpace.DUAL_RAIL

--- a/tests/core/test_state_vector_from_tensor_contract.py
+++ b/tests/core/test_state_vector_from_tensor_contract.py
@@ -82,6 +82,13 @@ def test_from_tensor_default_contract_rejects_basis_size_mismatch():
         StateVector.from_tensor(tensor, n_modes=4, n_photons=2)
 
 
+def test_from_tensor_default_contract_rejects_scalar_tensor():
+    tensor = torch.tensor(1.0)
+
+    with pytest.raises(ValueError, match="at least one-dimensional"):
+        StateVector.from_tensor(tensor, n_modes=1, n_photons=1)
+
+
 def test_from_tensor_default_contract_explicit_dtype_and_device_are_applied():
     tensor = torch.arange(1, 7, dtype=torch.float32)
 
@@ -133,6 +140,61 @@ def test_from_tensor_with_dual_rail_encoding_embeds_into_fock_space():
     assert torch.allclose(logical.grad, torch.ones_like(logical))
 
 
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"n_modes": 4},
+        {"n_photons": 2},
+    ],
+)
+def test_from_tensor_with_dual_rail_encoding_infers_dimensions(kwargs):
+    logical = torch.zeros(4, dtype=torch.complex64)
+
+    sv = StateVector.from_tensor(
+        logical,
+        encoding=EncodingSpace.DUAL_RAIL,
+        **kwargs,
+    )
+
+    assert sv.n_modes == 4
+    assert sv.n_photons == 2
+    assert sv.tensor.shape == (Combinadics("fock", 2, 4).compute_space_size(),)
+    assert sv.logical_to_fock_map() == EncodingSpace.DUAL_RAIL.logical_to_fock_indices(
+        n_modes=4,
+        n_photons=2,
+    )
+
+
+def test_from_tensor_with_dual_rail_encoding_rejects_non_power_of_two_inference():
+    logical = torch.zeros(3, dtype=torch.complex64)
+
+    with pytest.raises(ValueError, match="power of two"):
+        StateVector.from_tensor(logical, encoding=EncodingSpace.DUAL_RAIL)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"n_modes": 5}, "even n_modes"),
+        ({"n_modes": 5, "n_photons": 2}, "n_modes == 2 \\* n_photons"),
+        ({"n_modes": 6, "n_photons": 3}, "logical basis size"),
+    ],
+)
+def test_from_tensor_with_dual_rail_encoding_rejects_invalid_dimensions(
+    kwargs,
+    match,
+):
+    logical = torch.zeros(4, dtype=torch.complex64)
+
+    with pytest.raises(ValueError, match=match):
+        StateVector.from_tensor(
+            logical,
+            encoding=EncodingSpace.DUAL_RAIL,
+            **kwargs,
+        )
+
+
 def test_from_tensor_with_custom_partitioned_encoding_embeds_into_fock_space():
     encoding = EncodingSpace(modes_per_photon=[3, 2])
     logical = torch.arange(1, 7, dtype=torch.float32)
@@ -152,6 +214,46 @@ def test_from_tensor_with_custom_partitioned_encoding_embeds_into_fock_space():
     assert sv.encoding == encoding
     assert sv.tensor.shape == (fock_basis_size,)
     assert torch.allclose(sv.tensor, expected)
+
+
+def test_from_tensor_with_custom_partitioned_encoding_infers_dimensions():
+    encoding = EncodingSpace(modes_per_photon=[3, 2])
+    logical = torch.zeros(encoding.logical_basis_size(), dtype=torch.complex64)
+
+    sv = StateVector.from_tensor(logical, encoding=encoding)
+
+    assert sv.n_modes == 5
+    assert sv.n_photons == 2
+    assert sv.tensor.shape == (Combinadics("fock", 2, 5).compute_space_size(),)
+
+
+def test_from_tensor_with_qloq_encoding_infers_dimensions():
+    encoding = EncodingSpace.qloq(qubit_groups=[2, 1])
+    logical = torch.zeros(encoding.logical_basis_size(), dtype=torch.complex64)
+
+    sv = StateVector.from_tensor(logical, encoding=encoding)
+
+    assert sv.n_modes == 6
+    assert sv.n_photons == 2
+    assert sv.tensor.shape == (Combinadics("fock", 2, 6).compute_space_size(),)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"n_modes": 6}, "expects n_modes=5"),
+        ({"n_photons": 3}, "expects n_photons=2"),
+    ],
+)
+def test_from_tensor_with_partitioned_encoding_rejects_invalid_dimensions(
+    kwargs,
+    match,
+):
+    encoding = EncodingSpace(modes_per_photon=[3, 2])
+    logical = torch.zeros(encoding.logical_basis_size(), dtype=torch.complex64)
+
+    with pytest.raises(ValueError, match=match):
+        StateVector.from_tensor(logical, encoding=encoding, **kwargs)
 
 
 def test_from_tensor_with_batched_encoding_preserves_batch_and_autograd():

--- a/tests/memory_benchmark.py
+++ b/tests/memory_benchmark.py
@@ -94,8 +94,7 @@ def benchmark_bs(MODES=8, PHOTONS=4, BS=32, TYPE=torch.float32, set_hp=False):
     circuit = pcvl.GenericInterferometer(
         MODES,
         lambda i: (
-            pcvl
-            .BS(theta=pcvl.P(f"theta_1_{i}"))
+            pcvl.BS(theta=pcvl.P(f"theta_1_{i}"))
             .add(0, pcvl.PS(pcvl.P(f"phase_1_{i}")))
             .add(0, pcvl.BS(theta=pcvl.P(f"theta_2_{i}")))
             .add(0, pcvl.PS(pcvl.P(f"phase_2_{i}")))

--- a/tests/pcvl_pytorch/test_perceval_comparison.py
+++ b/tests/pcvl_pytorch/test_perceval_comparison.py
@@ -65,8 +65,7 @@ class TestPercevalComparison:
             parameters.append(parameter)
 
         chip = (
-            pcvl
-            .Circuit(self.N_MODES, name="chip")
+            pcvl.Circuit(self.N_MODES, name="chip")
             .add(0, pre_U)
             .add(0, phases_U, merge=False)
             .add(0, reservoir_U, merge=False)


### PR DESCRIPTION
<!--
Thank you for contributing to MerLin!
Please fill out the sections below to help us review your PR efficiently.

NOTE: this repo is a public repository, therefore, do NOT paste Jira URLs. Use the Jira issue key only (e.g., PML-126).
The Jira-GitHub integration will link PRs/commits automatically when the key is present.
-->

<!-- Add the Jira issue key in the title -->
<!-- e.g., PML-126 Updating PR template -->

## Summary
Adds the public `StateVector.from_tensor(..., encoding=...)` integration for `EncodingSpace`, plus the PML-271 observability helper for inspecting the logical-to-Fock index mapping used by an encoded `StateVector`.

This makes `EncodingSpace` the user-facing embedding authority: callers can pass compact logical amplitudes to `StateVector.from_tensor(...)`, receive an already embedded full-Fock tensor, and verify the applied mapping at runtime.

## Related Issue
Related Jira: PML-270

Also includes the small follow-up observability scope from PML-271.

## Type of change
- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor / Cleanup
- [x] Performance improvement
- [ ] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)


## Proposed changes
- Add `encoding: EncodingSpace | None = None` to `StateVector.from_tensor(...)`.
- Default omitted encodings to `EncodingSpace.FOCK`, preserving existing Fock tensor behavior.
- Store the originating encoding on `StateVector.encoding`.
- Add `EncodingSpace.logical_basis_size(...)` and `EncodingSpace.embed(...)`.
- Embed logical tensors into canonical full-Fock ordering for built-in and custom encodings.
- Add `StateVector.logical_to_fock_map()` for PML-271 observability.
- Cover FOCK, UNBUNCHED, DUAL_RAIL, custom partitioned, batched, sparse, dtype/device, and autograd behavior.
- Extend the superposition benchmark with a check comparing the new encoding-aware API against explicit manual Fock embedding.
- Update API reference docs and public docstrings for the new public surface.

## How to test / How to run

1. Unit and integration tests

```
python -m pytest -q --benchmark-skip
```

2. Pre-commit hooks from `.pre-commit-config.yaml`

```
python -m pre_commit run --all-files
```

3. Strict docs build

```
SPHINXOPTS="-W --keep-going -n" make -C docs clean html
```

4. Superposition benchmark consistency check

```
PYTHONPATH=$PWD python \
  benchmarks/benchmark_superposition_streaming.py \
  --label pml270-fromtensor-wsl-check \
  --runs 5 \
  --warmups 1 \
  --include-output
```

## Screenshots / Logs (optional)

Validation summary:

```
pytest: 753 passed, 214 skipped, 1 warning
pre-commit: ruff passed, ruff-format passed, mypy passed
Sphinx: build succeeded with -W --keep-going -n
```

Benchmark summary:

```
StateVector.from_tensor(..., encoding=EncodingSpace.DUAL_RAIL)
vs manual zero-fill/index-copy embedding:

tensor max diff: 0
output amplitude max diff: 0
output probability max diff: 0
```

## Performance considerations (optional)

The existing superposition streaming benchmark remains consistent with the parent branch:

- Output amplitude diff against the parent branch: `0`
- Output probability diff against the parent branch: `0`
- Whole-support allocations remain `0`
- Max allocation per benchmark case remains unchanged:
  - `m16_p3`: `0.050 MiB`
  - `m28_p3`: `0.248 MiB`
  - `m32_p3`: `0.365 MiB`

The new encoding API check showed no meaningful overhead compared with manual embedding for the tested dual-rail case.

## Documentation
- [x] User docs updated (Sphinx)
- [ ] Examples / notebooks updated
- [x] Docstrings updated
- [x] Updated the API

## Checklist
- [x] PR title includes Jira issue key (e.g., PML-126)
- [x] "Related Jira ticket" section includes the Jira issue key (no URL)
- [x] Code formatted (ruff format)
- [x] Lint passes (ruff)
- [x] Static typing passes (mypy) if applicable
- [x] Unit tests added/updated (pytest)
- [x] Tests pass locally (pytest)
- [ ] Tests pass on GPU (pytest)
- [x] Test coverage not decreased significantly
- [x] Docs build locally if affected (sphinx)
- [x] With this command: 

        > SPHINXOPTS="-W --keep-going -n" make -C docs clean html 

    the docs are built without any warning or errors.
- [x] New public classes/methods/packages are added in the API following the methodology presented in other files.
- [x] Dependencies updated (if needed) and pinned appropriately
- [x] PR description explains what changed and how to validate it


<!-- Helpful local commands - run from repo root:

# Lint & format
ruff format && ruff check .

# Type check (if used)
mypy .

# Tests with coverage
pytest

# Build docs
pip install -e .[docs] && make -C docs html

-->

