### PR TITLE
Fix post select fn bug with new perceval-quandela

### DIFF
--- a/merlin/algorithms/kernels.py
+++ b/merlin/algorithms/kernels.py
@@ -115,7 +115,7 @@ class FeatureMap:
         elif experiment is not None:
             if (
                 not experiment.is_unitary
-                or experiment.post_select_fn is not None
+                or not experiment.post_select_fn == pcvl.PostSelect()
                 or experiment.heralds
             ):
                 raise ValueError(

--- a/merlin/algorithms/kernels.py
+++ b/merlin/algorithms/kernels.py
@@ -946,9 +946,9 @@ class FidelityKernel(MerlinModule):
 
         # Check if we are constructing training matrix
         equal_inputs = self._check_equal_inputs(x1, x2)
-        U_forward = torch.stack(
-            [self.feature_map.compute_unitary(x).to(x1.device) for x in x1]
-        )
+        U_forward = torch.stack([
+            self.feature_map.compute_unitary(x).to(x1.device) for x in x1
+        ])
 
         len_x1 = len(x1)
         if x2 is not None:
@@ -957,25 +957,19 @@ class FidelityKernel(MerlinModule):
                 if isinstance(x2, torch.Tensor)
                 else torch.as_tensor(x2, dtype=self.dtype, device=self.device)
             )
-            U_adjoint = torch.stack(
-                [
-                    self.feature_map.compute_unitary(x)
+            U_adjoint = torch.stack([
+                self.feature_map.compute_unitary(x).transpose(0, 1).conj().to(x1.device)
+                for x in x2_tensor
+            ])
+            if isinstance(x2, torch.Tensor):
+                U_adjoint = torch.stack([
+                    self.feature_map
+                    .compute_unitary(x)
                     .transpose(0, 1)
                     .conj()
                     .to(x1.device)
-                    for x in x2_tensor
-                ]
-            )
-            if isinstance(x2, torch.Tensor):
-                U_adjoint = torch.stack(
-                    [
-                        self.feature_map.compute_unitary(x)
-                        .transpose(0, 1)
-                        .conj()
-                        .to(x1.device)
-                        for x in x2
-                    ]
-                )
+                    for x in x2
+                ])
             else:
                 raise (TypeError("x2 is not None nor torch.Tensor"))
 

--- a/merlin/algorithms/kernels.py
+++ b/merlin/algorithms/kernels.py
@@ -946,9 +946,9 @@ class FidelityKernel(MerlinModule):
 
         # Check if we are constructing training matrix
         equal_inputs = self._check_equal_inputs(x1, x2)
-        U_forward = torch.stack([
-            self.feature_map.compute_unitary(x).to(x1.device) for x in x1
-        ])
+        U_forward = torch.stack(
+            [self.feature_map.compute_unitary(x).to(x1.device) for x in x1]
+        )
 
         len_x1 = len(x1)
         if x2 is not None:
@@ -957,19 +957,25 @@ class FidelityKernel(MerlinModule):
                 if isinstance(x2, torch.Tensor)
                 else torch.as_tensor(x2, dtype=self.dtype, device=self.device)
             )
-            U_adjoint = torch.stack([
-                self.feature_map.compute_unitary(x).transpose(0, 1).conj().to(x1.device)
-                for x in x2_tensor
-            ])
-            if isinstance(x2, torch.Tensor):
-                U_adjoint = torch.stack([
-                    self.feature_map
-                    .compute_unitary(x)
+            U_adjoint = torch.stack(
+                [
+                    self.feature_map.compute_unitary(x)
                     .transpose(0, 1)
                     .conj()
                     .to(x1.device)
-                    for x in x2
-                ])
+                    for x in x2_tensor
+                ]
+            )
+            if isinstance(x2, torch.Tensor):
+                U_adjoint = torch.stack(
+                    [
+                        self.feature_map.compute_unitary(x)
+                        .transpose(0, 1)
+                        .conj()
+                        .to(x1.device)
+                        for x in x2
+                    ]
+                )
             else:
                 raise (TypeError("x2 is not None nor torch.Tensor"))
 
@@ -1210,7 +1216,7 @@ class FidelityKernel(MerlinModule):
         """Validate that the provided experiment is compatible with fidelity kernels."""
         if (
             not experiment.is_unitary
-            or experiment.post_select_fn is not None
+            or not experiment.post_select_fn == pcvl.PostSelect()
             or experiment.heralds
             or experiment.in_heralds
         ):

--- a/merlin/algorithms/layer_utils.py
+++ b/merlin/algorithms/layer_utils.py
@@ -523,7 +523,7 @@ def vet_experiment(experiment: pcvl.Experiment) -> dict[str, bool]:
         If the experiment uses unsupported features such as post-selection,
         heralding, feed-forward, time dependence, or minimum-photon filters.
     """
-    has_post_select = experiment.post_select_fn is not None
+    has_post_select = not experiment.post_select_fn == pcvl.PostSelect()
     has_heralding = bool(experiment.heralds) or bool(experiment.in_heralds)
     has_feedforward = bool(getattr(experiment, "has_feedforward", False))
     has_td_attr = getattr(experiment, "has_td", None)


### PR DESCRIPTION
## Summary
In the new perceval-quandela>=1.2, empty postselection functions in Experiments are pcvl.PostSelect() and not None.

## Related Issue
Bug

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / Cleanup
- [ ] Performance improvement
- [ ] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)


## Proposed changes
Changed experiment.post_select_fn is None to experiment.post_select_fn == pcvl.PostSelect()

## How to test / How to run
```
pytest -q
```

## Documentation
- [ ] User docs updated (Sphinx)
- [ ] Examples / notebooks updated
- [ ] Docstrings updated
- [ ] Updated the API