### PR TITLE
PML-286 g2 noise

### DIFF
--- a/docs/source/api_reference/api/merlin.core.rst
+++ b/docs/source/api_reference/api/merlin.core.rst
@@ -31,6 +31,8 @@ Modules
      - Computation processes and factory logic used to execute Merlin circuits.
    * - :doc:`merlin.core.merlin_processor`
      - The high-level :class:`~merlin.core.merlin_processor.MerlinProcessor` remote/local execution interface.
+   * - :doc:`merlin.core.sectored_distribution`
+     - Data classes used for g2 simulation outputs.
    * - :doc:`merlin.core.state`
      - State-pattern helpers and input-state generation utilities.
    * - :doc:`merlin.core.state_vector`
@@ -49,5 +51,6 @@ Modules
    merlin.core.probability_distribution
    merlin.core.process
    merlin.core.merlin_processor
+   merlin.cire.sectored_distribution
    merlin.core.state
    merlin.core.state_vector

--- a/docs/source/api_reference/api/merlin.core.rst
+++ b/docs/source/api_reference/api/merlin.core.rst
@@ -51,6 +51,6 @@ Modules
    merlin.core.probability_distribution
    merlin.core.process
    merlin.core.merlin_processor
-   merlin.cire.sectored_distribution
+   merlin.core.sectored_distribution
    merlin.core.state
    merlin.core.state_vector

--- a/docs/source/api_reference/api/merlin.core.sectored_distribution.rst
+++ b/docs/source/api_reference/api/merlin.core.sectored_distribution.rst
@@ -1,4 +1,4 @@
-merlin.core.probability_distribution
+merlin.core.sectored_distribution
 ====================================
 
 .. automodule:: merlin.core.sectored_distribution

--- a/docs/source/api_reference/api/merlin.core.sectored_distribution.rst
+++ b/docs/source/api_reference/api/merlin.core.sectored_distribution.rst
@@ -7,7 +7,7 @@ merlin.core.probability_distribution
 .. currentmodule:: merlin.core.sectored_distribution
 
 SectoredDistribution
--------------
+------------------------
 
 .. autoclass:: SectoredDistribution
    :members:

--- a/docs/source/api_reference/api/merlin.core.sectored_distribution.rst
+++ b/docs/source/api_reference/api/merlin.core.sectored_distribution.rst
@@ -1,0 +1,25 @@
+merlin.core.probability_distribution
+====================================
+
+.. automodule:: merlin.core.sectored_distribution
+   :no-members:
+
+.. currentmodule:: merlin.core.sectored_distribution
+
+SectoredDistribution
+-------------
+
+.. autoclass:: SectoredDistribution
+   :members:
+   :undoc-members:
+   :member-order: bysource
+   :show-inheritance:
+
+SectorResult
+-----------------------
+
+.. autoclass:: SectorResult
+   :members:
+   :undoc-members:
+   :member-order: bysource
+   :show-inheritance:

--- a/docs/source/api_reference/api/merlin.pcvl_pytorch.noisy_slos.rst
+++ b/docs/source/api_reference/api/merlin.pcvl_pytorch.noisy_slos.rst
@@ -6,7 +6,7 @@ merlin.pcvl\_pytorch.noisy\_slos module
 
 .. currentmodule:: merlin.pcvl_pytorch.noisy_slos
 
-.. autoclass:: NoisySLOSG2ComputeGraph
+.. autoclass:: NoisyG2SLOSComputeGraph
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/api_reference/api/merlin.pcvl_pytorch.noisy_slos.rst
+++ b/docs/source/api_reference/api/merlin.pcvl_pytorch.noisy_slos.rst
@@ -6,6 +6,11 @@ merlin.pcvl\_pytorch.noisy\_slos module
 
 .. currentmodule:: merlin.pcvl_pytorch.noisy_slos
 
+.. autoclass:: NoisySLOSG2ComputeGraph
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. autoclass:: NoisySLOSComputeGraph
    :members:
    :undoc-members:

--- a/docs/source/quantum_expert_area/noisy_simulations.rst
+++ b/docs/source/quantum_expert_area/noisy_simulations.rst
@@ -88,7 +88,7 @@ For noisy simulations, there are a couple of rules that need to be followed:
 1. All noisy simulations must be run with the probabilities measurement strategy.
 2. Noisy simulations cannot use ``return_object=True``.
 3. Noisy simulations with source noise must be run in the Fock computation space. If a different space is chosen, it will be changed automatically with a warning.
-4. Noisy simulation with ``g2>0`` can not use a grouping strategy. Indeed, since this noise creates input states with more phtons than expected, multiple photon sectors are explored. The fock spaces explored are m modes and n_photons to 2*n_photons that all have different space dimensions. To still apply a grouping strategy, you can iterate over the :class:`~merlin.core.sectored_distribution.SectorResult` objects of the :class:`~merlin.core.sectored_distribution.SectoredDistribution` and apply one grouping per sector.
+4. Noisy simulation with ``g2>0`` cannot use a grouping strategy. Indeed, since this noise creates input states with more photons than expected, multiple photon sectors are explored. The fock spaces explored are m modes and n_photons to 2*n_photons that all have different space dimensions. To still apply a grouping strategy, you can iterate over the :class:`~merlin.core.sectored_distribution.SectorResult` objects of the :class:`~merlin.core.sectored_distribution.SectoredDistribution` and apply one grouping per sector.
 
 
 g2_distinguishable parameter

--- a/docs/source/quantum_expert_area/noisy_simulations.rst
+++ b/docs/source/quantum_expert_area/noisy_simulations.rst
@@ -88,6 +88,7 @@ For noisy simulations, there are a couple of rules that need to be followed:
 1. All noisy simulations must be run with the probabilities measurement strategy.
 2. Noisy simulations cannot use ``return_object=True``.
 3. Noisy simulations with source noise must be run in the Fock computation space. If a different space is chosen, it will be changed automatically with a warning.
+4. Noisy simulation with ``g2>0`` can not use a grouping strategy. Indeed, since this noise creates input states with more phtons than expected, multiple photon sectors are explored. The fock spaces explored are m modes and n_photons to 2*n_photons that all have different space dimensions. To still apply a grouping strategy, you can iterate over the :class:`~merlin.core.sectored_distribution.SectorResult`s of the :class:`~merlin.core.sectored_distribution.SectoredDistribution` and apply one grouping per sector.
 
 
 g2_distinguishable parameter

--- a/docs/source/quantum_expert_area/noisy_simulations.rst
+++ b/docs/source/quantum_expert_area/noisy_simulations.rst
@@ -88,7 +88,7 @@ For noisy simulations, there are a couple of rules that need to be followed:
 1. All noisy simulations must be run with the probabilities measurement strategy.
 2. Noisy simulations cannot use ``return_object=True``.
 3. Noisy simulations with source noise must be run in the Fock computation space. If a different space is chosen, it will be changed automatically with a warning.
-4. Noisy simulation with ``g2>0`` can not use a grouping strategy. Indeed, since this noise creates input states with more phtons than expected, multiple photon sectors are explored. The fock spaces explored are m modes and n_photons to 2*n_photons that all have different space dimensions. To still apply a grouping strategy, you can iterate over the :class:`~merlin.core.sectored_distribution.SectorResult`s of the :class:`~merlin.core.sectored_distribution.SectoredDistribution` and apply one grouping per sector.
+4. Noisy simulation with ``g2>0`` can not use a grouping strategy. Indeed, since this noise creates input states with more phtons than expected, multiple photon sectors are explored. The fock spaces explored are m modes and n_photons to 2*n_photons that all have different space dimensions. To still apply a grouping strategy, you can iterate over the :class:`~merlin.core.sectored_distribution.SectorResult` objects of the :class:`~merlin.core.sectored_distribution.SectoredDistribution` and apply one grouping per sector.
 
 
 g2_distinguishable parameter

--- a/merlin/algorithms/kernels.py
+++ b/merlin/algorithms/kernels.py
@@ -993,9 +993,17 @@ class FidelityKernel(MerlinModule):
             all_circuits = U_forward[upper_idx[0]] @ U_adjoint[upper_idx[1]]
 
         # Distribution for every evaluated circuit
-        _, probabilities = self._slos_graph.compute_probs(
+        result = self._slos_graph.compute_probs(
             all_circuits, self.input_state
         )
+
+        # Handle both tuple return (SLOSComputeGraph) and SectoredDistribution return (NoisyG2SLOSComputeGraph)
+        from ..core.sectored_distribution import SectoredDistribution
+
+        if isinstance(result, SectoredDistribution):
+            raise NotImplementedError("Kernels do not currently support g2 noise models")
+
+        _, probabilities = result
 
         if probabilities.ndim == 1:
             probabilities = probabilities.unsqueeze(0)
@@ -1086,9 +1094,17 @@ class FidelityKernel(MerlinModule):
         U_adjoint = U_adjoint.conj().T
 
         kernel_unitary = U @ U_adjoint
-        _, probabilities = self._slos_graph.compute_probs(
+        result = self._slos_graph.compute_probs(
             kernel_unitary, self.input_state
         )
+
+        # Handle both tuple return (SLOSComputeGraph) and SectoredDistribution return (NoisyG2SLOSComputeGraph)
+        from ..core.sectored_distribution import SectoredDistribution
+
+        if isinstance(result, SectoredDistribution):
+            raise NotImplementedError("Kernels do not currently support g2 noise models")
+
+        _, probabilities = result
         if probabilities.ndim == 1:
             probabilities = probabilities.unsqueeze(0)
         probabilities = probabilities.to(dtype=self.dtype, device=self.device)

--- a/merlin/algorithms/kernels.py
+++ b/merlin/algorithms/kernels.py
@@ -993,15 +993,15 @@ class FidelityKernel(MerlinModule):
             all_circuits = U_forward[upper_idx[0]] @ U_adjoint[upper_idx[1]]
 
         # Distribution for every evaluated circuit
-        result = self._slos_graph.compute_probs(
-            all_circuits, self.input_state
-        )
+        result = self._slos_graph.compute_probs(all_circuits, self.input_state)
 
         # Handle both tuple return (SLOSComputeGraph) and SectoredDistribution return (NoisyG2SLOSComputeGraph)
         from ..core.sectored_distribution import SectoredDistribution
 
         if isinstance(result, SectoredDistribution):
-            raise NotImplementedError("Kernels do not currently support g2 noise models")
+            raise NotImplementedError(
+                "Kernels do not currently support g2 noise models"
+            )
 
         _, probabilities = result
 
@@ -1094,15 +1094,15 @@ class FidelityKernel(MerlinModule):
         U_adjoint = U_adjoint.conj().T
 
         kernel_unitary = U @ U_adjoint
-        result = self._slos_graph.compute_probs(
-            kernel_unitary, self.input_state
-        )
+        result = self._slos_graph.compute_probs(kernel_unitary, self.input_state)
 
         # Handle both tuple return (SLOSComputeGraph) and SectoredDistribution return (NoisyG2SLOSComputeGraph)
         from ..core.sectored_distribution import SectoredDistribution
 
         if isinstance(result, SectoredDistribution):
-            raise NotImplementedError("Kernels do not currently support g2 noise models")
+            raise NotImplementedError(
+                "Kernels do not currently support g2 noise models"
+            )
 
         _, probabilities = result
         if probabilities.ndim == 1:

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -1255,7 +1255,7 @@ class QuantumLayer(MerlinModule):
             # Photon loss Module
             if self._photon_loss_transform is not None:
                 if isinstance(self._photon_loss_transform, Sequence):
-                    for i in range(self._photon_loss_transform):
+                    for i in range(len(self._photon_loss_transform)):
                         self._photon_loss_transform[i] = self._photon_loss_transform[
                             i
                         ].to(device)
@@ -1264,7 +1264,7 @@ class QuantumLayer(MerlinModule):
             # Detector Module
             if self._detector_transform is not None:
                 if isinstance(self._detector_transform, Sequence):
-                    for i in range(self._detector_transform):
+                    for i in range(len(self._detector_transform)):
                         self._detector_transform[i] = self._detector_transform[i].to(
                             device
                         )
@@ -1468,6 +1468,9 @@ class QuantumLayer(MerlinModule):
                     distribution_copy.sectors[i].tensor = self._photon_loss_transform[
                         index
                     ](sector.tensor)
+                    distribution_copy.sectors[i].keys = tuple(
+                        self._photon_loss_transform[index].output_keys
+                    )
                 return distribution_copy
             return self._photon_loss_transform(distribution)
         if isinstance(self._photon_loss_transform, Sequence):
@@ -1493,6 +1496,9 @@ class QuantumLayer(MerlinModule):
                     distribution_copy.sectors[i].tensor = self._detector_transform[
                         index
                     ](sector.tensor)
+                    distribution_copy.sectors[i].keys = tuple(
+                        self._detector_transform[index].output_keys
+                    )
                 return distribution_copy
             return self._detector_transform(distribution)
         if isinstance(self._detector_transform, Sequence):

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -982,7 +982,12 @@ class QuantumLayer(MerlinModule):
             )
         else:
             # The `amplitudes` are already probabilities in the noisy case
+            # In g2 noise case, amplitudes is SectoredDistribution; use it as distribution
             distribution = amplitudes
+            # For mypy
+            # For noisy g2 case, set amplitudes to empty tensor since no raw amplitudes exist
+            if isinstance(amplitudes, SectoredDistribution):
+                amplitudes = torch.tensor([], dtype=torch.complex128)
 
         # Phase 6: Measurement strategy dispatch and output mapping
         strategy = resolve_measurement_strategy(self.measurement_strategy)

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -372,7 +372,8 @@ class QuantumLayer(MerlinModule):
         self._photon_loss_transform: (
             list[PhotonLossTransform] | PhotonLossTransform | None
         ) = None
-        self._detector_keys: list[tuple[int, ...]] = []
+        self._photon_loss_keys: list[tuple[int, ...]] | list[list[tuple[int, ...]]] = []
+        self._detector_keys: list[tuple[int, ...]] | list[list[tuple[int, ...]]] = []
         self._raw_output_keys: list[tuple[int, ...]] | list[list[tuple[int, ...]]] = []
         self._detector_is_identity = True
         self._output_size = 0
@@ -590,7 +591,7 @@ class QuantumLayer(MerlinModule):
                 keys = [list(raw_keys) for raw_keys in self._raw_output_keys]
                 dist_size = sum(len(key) for key in keys)
             else:
-                keys = list(self._raw_output_keys)
+                keys = cast(list[tuple[int, ...]], self._raw_output_keys)
                 dist_size = len(keys)
         else:
             if (
@@ -605,9 +606,9 @@ class QuantumLayer(MerlinModule):
                 dist_size = sum(len(key) for key in keys)
             else:
                 keys = (
-                    list(self._photon_loss_keys)
+                    cast(list[tuple[int, ...]], self._photon_loss_keys)
                     if self._detector_is_identity
-                    else list(self._detector_keys)
+                    else cast(list[tuple[int, ...]], self._detector_keys)
                 )
                 dist_size = len(keys)
 
@@ -646,10 +647,11 @@ class QuantumLayer(MerlinModule):
         if kind == MeasurementKind.PARTIAL or source_noise:
             self.measurement_mapping = nn.Identity()
         else:
+            measurement_keys = cast(list[tuple[int, ...]], keys)
             self.measurement_mapping = OutputMapper.create_mapping(
                 measurement_strategy,
                 self.computation_process.computation_space,
-                keys,
+                measurement_keys,
                 dtype=self.dtype,
             )
 
@@ -1291,7 +1293,7 @@ class QuantumLayer(MerlinModule):
             ):
                 return [list(keys) for keys in self._raw_output_keys]
             else:
-                return list(self._raw_output_keys)
+                return cast(list[tuple[int, ...]], self._raw_output_keys)
         if self._detector_is_identity:
             if (
                 isinstance(self._raw_output_keys, list)
@@ -1300,14 +1302,14 @@ class QuantumLayer(MerlinModule):
             ):
                 return [list(keys) for keys in self._photon_loss_keys]
             else:
-                return list(self._photon_loss_keys)
+                return cast(list[tuple[int, ...]], self._photon_loss_keys)
         if (
             isinstance(self._raw_output_keys, list)
             and self._raw_output_keys
             and isinstance(self._raw_output_keys[0], list)
         ):
             return [list(keys) for keys in self._detector_keys]
-        return list(self._detector_keys)
+        return cast(list[tuple[int, ...]], self._detector_keys)
 
     @property
     def output_size(self) -> int:
@@ -1343,7 +1345,7 @@ class QuantumLayer(MerlinModule):
             self._photon_loss_is_identity = all(photon_loss_identities)
         else:
             self._photon_loss_transform = PhotonLossTransform(
-                self._raw_output_keys,
+                cast(list[tuple[int, ...]], self._raw_output_keys),
                 self._photon_survival_probs,
                 dtype=self.dtype,
                 device=self.device,
@@ -1441,14 +1443,20 @@ class QuantumLayer(MerlinModule):
             )
         if self._photon_loss_is_identity:
             return distribution
-        if isinstance(self._detector_transform, Sequence):
-            distribution_copy = distribution.clone()
-            for i in range(len(distribution_copy.sectors)):
-                index = distribution_copy.sectors[i].n_photons - self.n_photons
-                distribution_copy.sectors[i].tensor = self._photon_loss_transform[
-                    index
-                ](distribution_copy.sectors[i].tensor)
-            return distribution_copy
+        if isinstance(distribution, SectoredDistribution):
+            if isinstance(self._photon_loss_transform, Sequence):
+                distribution_copy = distribution.clone()
+                for i, sector in enumerate(distribution_copy.sectors):
+                    index = sector.n_photons - self.n_photons
+                    distribution_copy.sectors[i].tensor = self._photon_loss_transform[
+                        index
+                    ](sector.tensor)
+                return distribution_copy
+            return self._photon_loss_transform(distribution)
+        if isinstance(self._photon_loss_transform, Sequence):
+            raise RuntimeError(
+                "Invalid photon-loss transform for non-sectored distribution."
+            )
         return self._photon_loss_transform(distribution)
 
     def _apply_detector_transform(
@@ -1460,14 +1468,20 @@ class QuantumLayer(MerlinModule):
             )
         if self._detector_is_identity:
             return distribution
+        if isinstance(distribution, SectoredDistribution):
+            if isinstance(self._detector_transform, Sequence):
+                distribution_copy = distribution.clone()
+                for i, sector in enumerate(distribution_copy.sectors):
+                    index = sector.n_photons - self.n_photons
+                    distribution_copy.sectors[i].tensor = self._detector_transform[
+                        index
+                    ](sector.tensor)
+                return distribution_copy
+            return self._detector_transform(distribution)
         if isinstance(self._detector_transform, Sequence):
-            distribution_copy = distribution.clone()
-            for i in range(len(distribution_copy.sectors)):
-                index = distribution_copy.sectors[i].n_photons - self.n_photons
-                distribution_copy.sectors[i].tensor = self._detector_transform[index](
-                    distribution_copy.sectors[i].tensor
-                )
-            return distribution_copy
+            raise RuntimeError(
+                "Invalid detector transform for non-sectored distribution."
+            )
         return self._detector_transform(distribution)
 
     # =====================  EXPORT API FOR REMOTE PROCESSORS  =====================

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -471,7 +471,7 @@ class QuantumLayer(MerlinModule):
                 if "g2" in self._noise_groups.source:
                     g2_noise = True
         if g2_noise:
-            raw_keys = cast(
+            raw_keys_per_n = cast(
                 list[list[tuple[int, ...]]],
                 [
                     list(keys_per_n)
@@ -481,17 +481,17 @@ class QuantumLayer(MerlinModule):
             self._raw_output_keys = cast(
                 list[list[tuple[int, ...]]],
                 [
-                    [self._normalize_output_key(key) for key in raw_keys_per_n]
-                    for raw_keys_per_n in raw_keys
+                    [self._normalize_output_key(key) for key in raw_keys]
+                    for raw_keys in raw_keys_per_n
                 ],
             )
         else:
-            raw_keys = cast(
+            flat_raw_keys = cast(
                 list[tuple[int, ...]],
                 self.computation_process.simulation_graph.mapped_keys,
             )
             self._raw_output_keys = [
-                self._normalize_output_key(key) for key in raw_keys
+                self._normalize_output_key(key) for key in flat_raw_keys
             ]
         self._initialize_photon_loss_transform()
         self._initialize_detector_transform()
@@ -585,17 +585,20 @@ class QuantumLayer(MerlinModule):
 
         kind = _resolve_measurement_kind(measurement_strategy)
 
+        flat_keys: list[tuple[int, ...]] | None = None
         if kind == MeasurementKind.AMPLITUDES:
             if (
                 isinstance(self._raw_output_keys, list)
                 and self._raw_output_keys
                 and isinstance(self._raw_output_keys[0], list)
             ):
-                keys = cast(list[list[tuple[int, ...]]], self._raw_output_keys)
-                dist_size = sum(len(key) for key in keys)
+                nested_amplitude_keys = cast(
+                    list[list[tuple[int, ...]]], self._raw_output_keys
+                )
+                dist_size = sum(len(key) for key in nested_amplitude_keys)
             else:
-                keys = cast(list[tuple[int, ...]], self._raw_output_keys)
-                dist_size = len(keys)
+                flat_keys = cast(list[tuple[int, ...]], self._raw_output_keys)
+                dist_size = len(flat_keys)
         else:
             if (
                 isinstance(self._raw_output_keys, list)
@@ -603,17 +606,21 @@ class QuantumLayer(MerlinModule):
                 and isinstance(self._raw_output_keys[0], list)
             ):
                 if self._detector_is_identity:
-                    keys = cast(list[list[tuple[int, ...]]], self._photon_loss_keys)
+                    nested_detector_keys = cast(
+                        list[list[tuple[int, ...]]], self._photon_loss_keys
+                    )
                 else:
-                    keys = cast(list[list[tuple[int, ...]]], self._detector_keys)
-                dist_size = sum(len(key) for key in keys)
+                    nested_detector_keys = cast(
+                        list[list[tuple[int, ...]]], self._detector_keys
+                    )
+                dist_size = sum(len(key) for key in nested_detector_keys)
             else:
-                keys = (
+                flat_keys = (
                     cast(list[tuple[int, ...]], self._photon_loss_keys)
                     if self._detector_is_identity
                     else cast(list[tuple[int, ...]], self._detector_keys)
                 )
-                dist_size = len(keys)
+                dist_size = len(flat_keys)
 
         # Determine output size (upstream model)
         if kind == MeasurementKind.PROBABILITIES:
@@ -650,7 +657,8 @@ class QuantumLayer(MerlinModule):
         if kind == MeasurementKind.PARTIAL or source_noise:
             self.measurement_mapping = nn.Identity()
         else:
-            measurement_keys = cast(list[tuple[int, ...]], keys)
+            assert flat_keys is not None
+            measurement_keys = flat_keys
             self.measurement_mapping = OutputMapper.create_mapping(
                 measurement_strategy,
                 self.computation_process.computation_space,
@@ -1420,8 +1428,12 @@ class QuantumLayer(MerlinModule):
             ]
             self._detector_is_identity = all(detector_transform_identities)
         else:
-            detector_transform = DetectorTransform(
+            flat_photon_loss_keys = cast(
+                Iterable[Sequence[int]],
                 self._photon_loss_keys,
+            )
+            detector_transform = DetectorTransform(
+                flat_photon_loss_keys,
                 detectors,
                 dtype=self.dtype,
                 device=self.device,

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -984,10 +984,12 @@ class QuantumLayer(MerlinModule):
             # The `amplitudes` are already probabilities in the noisy case
             # In g2 noise case, amplitudes is SectoredDistribution; use it as distribution
             distribution = amplitudes
-            # For mypy
             # For noisy g2 case, set amplitudes to empty tensor since no raw amplitudes exist
             if isinstance(amplitudes, SectoredDistribution):
                 amplitudes = torch.tensor([], dtype=torch.complex128)
+            else:
+                # In non-g2 noisy case, amplitudes is already a Tensor
+                amplitudes = cast(torch.Tensor, amplitudes)
 
         # Phase 6: Measurement strategy dispatch and output mapping
         strategy = resolve_measurement_strategy(self.measurement_strategy)

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -1042,7 +1042,7 @@ class QuantumLayer(MerlinModule):
         inferred_state: torch.Tensor | None,
         parameter_batch_dim: int,
         simultaneous_processes: int | None,
-    ) -> torch.Tensor:
+    ) -> torch.Tensor | SectoredDistribution:
         """Select the computation path based on the encoding mode and input state."""
         # Checking if there is source noise
         source_noise = False if self._noise_groups is None else True

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -478,10 +478,13 @@ class QuantumLayer(MerlinModule):
                     for keys_per_n in self.computation_process.simulation_graph.mapped_keys
                 ],
             )
-            self._raw_output_keys = [
-                [self._normalize_output_key(key) for key in raw_keys_per_n]
-                for raw_keys_per_n in raw_keys
-            ]
+            self._raw_output_keys = cast(
+                list[list[tuple[int, ...]]],
+                [
+                    [self._normalize_output_key(key) for key in raw_keys_per_n]
+                    for raw_keys_per_n in raw_keys
+                ],
+            )
         else:
             raw_keys = cast(
                 list[tuple[int, ...]],
@@ -588,7 +591,7 @@ class QuantumLayer(MerlinModule):
                 and self._raw_output_keys
                 and isinstance(self._raw_output_keys[0], list)
             ):
-                keys = [list(raw_keys) for raw_keys in self._raw_output_keys]
+                keys = cast(list[list[tuple[int, ...]]], self._raw_output_keys)
                 dist_size = sum(len(key) for key in keys)
             else:
                 keys = cast(list[tuple[int, ...]], self._raw_output_keys)
@@ -600,9 +603,9 @@ class QuantumLayer(MerlinModule):
                 and isinstance(self._raw_output_keys[0], list)
             ):
                 if self._detector_is_identity:
-                    keys = [list(raw_keys) for raw_keys in self._photon_loss_keys]
+                    keys = cast(list[list[tuple[int, ...]]], self._photon_loss_keys)
                 else:
-                    keys = [list(raw_keys) for raw_keys in self._detector_keys]
+                    keys = cast(list[list[tuple[int, ...]]], self._detector_keys)
                 dist_size = sum(len(key) for key in keys)
             else:
                 keys = (
@@ -1291,7 +1294,7 @@ class QuantumLayer(MerlinModule):
                 and self._raw_output_keys
                 and isinstance(self._raw_output_keys[0], list)
             ):
-                return [list(keys) for keys in self._raw_output_keys]
+                return cast(list[list[tuple[int, ...]]], self._raw_output_keys)
             else:
                 return cast(list[tuple[int, ...]], self._raw_output_keys)
         if self._detector_is_identity:
@@ -1300,7 +1303,7 @@ class QuantumLayer(MerlinModule):
                 and self._raw_output_keys
                 and isinstance(self._raw_output_keys[0], list)
             ):
-                return [list(keys) for keys in self._photon_loss_keys]
+                return cast(list[list[tuple[int, ...]]], self._photon_loss_keys)
             else:
                 return cast(list[tuple[int, ...]], self._photon_loss_keys)
         if (
@@ -1308,7 +1311,7 @@ class QuantumLayer(MerlinModule):
             and self._raw_output_keys
             and isinstance(self._raw_output_keys[0], list)
         ):
-            return [list(keys) for keys in self._detector_keys]
+            return cast(list[list[tuple[int, ...]]], self._detector_keys)
         return cast(list[tuple[int, ...]], self._detector_keys)
 
     @property
@@ -1383,10 +1386,10 @@ class QuantumLayer(MerlinModule):
                 raise ValueError(
                     "Partial measurement requires at least one measured mode."
                 )
-            if g2_noise is True:
-                n_modes = len(self._photon_loss_keys[0][0])
+            if g2_noise is True and isinstance(self._photon_loss_keys[0], list):
+                n_modes = len(cast(tuple[int, ...], self._photon_loss_keys[0][0]))
             else:
-                n_modes = len(self._photon_loss_keys[0])
+                n_modes = len(cast(tuple[int, ...], self._photon_loss_keys[0]))
             self.measurement_strategy.validate_modes(n_modes)
             measured = set(self.measurement_strategy.measured_modes)
             detectors = [
@@ -1395,23 +1398,25 @@ class QuantumLayer(MerlinModule):
             ]
             partial = True
         if g2_noise:
-            detector_transform = [
+            detector_transform_list: list[DetectorTransform] = [
                 DetectorTransform(
-                    photon_loss_key,
+                    cast(Iterable[Sequence[int]], photon_loss_key),
                     detectors,
                     dtype=self.dtype,
                     device=self.device,
                     partial_measurement=partial,
                 )
-                for photon_loss_key in self._photon_loss_keys
+                for photon_loss_key in cast(
+                    list[list[tuple[int, ...]]], self._photon_loss_keys
+                )
             ]
-            self._detector_transform = detector_transform
+            self._detector_transform = detector_transform_list
             self._detector_keys = [
                 detector_transform_per_n.output_keys
-                for detector_transform_per_n in self._detector_transform
+                for detector_transform_per_n in detector_transform_list
             ]
             detector_transform_identities = [
-                transform.is_identity for transform in self._detector_transform
+                transform.is_identity for transform in detector_transform_list
             ]
             self._detector_is_identity = all(detector_transform_identities)
         else:

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -44,6 +44,7 @@ from ..core.probability_distribution import ProbabilityDistribution
 from ..core.process import ComputationProcessFactory
 from ..core.state import StatePattern, generate_state
 from ..core.state_vector import StateVector
+from ..core.sectored_distribution import SectoredDistribution
 from ..measurement import OutputMapper
 from ..measurement.autodiff import AutoDiffProcess
 from ..measurement.detectors import DetectorTransform
@@ -993,7 +994,7 @@ class QuantumLayer(MerlinModule):
             amplitudes=amplitudes,
             apply_sampling=apply_sampling,
             effective_shots=effective_shots,
-            sample_fn=adp.sampling_noise.pcvl_sampler,
+            sampler=adp.sampling_noise,
             apply_photon_loss=self._apply_photon_loss_transform,
             apply_detectors=self._apply_detector_transform,
             grouping=grouping,

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -62,6 +62,7 @@ from ..utils.deprecations import (
 )
 from ..utils.grouping import ModGrouping
 from ..utils.normalization import normalize_probabilities_and_amplitudes
+from ..utils.combinadics import Combinadics
 from .layer_utils import (
     InitializationContext,
     apply_angle_encoding,
@@ -366,10 +367,14 @@ class QuantumLayer(MerlinModule):
         self._detectors = context.detectors
         self._has_custom_detectors = context.has_custom_detectors
         self.detectors = self._detectors
-        self._detector_transform: DetectorTransform | None = None
-        self._photon_loss_transform: PhotonLossTransform | None = None
+        self._detector_transform: list[DetectorTransform] | DetectorTransform | None = (
+            None
+        )
+        self._photon_loss_transform: (
+            list[PhotonLossTransform] | PhotonLossTransform | None
+        ) = None
         self._detector_keys: list[tuple[int, ...]] = []
-        self._raw_output_keys: list[tuple[int, ...]] = []
+        self._raw_output_keys: list[tuple[int, ...]] | list[list[tuple[int, ...]]] = []
         self._detector_is_identity = True
         self._output_size = 0
         self._current_params: dict[str, Any] = {}
@@ -459,10 +464,32 @@ class QuantumLayer(MerlinModule):
 
         # Setup PhotonLossTransform & DetectorTransform
         self.n_photons = self.computation_process.n_photons
-        raw_keys = cast(
-            list[tuple[int, ...]], self.computation_process.simulation_graph.mapped_keys
-        )
-        self._raw_output_keys = [self._normalize_output_key(key) for key in raw_keys]
+
+        g2_noise = False
+        if self._noise_groups is not None:
+            if self._noise_groups.source is not None:
+                if "g2" in self._noise_groups.source:
+                    g2_noise = True
+        if g2_noise:
+            raw_keys = cast(
+                list[list[tuple[int, ...]]],
+                [
+                    list(keys_per_n)
+                    for keys_per_n in self.computation_process.simulation_graph.mapped_keys
+                ],
+            )
+            self._raw_output_keys = [
+                [self._normalize_output_key(key) for key in raw_keys_per_n]
+                for raw_keys_per_n in raw_keys
+            ]
+        else:
+            raw_keys = cast(
+                list[tuple[int, ...]],
+                self.computation_process.simulation_graph.mapped_keys,
+            )
+            self._raw_output_keys = [
+                self._normalize_output_key(key) for key in raw_keys
+            ]
         self._initialize_photon_loss_transform()
         self._initialize_detector_transform()
 
@@ -556,15 +583,34 @@ class QuantumLayer(MerlinModule):
         kind = _resolve_measurement_kind(measurement_strategy)
 
         if kind == MeasurementKind.AMPLITUDES:
-            keys = list(self._raw_output_keys)
+            if (
+                isinstance(self._raw_output_keys, list)
+                and self._raw_output_keys
+                and isinstance(self._raw_output_keys[0], list)
+            ):
+                keys = list(list(raw_keys) for raw_keys in self._raw_output_keys)
+                dist_size = sum([len(key) for key in keys])
+            else:
+                keys = list(self._raw_output_keys)
+                dist_size = len(keys)
         else:
-            keys = (
-                list(self._photon_loss_keys)
-                if self._detector_is_identity
-                else list(self._detector_keys)
-            )
-
-        dist_size = len(keys)
+            if (
+                isinstance(self._raw_output_keys, list)
+                and self._raw_output_keys
+                and isinstance(self._raw_output_keys[0], list)
+            ):
+                if self._detector_is_identity:
+                    keys = list(list(raw_keys) for raw_keys in self._photon_loss_keys)
+                else:
+                    keys = list(list(raw_keys) for raw_keys in self._detector_keys)
+                dist_size = sum([len(key) for key in keys])
+            else:
+                keys = (
+                    list(self._photon_loss_keys)
+                    if self._detector_is_identity
+                    else list(self._detector_keys)
+                )
+                dist_size = len(keys)
 
         # Determine output size (upstream model)
         if kind == MeasurementKind.PROBABILITIES:
@@ -582,7 +628,12 @@ class QuantumLayer(MerlinModule):
                 raise RuntimeError(
                     "Detector transform must be initialised before sizing."
                 )
-            self._output_size = self._detector_transform.output_size
+            if isinstance(self._detector_transform, Sequence):
+                self._output_size = 1
+                for detector in self._detector_transform:
+                    self._output_size += detector.output_size
+            else:
+                self._output_size = self._detector_transform.output_size
         else:
             raise TypeError(f"Unknown measurement_strategy: {measurement_strategy}")
 
@@ -697,12 +748,25 @@ class QuantumLayer(MerlinModule):
         # With partial measurement, the amplitude input size cannot be verified using `output_keys` (reduced by the partial measurement)
         # Instead it should be confirmed with `_raw_output_keys`.
         if (
-            isinstance(self.measurement_strategy, MeasurementStrategy)
-            and self.measurement_strategy.type is MeasurementKind.PARTIAL
+            isinstance(self._raw_output_keys, list)
+            and self._raw_output_keys
+            and isinstance(self._raw_output_keys[0], list)
         ):
-            expected_dim = len(self._raw_output_keys)
+            if (
+                isinstance(self.measurement_strategy, MeasurementStrategy)
+                and self.measurement_strategy.type is MeasurementKind.PARTIAL
+            ):
+                expected_dim = len([len(key) for key in self._raw_output_keys])
+            else:
+                expected_dim = len(self.output_keys)
         else:
-            expected_dim = len(self.output_keys)
+            if (
+                isinstance(self.measurement_strategy, MeasurementStrategy)
+                and self.measurement_strategy.type is MeasurementKind.PARTIAL
+            ):
+                expected_dim = len(self._raw_output_keys)
+            else:
+                expected_dim = len(self.output_keys)
 
         feature_dim = amplitude.shape[-1]
         if feature_dim != expected_dim:
@@ -1178,10 +1242,22 @@ class QuantumLayer(MerlinModule):
 
             # Photon loss Module
             if self._photon_loss_transform is not None:
-                self._photon_loss_transform = self._photon_loss_transform.to(device)
+                if isinstance(self._photon_loss_transform, Sequence):
+                    for i in range(self._photon_loss_transform):
+                        self._photon_loss_transform[i] = self._photon_loss_transform[
+                            i
+                        ].to(device)
+                else:
+                    self._photon_loss_transform = self._photon_loss_transform.to(device)
             # Detector Module
             if self._detector_transform is not None:
-                self._detector_transform = self._detector_transform.to(device)
+                if isinstance(self._detector_transform, Sequence):
+                    for i in range(self._detector_transform):
+                        self._detector_transform[i] = self._detector_transform[i].to(
+                            device
+                        )
+                else:
+                    self._detector_transform = self._detector_transform.to(device)
 
         return self
 
@@ -1192,14 +1268,46 @@ class QuantumLayer(MerlinModule):
             getattr(self, "_photon_loss_transform", None) is None
             or getattr(self, "_detector_transform", None) is None
         ):
-            return [self._normalize_output_key(key) for key in self._raw_output_keys]
+            if (
+                isinstance(self._raw_output_keys, list)
+                and self._raw_output_keys
+                and isinstance(self._raw_output_keys[0], list)
+            ):
+                return [
+                    [self._normalize_output_key(key) for key in output_key_per_photon]
+                    for output_key_per_photon in self._raw_output_keys
+                ]
+            else:
+                return [
+                    self._normalize_output_key(key) for key in self._raw_output_keys
+                ]
         if (
             _resolve_measurement_kind(self.measurement_strategy)
             == MeasurementKind.AMPLITUDES
         ):
-            return list(self._raw_output_keys)
+            if (
+                isinstance(self._raw_output_keys, list)
+                and self._raw_output_keys
+                and isinstance(self._raw_output_keys[0], list)
+            ):
+                return list([list(keys) for keys in self._raw_output_keys])
+            else:
+                return list(self._raw_output_keys)
         if self._detector_is_identity:
-            return list(self._photon_loss_keys)
+            if (
+                isinstance(self._raw_output_keys, list)
+                and self._raw_output_keys
+                and isinstance(self._raw_output_keys[0], list)
+            ):
+                return list([list(keys) for keys in self._photon_loss_keys])
+            else:
+                return list(self._photon_loss_keys)
+        if (
+            isinstance(self._raw_output_keys, list)
+            and self._raw_output_keys
+            and isinstance(self._raw_output_keys[0], list)
+        ):
+            return list([list(keys) for keys in self._detector_keys])
         return list(self._detector_keys)
 
     @property
@@ -1213,18 +1321,50 @@ class QuantumLayer(MerlinModule):
         return self._has_custom_detectors
 
     def _initialize_photon_loss_transform(self) -> None:
-        self._photon_loss_transform = PhotonLossTransform(
-            self._raw_output_keys,
-            self._photon_survival_probs,
-            dtype=self.dtype,
-            device=self.device,
-        )
-        self._photon_loss_keys = self._photon_loss_transform.output_keys
-        self._photon_loss_is_identity = self._photon_loss_transform.is_identity
+        if (
+            isinstance(self._raw_output_keys, list)
+            and self._raw_output_keys
+            and isinstance(self._raw_output_keys[0], list)
+        ):
+            self._photon_loss_transform = [
+                PhotonLossTransform(
+                    keys,
+                    self._photon_survival_probs,
+                    dtype=self.dtype,
+                    device=self.device,
+                )
+                for keys in self._raw_output_keys
+            ]
+            self._photon_loss_keys = [
+                transform.output_keys for transform in self._photon_loss_transform
+            ]
+            photon_loss_identities = [
+                transform.is_identity for transform in self._photon_loss_transform
+            ]
+            self._photon_loss_is_identity = all(photon_loss_identities)
+        else:
+            self._photon_loss_transform = PhotonLossTransform(
+                self._raw_output_keys,
+                self._photon_survival_probs,
+                dtype=self.dtype,
+                device=self.device,
+            )
+            self._photon_loss_keys = self._photon_loss_transform.output_keys
+            self._photon_loss_is_identity = self._photon_loss_transform.is_identity
 
     def _initialize_detector_transform(self) -> None:
         detectors = self._detectors
         partial = False
+
+        if (
+            isinstance(self._raw_output_keys, list)
+            and self._raw_output_keys
+            and isinstance(self._raw_output_keys[0], list)
+        ):
+            g2_noise = True
+        else:
+            g2_noise = False
+
         if (
             _resolve_measurement_kind(self.measurement_strategy)
             == MeasurementKind.PARTIAL
@@ -1242,7 +1382,10 @@ class QuantumLayer(MerlinModule):
                 raise ValueError(
                     "Partial measurement requires at least one measured mode."
                 )
-            n_modes = len(self._photon_loss_keys[0])
+            if g2_noise is True:
+                n_modes = len(self._photon_loss_keys[0][0])
+            else:
+                n_modes = len(self._photon_loss_keys[0])
             self.measurement_strategy.validate_modes(n_modes)
             measured = set(self.measurement_strategy.measured_modes)
             detectors = [
@@ -1250,16 +1393,37 @@ class QuantumLayer(MerlinModule):
                 for idx, det in enumerate(self._detectors)
             ]
             partial = True
-        detector_transform = DetectorTransform(
-            self._photon_loss_keys,
-            detectors,
-            dtype=self.dtype,
-            device=self.device,
-            partial_measurement=partial,
-        )
-        self._detector_transform = detector_transform
-        self._detector_keys = detector_transform.output_keys
-        self._detector_is_identity = detector_transform.is_identity
+        if g2_noise:
+            detector_transform = [
+                DetectorTransform(
+                    photon_loss_key,
+                    detectors,
+                    dtype=self.dtype,
+                    device=self.device,
+                    partial_measurement=partial,
+                )
+                for photon_loss_key in self._photon_loss_keys
+            ]
+            self._detector_transform = detector_transform
+            self._detector_keys = [
+                detector_transform_per_n.output_keys
+                for detector_transform_per_n in self._detector_transform
+            ]
+            detector_transform_identities = [
+                transform.is_identity for transform in self._detector_transform
+            ]
+            self._detector_is_identity = all(detector_transform_identities)
+        else:
+            detector_transform = DetectorTransform(
+                self._photon_loss_keys,
+                detectors,
+                dtype=self.dtype,
+                device=self.device,
+                partial_measurement=partial,
+            )
+            self._detector_transform = detector_transform
+            self._detector_keys = detector_transform.output_keys
+            self._detector_is_identity = detector_transform.is_identity
 
     @staticmethod
     def _normalize_output_key(
@@ -1269,22 +1433,42 @@ class QuantumLayer(MerlinModule):
             return tuple(int(v) for v in key.tolist())
         return tuple(int(v) for v in key)
 
-    def _apply_photon_loss_transform(self, distribution: torch.Tensor) -> torch.Tensor:
+    def _apply_photon_loss_transform(
+        self, distribution: torch.Tensor | SectoredDistribution
+    ) -> torch.Tensor | SectoredDistribution:
         if self._photon_loss_transform is None:
             raise RuntimeError(
                 "Photon loss transform must be initialised before applying photon loss."
             )
         if self._photon_loss_is_identity:
             return distribution
+        if isinstance(self._detector_transform, Sequence):
+            distribution_copy = distribution.clone()
+            for i in range(len(distribution_copy.sectors)):
+                index = distribution_copy.sectors[i].n_photons - self.n_photons
+                distribution_copy.sectors[i].tensor = self._photon_loss_transform[
+                    index
+                ](distribution_copy.sectors[i].tensor)
+            return distribution_copy
         return self._photon_loss_transform(distribution)
 
-    def _apply_detector_transform(self, distribution: torch.Tensor) -> torch.Tensor:
+    def _apply_detector_transform(
+        self, distribution: torch.Tensor | SectoredDistribution
+    ) -> torch.Tensor | SectoredDistribution:
         if self._detector_transform is None:
             raise RuntimeError(
                 "Detector transform must be initialised before applying detectors."
             )
         if self._detector_is_identity:
             return distribution
+        if isinstance(self._detector_transform, Sequence):
+            distribution_copy = distribution.clone()
+            for i in range(len(distribution_copy.sectors)):
+                index = distribution_copy.sectors[i].n_photons - self.n_photons
+                distribution_copy.sectors[i].tensor = self._detector_transform[index](
+                    distribution_copy.sectors[i].tensor
+                )
+            return distribution_copy
         return self._detector_transform(distribution)
 
     # =====================  EXPORT API FOR REMOTE PROCESSORS  =====================

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -42,9 +42,9 @@ from ..core.computation_space import ComputationSpace
 from ..core.partial_measurement import PartialMeasurement
 from ..core.probability_distribution import ProbabilityDistribution
 from ..core.process import ComputationProcessFactory
+from ..core.sectored_distribution import SectoredDistribution
 from ..core.state import StatePattern, generate_state
 from ..core.state_vector import StateVector
-from ..core.sectored_distribution import SectoredDistribution
 from ..measurement import OutputMapper
 from ..measurement.autodiff import AutoDiffProcess
 from ..measurement.detectors import DetectorTransform
@@ -797,7 +797,13 @@ class QuantumLayer(MerlinModule):
         shots: int | None = None,
         sampling_method: str | None = None,
         simultaneous_processes: int | None = None,
-    ) -> torch.Tensor | PartialMeasurement | StateVector | ProbabilityDistribution:
+    ) -> (
+        torch.Tensor
+        | PartialMeasurement
+        | StateVector
+        | ProbabilityDistribution
+        | SectoredDistribution
+    ):
         """Forward pass through the quantum layer.
 
         Encoding is inferred from the input type:
@@ -820,7 +826,7 @@ class QuantumLayer(MerlinModule):
 
         Returns
         -------
-        torch.Tensor | PartialMeasurement | merlin.core.state_vector.StateVector | ProbabilityDistribution
+        torch.Tensor | PartialMeasurement | merlin.core.state_vector.StateVector | ProbabilityDistribution | SectoredDistribution
             Output after measurement mapping.
             Depending on the return_object argument and measurement strategy defined in the input, the output
             type will be different. Check the constructor for more details.

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -62,7 +62,6 @@ from ..utils.deprecations import (
 )
 from ..utils.grouping import ModGrouping
 from ..utils.normalization import normalize_probabilities_and_amplitudes
-from ..utils.combinadics import Combinadics
 from .layer_utils import (
     InitializationContext,
     apply_angle_encoding,
@@ -588,8 +587,8 @@ class QuantumLayer(MerlinModule):
                 and self._raw_output_keys
                 and isinstance(self._raw_output_keys[0], list)
             ):
-                keys = list(list(raw_keys) for raw_keys in self._raw_output_keys)
-                dist_size = sum([len(key) for key in keys])
+                keys = [list(raw_keys) for raw_keys in self._raw_output_keys]
+                dist_size = sum(len(key) for key in keys)
             else:
                 keys = list(self._raw_output_keys)
                 dist_size = len(keys)
@@ -600,10 +599,10 @@ class QuantumLayer(MerlinModule):
                 and isinstance(self._raw_output_keys[0], list)
             ):
                 if self._detector_is_identity:
-                    keys = list(list(raw_keys) for raw_keys in self._photon_loss_keys)
+                    keys = [list(raw_keys) for raw_keys in self._photon_loss_keys]
                 else:
-                    keys = list(list(raw_keys) for raw_keys in self._detector_keys)
-                dist_size = sum([len(key) for key in keys])
+                    keys = [list(raw_keys) for raw_keys in self._detector_keys]
+                dist_size = sum(len(key) for key in keys)
             else:
                 keys = (
                     list(self._photon_loss_keys)
@@ -1290,7 +1289,7 @@ class QuantumLayer(MerlinModule):
                 and self._raw_output_keys
                 and isinstance(self._raw_output_keys[0], list)
             ):
-                return list([list(keys) for keys in self._raw_output_keys])
+                return [list(keys) for keys in self._raw_output_keys]
             else:
                 return list(self._raw_output_keys)
         if self._detector_is_identity:
@@ -1299,7 +1298,7 @@ class QuantumLayer(MerlinModule):
                 and self._raw_output_keys
                 and isinstance(self._raw_output_keys[0], list)
             ):
-                return list([list(keys) for keys in self._photon_loss_keys])
+                return [list(keys) for keys in self._photon_loss_keys]
             else:
                 return list(self._photon_loss_keys)
         if (
@@ -1307,7 +1306,7 @@ class QuantumLayer(MerlinModule):
             and self._raw_output_keys
             and isinstance(self._raw_output_keys[0], list)
         ):
-            return list([list(keys) for keys in self._detector_keys])
+            return [list(keys) for keys in self._detector_keys]
         return list(self._detector_keys)
 
     @property

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -983,7 +983,8 @@ class QuantumLayer(MerlinModule):
         else:
             # The `amplitudes` are already probabilities in the noisy case
             # In g2 noise case, amplitudes is SectoredDistribution; use it as distribution
-            distribution = amplitudes
+            distribution: torch.Tensor | SectoredDistribution = amplitudes
+            # mypy handling
             # For noisy g2 case, set amplitudes to empty tensor since no raw amplitudes exist
             if isinstance(amplitudes, SectoredDistribution):
                 amplitudes = torch.tensor([], dtype=torch.complex128)

--- a/merlin/algorithms/layer_utils.py
+++ b/merlin/algorithms/layer_utils.py
@@ -731,14 +731,7 @@ def setup_noise_and_detectors(
 
     # Not implemented errors
     if noise_groups is not None:
-        noises_not_implemented_source = []
         noises_not_implemented_circuit = []
-        if noise_groups.source is not None:
-            if "g2_distinguishable" in noise_groups.source:
-                noises_not_implemented_source.append("g2_distinguishable")
-
-            if "g2" in noise_groups.source:
-                noises_not_implemented_source.append("g2")
 
         if noise_groups.circuit is not None:
             if "phase_imprecision" in noise_groups.circuit:
@@ -746,17 +739,8 @@ def setup_noise_and_detectors(
 
             if "phase_error" in noise_groups.circuit:
                 noises_not_implemented_circuit.append("phase_error")
-        if len(noises_not_implemented_source) > 0:
-            if len(noises_not_implemented_circuit) > 0:
-                raise NotImplementedError(
-                    f"The following noises are not implemented yet for the QuantumLayer. Source noises: {noises_not_implemented_source}. Circuit noises: {noises_not_implemented_circuit}."
-                )
-            else:
-                raise NotImplementedError(
-                    f"The following noises are not implemented yet for the QuantumLayer. Source noises: {noises_not_implemented_source}."
-                )
 
-        elif len(noises_not_implemented_circuit) > 0:
+        if len(noises_not_implemented_circuit) > 0:
             raise NotImplementedError(
                 f"The following noises are not implemented yet for the QuantumLayer. Circuit noises: {noises_not_implemented_circuit}."
             )

--- a/merlin/core/__init__.py
+++ b/merlin/core/__init__.py
@@ -28,6 +28,7 @@ from .components import BeamSplitter, Component, EntanglingBlock, Rotation
 from .computation_space import ComputationSpace
 from .probability_distribution import ProbabilityDistribution
 from .process import ComputationProcess, ComputationProcessFactory
+from .sectored_distribution import SectoredDistribution, SectorResult
 from .state import StatePattern, generate_state
 from .state_vector import StateVector
 
@@ -44,5 +45,7 @@ __all__ = [
     "EntanglingBlock",
     "Circuit",
     "StateVector",
+    "SectoredDistribution",
+    "SectorResult",
     "ProbabilityDistribution",
 ]

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -30,11 +30,12 @@ from typing import Literal, overload
 import perceval as pcvl
 import torch
 
-from merlin.pcvl_pytorch.noisy_slos import (
-    NoisySLOSComputeGraph,
-    NoisyG2SLOSComputeGraph,
-)
 from merlin.core.sectored_distribution import SectoredDistribution, SectorResult
+from merlin.pcvl_pytorch.noisy_slos import (
+    NoisyG2SLOSComputeGraph,
+    NoisySLOSComputeGraph,
+)
+
 from ..algorithms.layer_utils import NoiseGroups
 from ..pcvl_pytorch import (
     CircuitConverter,
@@ -226,13 +227,12 @@ class ComputationProcess(AbstractComputationProcess):
                                 sector.tensor = sector.tensor.unsqueeze(0)
                         probs_per_state.append(probs)
 
-                    photon_sectors_to_analyze = [
-                        i
-                        for i in range(
+                    photon_sectors_to_analyze = list(
+                        range(
                             self.simulation_graph.n_photons,
                             (2 * self.simulation_graph.n_photons) + 1,
                         )
-                    ]
+                    )
                     output_sectors = []
                     for photon_number in photon_sectors_to_analyze:
                         probs_per_state_per_photon_number = [

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -183,7 +183,7 @@ class ComputationProcess(AbstractComputationProcess):
         self,
         parameters: list[torch.Tensor],
         amplitude_encoding: bool = False,
-    ) -> torch.Tensor:
+    ) -> torch.Tensor | SectoredDistribution:
         """Compute output amplitudes for the configured input state.
 
         Parameters
@@ -196,8 +196,10 @@ class ComputationProcess(AbstractComputationProcess):
 
         Returns
         -------
-        torch.Tensor
-            Output probabilities if the simulation is noisy and amplitudes otherwise produced by the simulation graph.
+        torch.Tensor | SectoredDistribution
+            Output probabilities if the simulation is noisy (a
+            :class:`~merlin.core.sectored_distribution.SectoredDistribution` when g2
+            noise is present) and amplitudes otherwise produced by the simulation graph.
         """
         # Generate unitary matrix from parameters
 
@@ -270,7 +272,7 @@ class ComputationProcess(AbstractComputationProcess):
                         )
                     return SectoredDistribution(tuple(output_sectors))
                 else:
-                    probs_per_state = []
+                    probs_per_state: list[torch.Tensor] = []
                     for idx in active_indices:
                         input_fock_state = self.simulation_graph.mapped_keys[idx]
                         _, probs = self.simulation_graph.compute_probs(

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -220,7 +220,7 @@ class ComputationProcess(AbstractComputationProcess):
                 if isinstance(self.simulation_graph, NoisyG2SLOSComputeGraph):
                     output_distribution: SectoredDistribution | None = None
                     for idx in active_indices:
-                        input_fock_state = self.simulation_graph.mapped_keys[idx]
+                        input_fock_state = self.simulation_graph.mapped_keys[0][idx]
                         probs = self.simulation_graph.compute_probs(
                             unitary, input_fock_state
                         )

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -298,9 +298,12 @@ class ComputationProcess(AbstractComputationProcess):
 
                     return mixed_probs
             else:
-                keys, probs = self.simulation_graph.compute_probs(
-                    unitary, self.input_state
-                )
+                result = self.simulation_graph.compute_probs(unitary, self.input_state)
+                # NoisyG2SLOSComputeGraph returns SectoredDistribution directly
+                if isinstance(result, SectoredDistribution):
+                    return result
+                # NoisySLOSComputeGraph returns (keys, probs) tuple
+                keys, probs = result
                 return probs
         else:
             if isinstance(self.input_state, torch.Tensor):

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -218,59 +218,33 @@ class ComputationProcess(AbstractComputationProcess):
                 active_indices = torch.nonzero(active_mask, as_tuple=True)[0].tolist()
                 # If there is g2 noise, the data needs to be treated per photon sector
                 if isinstance(self.simulation_graph, NoisyG2SLOSComputeGraph):
-                    probs_per_state = []
+                    output_distribution: SectoredDistribution | None = None
                     for idx in active_indices:
                         input_fock_state = self.simulation_graph.mapped_keys[idx]
                         probs = self.simulation_graph.compute_probs(
                             unitary, input_fock_state
                         )
+
                         for sector in probs.sectors:
                             if sector.tensor.ndim == 1:
                                 sector.tensor = sector.tensor.unsqueeze(0)
-                        probs_per_state.append(probs)
-
-                    photon_sectors_to_analyze = list(
-                        range(
-                            self.simulation_graph.n_photons,
-                            (2 * self.simulation_graph.n_photons) + 1,
-                        )
-                    )
-                    output_sectors = []
-                    for photon_number in photon_sectors_to_analyze:
-                        probs_per_state_per_photon_number = [
-                            dist.get_sector(photon_number).tensor
-                            for dist in probs_per_state
-                        ]
-                        # probs_stacked: [n_active, unitary_batch, n_output_states]
-                        probs_stacked = torch.stack(
-                            probs_per_state_per_photon_number, dim=0
-                        )
-                        # selected_weights: [input_batch, n_active]
-                        selected_weights = weights[:, active_indices].to(
-                            probs_stacked.dtype
-                        )
-                        # mixed_probs: [input_batch, unitary_batch, n_output_states]
-                        mixed_probs = torch.einsum(
-                            "is,sbo->ibo", selected_weights, probs_stacked
-                        )
-
-                        if mixed_probs.shape[1] == 1:
-                            mixed_probs = mixed_probs.squeeze(
-                                1
-                            )  # [input_batch, n_output_states]
-
-                        output_sectors.append(
-                            SectorResult(
-                                mixed_probs,
-                                n_modes=probs_per_state[0].sectors[0].n_modes,
-                                n_photons=photon_number,
-                                computation_space=probs_per_state[0]
-                                .sectors[0]
-                                .computation_space,
-                                keys=probs_per_state[0].sectors[0].keys,
+                            selected_weights = weights[:, idx].to(sector.tensor.dtype)
+                            sector.tensor = torch.einsum(
+                                "i,bo->ibo", selected_weights, sector.tensor
                             )
-                        )
-                    return SectoredDistribution(tuple(output_sectors))
+                            if sector.tensor.shape[1] == 1:
+                                sector.tensor = sector.tensor.squeeze(1)
+
+                        if output_distribution is None:
+                            output_distribution = probs
+                        else:
+                            for sector in output_distribution.sectors:
+                                sector.tensor = (
+                                    sector.tensor
+                                    + probs.get_sector(sector.n_photons).tensor
+                                )
+
+                    return output_distribution
                 else:
                     tensor_probs_per_state: list[torch.Tensor] = []
                     for idx in active_indices:

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -30,8 +30,11 @@ from typing import Literal, overload
 import perceval as pcvl
 import torch
 
-from merlin.pcvl_pytorch.noisy_slos import NoisySLOSComputeGraph
-
+from merlin.pcvl_pytorch.noisy_slos import (
+    NoisySLOSComputeGraph,
+    NoisyG2SLOSComputeGraph,
+)
+from merlin.core.sectored_distribution import SectoredDistribution, SectorResult
 from ..algorithms.layer_utils import NoiseGroups
 from ..pcvl_pytorch import (
     CircuitConverter,
@@ -171,7 +174,9 @@ class ComputationProcess(AbstractComputationProcess):
             device=self.device,
             dtype=self.dtype,
         )
-        self.noisy_simulation = isinstance(self.simulation_graph, NoisySLOSComputeGraph)
+        self.noisy_simulation = isinstance(
+            self.simulation_graph, NoisySLOSComputeGraph
+        ) or isinstance(self.simulation_graph, NoisyG2SLOSComputeGraph)
 
     def compute(
         self,
@@ -208,32 +213,90 @@ class ComputationProcess(AbstractComputationProcess):
 
                 active_mask = torch.any(weights >= 1e-13, dim=0)
                 active_indices = torch.nonzero(active_mask, as_tuple=True)[0].tolist()
+                # If there is g2 noise, the data needs to be treated per photon sector
+                if isinstance(self.simulation_graph, NoisyG2SLOSComputeGraph):
+                    probs_per_state = []
+                    for idx in active_indices:
+                        input_fock_state = self.simulation_graph.mapped_keys[idx]
+                        _, probs = self.simulation_graph.compute_probs(
+                            unitary, input_fock_state
+                        )
+                        for sector in probs.sectors:
+                            if sector.tensor.ndim == 1:
+                                sector.tensor = sector.tensor.unsqueeze(0)
+                        probs_per_state.append(probs)
 
-                probs_per_state = []
-                for idx in active_indices:
-                    input_fock_state = self.simulation_graph.mapped_keys[idx]
-                    _, probs = self.simulation_graph.compute_probs(
-                        unitary, input_fock_state
+                    photon_sectors_to_analyze = [
+                        i
+                        for i in range(
+                            self.simulation_graph.n_photons,
+                            (2 * self.simulation_graph.n_photons) + 1,
+                        )
+                    ]
+                    output_sectors = []
+                    for photon_number in photon_sectors_to_analyze:
+                        probs_per_state_per_photon_number = [
+                            dist.get_sector(photon_number).tensor
+                            for dist in probs_per_state
+                        ]
+                        # probs_stacked: [n_active, unitary_batch, n_output_states]
+                        probs_stacked = torch.stack(
+                            probs_per_state_per_photon_number, dim=0
+                        )
+                        # selected_weights: [input_batch, n_active]
+                        selected_weights = weights[:, active_indices].to(
+                            probs_stacked.dtype
+                        )
+                        # mixed_probs: [input_batch, unitary_batch, n_output_states]
+                        mixed_probs = torch.einsum(
+                            "is,sbo->ibo", selected_weights, probs_stacked
+                        )
+
+                        if mixed_probs.shape[1] == 1:
+                            mixed_probs = mixed_probs.squeeze(
+                                1
+                            )  # [input_batch, n_output_states]
+
+                        output_sectors.append(
+                            SectorResult(
+                                mixed_probs,
+                                n_modes=probs_per_state[0].sectors[0].n_modes,
+                                n_photons=photon_number,
+                                computation_space=probs_per_state[0]
+                                .sectors[0]
+                                .computation_space,
+                                keys=probs_per_state[0].sectors[0].keys,
+                            )
+                        )
+                    return SectoredDistribution(output_sectors)
+                else:
+                    probs_per_state = []
+                    for idx in active_indices:
+                        input_fock_state = self.simulation_graph.mapped_keys[idx]
+                        _, probs = self.simulation_graph.compute_probs(
+                            unitary, input_fock_state
+                        )
+                        if probs.ndim == 1:
+                            probs = probs.unsqueeze(0)
+                        probs_per_state.append(probs)
+
+                    # probs_stacked: [n_active, unitary_batch, n_output_states]
+                    probs_stacked = torch.stack(probs_per_state, dim=0)
+                    # selected_weights: [input_batch, n_active]
+                    selected_weights = weights[:, active_indices].to(
+                        probs_stacked.dtype
                     )
-                    if probs.ndim == 1:
-                        probs = probs.unsqueeze(0)
-                    probs_per_state.append(probs)
+                    # mixed_probs: [input_batch, unitary_batch, n_output_states]
+                    mixed_probs = torch.einsum(
+                        "is,sbo->ibo", selected_weights, probs_stacked
+                    )
 
-                # probs_stacked: [n_active, unitary_batch, n_output_states]
-                probs_stacked = torch.stack(probs_per_state, dim=0)
-                # selected_weights: [input_batch, n_active]
-                selected_weights = weights[:, active_indices].to(probs_stacked.dtype)
-                # mixed_probs: [input_batch, unitary_batch, n_output_states]
-                mixed_probs = torch.einsum(
-                    "is,sbo->ibo", selected_weights, probs_stacked
-                )
+                    if mixed_probs.shape[1] == 1:
+                        mixed_probs = mixed_probs.squeeze(
+                            1
+                        )  # [input_batch, n_output_states]
 
-                if mixed_probs.shape[1] == 1:
-                    mixed_probs = mixed_probs.squeeze(
-                        1
-                    )  # [input_batch, n_output_states]
-
-                return mixed_probs
+                    return mixed_probs
             else:
                 keys, probs = self.simulation_graph.compute_probs(
                     unitary, self.input_state

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -272,7 +272,7 @@ class ComputationProcess(AbstractComputationProcess):
                         )
                     return SectoredDistribution(tuple(output_sectors))
                 else:
-                    probs_per_state: list[torch.Tensor] = []
+                    tensor_probs_per_state: list[torch.Tensor] = []
                     for idx in active_indices:
                         input_fock_state = self.simulation_graph.mapped_keys[idx]
                         _, probs = self.simulation_graph.compute_probs(
@@ -280,10 +280,10 @@ class ComputationProcess(AbstractComputationProcess):
                         )
                         if probs.ndim == 1:
                             probs = probs.unsqueeze(0)
-                        probs_per_state.append(probs)
+                        tensor_probs_per_state.append(probs)
 
                     # probs_stacked: [n_active, unitary_batch, n_output_states]
-                    probs_stacked = torch.stack(probs_per_state, dim=0)
+                    probs_stacked = torch.stack(tensor_probs_per_state, dim=0)
                     # selected_weights: [input_batch, n_active]
                     selected_weights = weights[:, active_indices].to(
                         probs_stacked.dtype

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -30,7 +30,7 @@ from typing import Literal, overload
 import perceval as pcvl
 import torch
 
-from merlin.core.sectored_distribution import SectoredDistribution, SectorResult
+from merlin.core.sectored_distribution import SectoredDistribution
 from merlin.pcvl_pytorch.noisy_slos import (
     NoisyG2SLOSComputeGraph,
     NoisySLOSComputeGraph,

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -219,7 +219,7 @@ class ComputationProcess(AbstractComputationProcess):
                     probs_per_state = []
                     for idx in active_indices:
                         input_fock_state = self.simulation_graph.mapped_keys[idx]
-                        _, probs = self.simulation_graph.compute_probs(
+                        probs = self.simulation_graph.compute_probs(
                             unitary, input_fock_state
                         )
                         for sector in probs.sectors:
@@ -268,7 +268,7 @@ class ComputationProcess(AbstractComputationProcess):
                                 keys=probs_per_state[0].sectors[0].keys,
                             )
                         )
-                    return SectoredDistribution(output_sectors)
+                    return SectoredDistribution(tuple(output_sectors))
                 else:
                     probs_per_state = []
                     for idx in active_indices:

--- a/merlin/core/sectored_distribution.py
+++ b/merlin/core/sectored_distribution.py
@@ -119,9 +119,11 @@ class SectoredDistribution:
 
     def total_probability(self) -> torch.Tensor:
         """Returns the total probability across the sectors."""
-        total_prob = 0.0
+        total_prob = torch.zeros(
+            (), dtype=self.sectors[0].tensor.dtype, device=self.sectors[0].tensor.device
+        )
         for sector in self.sectors:
-            total_prob += sector.tensor.sum()
+            total_prob = total_prob + sector.tensor.sum()
         return total_prob
 
     def to(self, *args, **kwargs) -> SectoredDistribution:

--- a/merlin/core/sectored_distribution.py
+++ b/merlin/core/sectored_distribution.py
@@ -16,15 +16,16 @@ class SectorResult:
     n_modes: int
     n_photons: int
     computation_space: ComputationSpace = ComputationSpace.FOCK
-    keys: tuple[tuple[int, ...], ...] = ()
+    keys: tuple[tuple[int, ...], ...] | None = None
 
     def __post_init__(self) -> None:
         """Create the photon number to sector index map."""
-        self.keys = tuple(
-            Combinadics(
-                scheme="fock", n=self.n_photons, m=self.n_modes
-            ).enumerate_states()
-        )
+        if self.keys is None:
+            self.keys = tuple(
+                Combinadics(
+                    scheme="fock", n=self.n_photons, m=self.n_modes
+                ).enumerate_states()
+            )
 
     def to(self, *args, **kwargs) -> SectorResult:
         """Return a new state vector moved or cast via ``torch.Tensor.to``.

--- a/merlin/core/sectored_distribution.py
+++ b/merlin/core/sectored_distribution.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import torch
+from dataclasses import dataclass
+
+from .probability_distribution import ProbabilityDistribution
+from .computation_space import ComputationSpace
+
+
+@dataclass
+class SectorResult:
+    """One photon-number sector of a probability output."""
+
+    tensor: torch.Tensor
+    n_modes: int
+    n_photons: int
+    computation_space: ComputationSpace = ComputationSpace.FOCK
+    keys: tuple[tuple[int, ...], ...] = ()
+
+    # mirrors StateVector / ProbabilityDistribution:
+    # to(), clone(), detach(), requires_grad_()
+
+    def to(self, *args, **kwargs) -> SectorResult:
+        """Return a new state vector moved or cast via ``torch.Tensor.to``.
+
+        Parameters
+        ----------
+        *args
+            Positional arguments forwarded to :meth:`torch.Tensor.to`.
+        **kwargs
+            Keyword arguments forwarded to :meth:`torch.Tensor.to`.
+
+        Returns
+        -------
+        StateVector
+            Converted state vector.
+        """
+        new_tensor = self.tensor.to(*args, **kwargs)
+        return SectorResult(
+            new_tensor, self.n_modes, self.n_photons, computation_space=self.computation_space,keys=self.keys
+        )
+
+    def clone(self) -> SectorResult:
+        """Return a cloned ``SectorResult`` with identical metadata and normalization flag.
+
+        Returns
+        -------
+        StateVector
+            Cloned state vector.
+        """
+        return SectorResult(
+            self.tensor.clone(),
+            self.n_modes, self.n_photons, computation_space=self.computation_space,keys=self.keys
+        )
+
+    def detach(self) -> SectorResult:
+        """Return a detached ``SectorResult`` sharing data without gradients.
+
+        Returns
+        -------
+        StateVector
+            Detached state vector.
+        """
+        return SectorResult(
+            self.tensor.detach(),
+            self.n_modes, self.n_photons, computation_space=self.computation_space,keys=self.keys
+        )
+
+    def requires_grad_(self, requires_grad: bool = True) -> SectorResult:
+        """Set ``requires_grad`` on the underlying tensor and return self.
+
+        Parameters
+        ----------
+        requires_grad : bool
+            Whether gradients should be tracked.
+
+        Returns
+        -------
+        StateVector
+            The updated instance.
+        """
+        self.tensor.requires_grad_(requires_grad)
+        return self
+    
+
+@dataclass
+class SectoredDistribution:
+    """Probability output spanning multiple photon-number sectors."""
+    sectors: tuple[SectorResult, ...]
+
+
+     # mirrors StateVector / ProbabilityDistribution:
+    # to(), clone(), detach(), requires_grad_()
+    # get_sector(n_photons), photon_counts, total_probability()

--- a/merlin/core/sectored_distribution.py
+++ b/merlin/core/sectored_distribution.py
@@ -5,17 +5,26 @@ from dataclasses import dataclass
 import torch
 
 from .computation_space import ComputationSpace
+from ..utils.combinadics import Combinadics
 
 
 @dataclass
 class SectorResult:
-    """One photon-number sector of a probability output."""
+    """One photon-number sector of a probability output. If keys are not given, the Combinatics.enumerate_states will be used."""
 
     tensor: torch.Tensor
     n_modes: int
     n_photons: int
     computation_space: ComputationSpace = ComputationSpace.FOCK
     keys: tuple[tuple[int, ...], ...] = ()
+
+    def __post_init__(self) -> None:
+        """Create the photon number to sector index map."""
+        self.keys = tuple(
+            Combinadics(
+                scheme="fock", n=self.n_photons, m=self.n_modes
+            ).enumerate_states()
+        )
 
     def to(self, *args, **kwargs) -> SectorResult:
         """Return a new state vector moved or cast via ``torch.Tensor.to``.
@@ -108,11 +117,11 @@ class SectoredDistribution:
             raise ValueError("No SectorResult with that number of photons")
         return self.sectors[self._photon_map[n_photons]]
 
-    def total_probability(self) -> float:
+    def total_probability(self) -> torch.Tensor:
         """Returns the total probability across the sectors."""
         total_prob = 0.0
         for sector in self.sectors:
-            total_prob += sector.tensor.sum().item()
+            total_prob += sector.tensor.sum()
         return total_prob
 
     def to(self, *args, **kwargs) -> SectoredDistribution:

--- a/merlin/core/sectored_distribution.py
+++ b/merlin/core/sectored_distribution.py
@@ -96,10 +96,8 @@ class SectoredDistribution:
 
     sectors: tuple[SectorResult, ...]
 
-    # get_sector(n_photons), photon_counts, total_probability()
-
     def __post_init__(self) -> None:
-        """Sort sectors by photon number after initialization."""
+        """Create the photon number to sector index map."""
         self._photon_map = {
             self.sectors[i].n_photons: i for i in range(len(self.sectors))
         }
@@ -111,7 +109,7 @@ class SectoredDistribution:
         return self.sectors[self._photon_map[n_photons]]
 
     def total_probability(self) -> float:
-        """Return the SectorResult associated with n_photons."""
+        """Returns the total probability across the sectors."""
         total_prob = 0.0
         for sector in self.sectors:
             total_prob += sector.tensor.sum().item()

--- a/merlin/core/sectored_distribution.py
+++ b/merlin/core/sectored_distribution.py
@@ -17,9 +17,6 @@ class SectorResult:
     computation_space: ComputationSpace = ComputationSpace.FOCK
     keys: tuple[tuple[int, ...], ...] = ()
 
-    # mirrors StateVector / ProbabilityDistribution:
-    # to(), clone(), detach(), requires_grad_()
-
     def to(self, *args, **kwargs) -> SectorResult:
         """Return a new state vector moved or cast via ``torch.Tensor.to``.
 
@@ -37,7 +34,11 @@ class SectorResult:
         """
         new_tensor = self.tensor.to(*args, **kwargs)
         return SectorResult(
-            new_tensor, self.n_modes, self.n_photons, computation_space=self.computation_space,keys=self.keys
+            new_tensor,
+            self.n_modes,
+            self.n_photons,
+            computation_space=self.computation_space,
+            keys=self.keys,
         )
 
     def clone(self) -> SectorResult:
@@ -50,7 +51,10 @@ class SectorResult:
         """
         return SectorResult(
             self.tensor.clone(),
-            self.n_modes, self.n_photons, computation_space=self.computation_space,keys=self.keys
+            self.n_modes,
+            self.n_photons,
+            computation_space=self.computation_space,
+            keys=self.keys,
         )
 
     def detach(self) -> SectorResult:
@@ -63,7 +67,10 @@ class SectorResult:
         """
         return SectorResult(
             self.tensor.detach(),
-            self.n_modes, self.n_photons, computation_space=self.computation_space,keys=self.keys
+            self.n_modes,
+            self.n_photons,
+            computation_space=self.computation_space,
+            keys=self.keys,
         )
 
     def requires_grad_(self, requires_grad: bool = True) -> SectorResult:
@@ -81,14 +88,95 @@ class SectorResult:
         """
         self.tensor.requires_grad_(requires_grad)
         return self
-    
+
 
 @dataclass
 class SectoredDistribution:
     """Probability output spanning multiple photon-number sectors."""
+
     sectors: tuple[SectorResult, ...]
 
-
-     # mirrors StateVector / ProbabilityDistribution:
-    # to(), clone(), detach(), requires_grad_()
     # get_sector(n_photons), photon_counts, total_probability()
+
+    def __post_init__(self) -> None:
+        """Sort sectors by photon number after initialization."""
+        self._photon_map = {
+            self.sectors[i].n_photons: i for i in range(len(self.sectors))
+        }
+
+    @property
+    def get_sector(self, n_photons: int) -> SectorResult:
+        """Return the SectorResult associated with n_photons."""
+        if n_photons not in self._photon_map.keys():
+            raise ValueError("No SectorResult with that number of photons")
+        return self.sectors[self._photon_map[n_photons]]
+
+    def total_probability(self) -> float:
+        """Return the SectorResult associated with n_photons."""
+        total_prob = 0
+        for sector in self.sectors:
+            total_prob += sector.tensor.sum().item()
+        return total_prob
+
+    def to(self, *args, **kwargs) -> SectoredDistribution:
+        """Return a new ``SectoredDistribution`` with SectorResults moved/cast via ``torch.Tensor.to``.
+
+        Parameters
+        ----------
+        *args
+            Positional arguments forwarded to :meth:`torch.Tensor.to`.
+        **kwargs
+            Keyword arguments forwarded to :meth:`torch.Tensor.to`.
+
+        Returns
+        -------
+        SectoredDistribution
+            Converted sectored distribution.
+        """
+        new_sectors = []
+        for sector in self.sectors:
+            new_sectors.append(sector.to(*args, **kwargs))
+        return SectoredDistribution(new_sectors)
+
+    def clone(self) -> SectoredDistribution:
+        """Return a cloned SectoredDistribution with metadata and logical performance preserved.
+
+        Returns
+        -------
+        SectoredDistribution
+            Cloned sectored distribution.
+        """
+        new_sectors = []
+        for sector in self.sectors:
+            new_sectors.append(sector.clone())
+        return SectoredDistribution(new_sectors)
+
+    def detach(self) -> SectoredDistribution:
+        """Return a detached ``SectoredDistribution`` sharing data without gradients.
+
+        Returns
+        -------
+        SectoredDistribution
+            Detached sectored distribution.
+        """
+        new_sectors = []
+        for sector in self.sectors:
+            new_sectors.append(sector.detach())
+        return SectoredDistribution(new_sectors)
+
+    def requires_grad_(self, requires_grad: bool = True) -> SectoredDistribution:
+        """Set ``requires_grad`` on underlying tensors and return self.
+
+        Parameters
+        ----------
+        requires_grad : bool
+            Whether gradients should be tracked.
+
+        Returns
+        -------
+        SectoredDistribution
+            The updated instance.
+        """
+        for sector in self.sectors:
+            sector.requires_grad_(requires_grad)
+        return self

--- a/merlin/core/sectored_distribution.py
+++ b/merlin/core/sectored_distribution.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import torch
 from dataclasses import dataclass
 
-from .probability_distribution import ProbabilityDistribution
+import torch
+
 from .computation_space import ComputationSpace
 
 
@@ -29,8 +29,8 @@ class SectorResult:
 
         Returns
         -------
-        StateVector
-            Converted state vector.
+        SectorResult
+            Converted sector result.
         """
         new_tensor = self.tensor.to(*args, **kwargs)
         return SectorResult(
@@ -46,8 +46,8 @@ class SectorResult:
 
         Returns
         -------
-        StateVector
-            Cloned state vector.
+        SectorResult
+            Cloned sector result.
         """
         return SectorResult(
             self.tensor.clone(),
@@ -62,8 +62,8 @@ class SectorResult:
 
         Returns
         -------
-        StateVector
-            Detached state vector.
+        SectorResult
+            Detached sector result.
         """
         return SectorResult(
             self.tensor.detach(),
@@ -83,7 +83,7 @@ class SectorResult:
 
         Returns
         -------
-        StateVector
+        SectorResult
             The updated instance.
         """
         self.tensor.requires_grad_(requires_grad)

--- a/merlin/core/sectored_distribution.py
+++ b/merlin/core/sectored_distribution.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass
 
 import torch
 
-from .computation_space import ComputationSpace
 from ..utils.combinadics import Combinadics
+from .computation_space import ComputationSpace
 
 
 @dataclass

--- a/merlin/core/sectored_distribution.py
+++ b/merlin/core/sectored_distribution.py
@@ -104,7 +104,6 @@ class SectoredDistribution:
             self.sectors[i].n_photons: i for i in range(len(self.sectors))
         }
 
-    @property
     def get_sector(self, n_photons: int) -> SectorResult:
         """Return the SectorResult associated with n_photons."""
         if n_photons not in self._photon_map.keys():
@@ -113,7 +112,7 @@ class SectoredDistribution:
 
     def total_probability(self) -> float:
         """Return the SectorResult associated with n_photons."""
-        total_prob = 0
+        total_prob = 0.0
         for sector in self.sectors:
             total_prob += sector.tensor.sum().item()
         return total_prob
@@ -136,7 +135,7 @@ class SectoredDistribution:
         new_sectors = []
         for sector in self.sectors:
             new_sectors.append(sector.to(*args, **kwargs))
-        return SectoredDistribution(new_sectors)
+        return SectoredDistribution(tuple(new_sectors))
 
     def clone(self) -> SectoredDistribution:
         """Return a cloned SectoredDistribution with metadata and logical performance preserved.
@@ -149,7 +148,7 @@ class SectoredDistribution:
         new_sectors = []
         for sector in self.sectors:
             new_sectors.append(sector.clone())
-        return SectoredDistribution(new_sectors)
+        return SectoredDistribution(tuple(new_sectors))
 
     def detach(self) -> SectoredDistribution:
         """Return a detached ``SectoredDistribution`` sharing data without gradients.
@@ -162,7 +161,7 @@ class SectoredDistribution:
         new_sectors = []
         for sector in self.sectors:
             new_sectors.append(sector.detach())
-        return SectoredDistribution(new_sectors)
+        return SectoredDistribution(tuple(new_sectors))
 
     def requires_grad_(self, requires_grad: bool = True) -> SectoredDistribution:
         """Set ``requires_grad`` on underlying tensors and return self.

--- a/merlin/measurement/process.py
+++ b/merlin/measurement/process.py
@@ -226,7 +226,7 @@ class SamplingProcess:
 
         # Reformatting the output
         sectors = []
-        for sector, index_splits in zip(distribution.sectors, indexes):
+        for sector, index_splits in zip(distribution.sectors, indexes, strict=True):
             sectors.append(sector.clone())
             if augment_input:
                 sectors[-1].tensor = one_dimension_counts[

--- a/merlin/measurement/process.py
+++ b/merlin/measurement/process.py
@@ -29,6 +29,7 @@ from collections.abc import Callable
 import torch
 
 from merlin.core.partial_measurement import DetectorTransformOutput, PartialMeasurement
+from merlin.core.sectored_distribution import SectoredDistribution
 
 
 class SamplingProcess:
@@ -132,6 +133,111 @@ class SamplingProcess:
         raise ValueError(
             f"Invalid sampling method: {method}. Valid options are: {self.valid_methods}"
         )
+
+    def pcvl_sampler_g2(
+        self, distribution: SectoredDistribution, shots: int, method: str = None
+    ) -> SectoredDistribution:
+        """Apply sampling noise to a SectoredDistribution.
+
+        Parameters
+        ----------
+        distribution : SectoredDistribution
+            Input probability distribution object.
+        shots : int
+            Number of measurement shots to simulate.
+        method : str | None
+            Sampling method to use ('multinomial', 'binomial', or 'gaussian'),
+            defaults to the initialized method
+
+        Returns
+        -------
+        SectoredDistribution
+            Noisy probability distribution after sampling.
+
+        Raises
+        ------
+        ValueError
+            If ``method`` is not one of the valid options.
+        """
+        if shots <= 0:
+            return distribution
+
+        if method is None:
+            method = self.method
+
+        # Flattening the vectors into one sole vector
+        one_dimension_vector = None
+        one_dimension_counts = None
+        indexes = []
+        for sector in distribution.sectors:
+            if one_dimension_vector is None:
+                one_dimension_vector = sector.tensor
+                if one_dimension_vector.dim() == 1:
+                    augment_input = True
+                    one_dimension_vector.unsqueeze(0)
+                else:
+                    augment_input = False
+                indexes.append((0, one_dimension_vector.size(1)))
+            else:
+                if augment_input:
+                    one_dimension_vector = torch.cat(
+                        [one_dimension_vector, sector.tensor.unsqueeze(0)], dim=1
+                    )
+                else:
+                    one_dimension_vector = torch.cat(
+                        [one_dimension_vector, sector.tensor], dim=1
+                    )
+                indexes.append((indexes[-1][-1], one_dimension_vector.size(1)))
+
+        # Sampling
+        if method == "multinomial":
+            batch_size = one_dimension_vector.shape[0]
+            noisy_dists = []
+            for i in range(batch_size):
+                sampled_counts = torch.multinomial(
+                    one_dimension_vector[i], num_samples=shots, replacement=True
+                )
+                noisy_dist = torch.zeros_like(one_dimension_vector[i])
+                for idx in sampled_counts:
+                    noisy_dist[idx] += 1
+                noisy_dists.append(noisy_dist / shots)
+            one_dimension_counts = torch.stack(noisy_dists)
+
+        elif method == "binomial":
+            one_dimension_counts = (
+                torch.distributions.Binomial(shots, one_dimension_vector).sample()
+                / shots
+            )
+
+        elif method == "gaussian":
+            std_dev = torch.sqrt(
+                one_dimension_vector * (1 - one_dimension_vector) / shots
+            )
+            noise = torch.randn_like(one_dimension_vector) * std_dev
+            noisy_dist = one_dimension_vector + noise
+            noisy_dist = torch.clamp(noisy_dist, 0, 1)
+            noisy_dist = noisy_dist / noisy_dist.sum(dim=-1, keepdim=True)
+            one_dimension_counts = noisy_dist
+
+        if one_dimension_counts is None:
+            raise ValueError(
+                f"Invalid sampling method: {method}. Valid options are: {self.valid_methods}"
+            )
+
+        # Reformatting the output
+        sectors = []
+        for sector, index_splits in zip(distribution.sectors, indexes):
+            sectors.append(sector.clone())
+            if augment_input:
+                sectors[-1].tensor = one_dimension_counts[
+                    :, index_splits[0] : index_splits[1]
+                ].squeeze(dim=0)
+            else:
+                sectors[-1].tensor = one_dimension_counts[
+                    :, index_splits[0] : index_splits[1]
+                ]
+
+        return SectoredDistribution(sectors)
 
 
 def partial_measurement(

--- a/merlin/measurement/process.py
+++ b/merlin/measurement/process.py
@@ -237,7 +237,7 @@ class SamplingProcess:
                     :, index_splits[0] : index_splits[1]
                 ]
 
-        return SectoredDistribution(sectors)
+        return SectoredDistribution(tuple(sectors))
 
 
 def partial_measurement(

--- a/merlin/measurement/process.py
+++ b/merlin/measurement/process.py
@@ -174,7 +174,7 @@ class SamplingProcess:
                 one_dimension_vector = sector.tensor
                 if one_dimension_vector.dim() == 1:
                     augment_input = True
-                    one_dimension_vector.unsqueeze(0)
+                    one_dimension_vector = one_dimension_vector.unsqueeze(0)
                 else:
                     augment_input = False
                 indexes.append((0, one_dimension_vector.size(1)))

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -74,7 +74,7 @@ class BaseMeasurementStrategy:
     def process(
         self,
         *,
-        distribution: torch.Tensor,
+        distribution: torch.Tensor | SectoredDistribution,
         amplitudes: torch.Tensor | SectoredDistribution,
         apply_sampling: bool,
         effective_shots: int,
@@ -87,8 +87,9 @@ class BaseMeasurementStrategy:
 
         Parameters
         ----------
-        distribution : torch.Tensor
-            Probability distribution before final post-processing.
+        distribution : torch.Tensor | SectoredDistribution
+            Probability distribution before final post-processing, or a sectored
+            distribution in the g2 noise case.
         amplitudes : torch.Tensor | SectoredDistribution
             Raw amplitudes before measurement-specific processing, or a sectored
             distribution in the g2 noise case.
@@ -135,7 +136,7 @@ class DistributionStrategy(BaseMeasurementStrategy):
         if isinstance(distribution, SectoredDistribution):
             if grouping:
                 raise RuntimeError(
-                    f"A grouping strategy can not be applied to the output of a simulation with g2 noise. Indeed, since this noise creates input states with more phtons than expected, multiple photon sectors are explored. The fock spaces explored are m={distribution.sectors[0].n_modes} modes and n_photons={min(distribution._photon_map.keys())} to 2*n_photons={max(distribution._photon_map.keys())} that all have different space dimensions. To still apply a grouping strategy, you can iterate over the :class:`~merlin.core.sectored_distribution.SectorResult`s of the :class:`~merlin.core.sectored_distribution.SectoredDistribution` and apply one grouping per sector."
+                    f"A grouping strategy cannot be applied to the output of a simulation with g2 noise. Indeed, since this noise creates input states with more photons than expected, multiple photon sectors are explored. The fock spaces explored are m={distribution.sectors[0].n_modes} modes and n_photons={min(distribution._photon_map.keys())} to 2*n_photons={max(distribution._photon_map.keys())} that all have different space dimensions. To still apply a grouping strategy, you can iterate over the :class:`~merlin.core.sectored_distribution.SectorResult`s of the :class:`~merlin.core.sectored_distribution.SectoredDistribution` and apply one grouping per sector."
                 )
             for sector_result in distribution.sectors:
                 sector_result.tensor = apply_photon_loss(sector_result.tensor)
@@ -203,7 +204,7 @@ class PartialMeasurementStrategy(BaseMeasurementStrategy):
     def process(
         self,
         *,
-        distribution: torch.Tensor,
+        distribution: torch.Tensor | SectoredDistribution,
         amplitudes: torch.Tensor | SectoredDistribution,
         apply_sampling: bool,
         effective_shots: int,
@@ -423,12 +424,14 @@ class MeasurementStrategy(metaclass=_MeasurementStrategyMeta):
         return NotImplemented
 
     def __hash__(self) -> int:
-        return hash((
-            self.type,
-            self.measured_modes,
-            self.computation_space,
-            self.grouping,
-        ))
+        return hash(
+            (
+                self.type,
+                self.measured_modes,
+                self.computation_space,
+                self.grouping,
+            )
+        )
 
     def validate_modes(self, n_modes: int) -> None:
         """Validate mode indices and warn when the selection covers all modes."""

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -132,7 +132,6 @@ class DistributionStrategy(BaseMeasurementStrategy):
     ) -> torch.Tensor | SectoredDistribution:
         # Distribution strategies apply detector/noise transforms before sampling.
         if isinstance(distribution, SectoredDistribution):
-            sample_fn = sampler.pcvl_sampler_g2
             if grouping:
                 raise RuntimeError(
                     f"A grouping strategy can not be applied to the output of a simulation with g2 noise. Indeed, since this noise creates input states with more phtons than expected, multiple photon sectors are explored. The fock spaces explored are m={distribution.sectors[0].n_modes} modes and n_photons={min(distribution._photon_map.keys())} to 2*n_photons={max(distribution._photon_map.keys())} that all have different space dimensions. To still apply a grouping strategy, you can iterate over the :class:`~merlin.core.sectored_distribution.SectorResult`s of the :class:`~merlin.core.sectored_distribution.SectoredDistribution` and apply one grouping per sector."
@@ -142,17 +141,18 @@ class DistributionStrategy(BaseMeasurementStrategy):
                 sector_result.tensor = apply_detectors(sector_result.tensor)
 
             if apply_sampling and effective_shots > 0:
-                distribution = sample_fn(distribution, effective_shots)
+                distribution = sampler.pcvl_sampler_g2(distribution, effective_shots)
+            # Return SectoredDistribution cast to match base class type annotation
+            return distribution  # type: ignore[return-value]
         else:
-            sample_fn = sampler.pcvl_sampler
             distribution = apply_photon_loss(distribution)
             distribution = apply_detectors(distribution)
 
             if apply_sampling and effective_shots > 0:
-                distribution = sample_fn(distribution, effective_shots)
+                distribution = sampler.pcvl_sampler(distribution, effective_shots)
             if grouping is not None:
                 return grouping(distribution)
-        return distribution
+            return distribution
 
 
 class ProbabilitiesStrategy(DistributionStrategy):

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -31,9 +31,10 @@ from enum import Enum
 from typing import TYPE_CHECKING, ClassVar, TypeAlias
 
 import torch
-
+from merlin.measurement.process import SamplingProcess
 from merlin.core.computation_space import ComputationSpace
 from merlin.core.partial_measurement import PartialMeasurement
+from merlin.core.sectored_distribution import SectoredDistribution
 from merlin.measurement.process import partial_measurement
 from merlin.utils.deprecations import warn_deprecated_enum_access
 from merlin.utils.grouping import LexGrouping, ModGrouping
@@ -120,23 +121,40 @@ class DistributionStrategy(BaseMeasurementStrategy):
     def process(
         self,
         *,
-        distribution: torch.Tensor,
+        distribution: torch.Tensor | SectoredDistribution,
         amplitudes: torch.Tensor,
         apply_sampling: bool,
         effective_shots: int,
-        sample_fn: Callable[[torch.Tensor, int], torch.Tensor],
+        sampler: SamplingProcess,
         apply_photon_loss: Callable[[torch.Tensor], torch.Tensor],
         apply_detectors: Callable[[torch.Tensor], torch.Tensor],
         grouping: Callable[[torch.Tensor], torch.Tensor] | None = None,
     ) -> torch.Tensor:
         # Distribution strategies apply detector/noise transforms before sampling.
-        distribution = apply_photon_loss(distribution)
-        distribution = apply_detectors(distribution)
+        if isinstance(distribution, SectoredDistribution):
+            sample_fn = sampler.pcvl_sampler_g2
+            if grouping:
+                raise RuntimeError(
+                    f"One grouping strategy can not be applied to the output of a simulation with g2 noise. Indeed, since this noise creates input states with more phtons than expected, multiple photon sectors are explored. The fock spaces explored are m={distribution.sectors[0].n_modes} modes and n_photons={min(distribution._photon_map.keys())} to 2*n_photons={max(distribution._photon_map.keys())} that all have different space dimensions. To still apply a grouping strategy, you can iterate over the :class:`~merlin.core.sectored_distribution.SectorResult`s of the :class:`~merlin.core.sectored_distribution.SectoredDistribution` and apply one grouping per sector."
+                )
+            for sector_result in distribution.sectors:
+                sector_result.tensor = apply_photon_loss(sector_result.tensor)
+                sector_result.tensor = apply_detectors(sector_result.tensor)
 
-        if apply_sampling and effective_shots > 0:
-            distribution = sample_fn(distribution, effective_shots)
-        if grouping is not None:
-            return grouping(distribution)
+                if apply_sampling and effective_shots > 0:
+                    sector_result.tensor = sample_fn(
+                        sector_result.tensor, effective_shots
+                    )
+            distribution = sample_fn(distribution)
+        else:
+            sample_fn = sampler.pcvl_sampler
+            distribution = apply_photon_loss(distribution)
+            distribution = apply_detectors(distribution)
+
+            if apply_sampling and effective_shots > 0:
+                distribution = sample_fn(distribution, effective_shots)
+            if grouping is not None:
+                return grouping(distribution)
         return distribution
 
 
@@ -398,12 +416,14 @@ class MeasurementStrategy(metaclass=_MeasurementStrategyMeta):
         return NotImplemented
 
     def __hash__(self) -> int:
-        return hash((
-            self.type,
-            self.measured_modes,
-            self.computation_space,
-            self.grouping,
-        ))
+        return hash(
+            (
+                self.type,
+                self.measured_modes,
+                self.computation_space,
+                self.grouping,
+            )
+        )
 
     def validate_modes(self, n_modes: int) -> None:
         """Validate mode indices and warn when the selection covers all modes."""

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -133,23 +133,18 @@ class DistributionStrategy(BaseMeasurementStrategy):
         grouping: Callable[[torch.Tensor], torch.Tensor] | None = None,
     ) -> torch.Tensor | SectoredDistribution:
         # Distribution strategies apply detector/noise transforms before sampling.
+        distribution = apply_photon_loss(distribution)
+        distribution = apply_detectors(distribution)
         if isinstance(distribution, SectoredDistribution):
             if grouping:
                 raise RuntimeError(
                     f"A grouping strategy cannot be applied to the output of a simulation with g2 noise. Indeed, since this noise creates input states with more photons than expected, multiple photon sectors are explored. The fock spaces explored are m={distribution.sectors[0].n_modes} modes and n_photons={min(distribution._photon_map.keys())} to 2*n_photons={max(distribution._photon_map.keys())} that all have different space dimensions. To still apply a grouping strategy, you can iterate over the :class:`~merlin.core.sectored_distribution.SectorResult`s of the :class:`~merlin.core.sectored_distribution.SectoredDistribution` and apply one grouping per sector."
                 )
-            for sector_result in distribution.sectors:
-                sector_result.tensor = apply_photon_loss(sector_result.tensor)
-                sector_result.tensor = apply_detectors(sector_result.tensor)
-
             if apply_sampling and effective_shots > 0:
                 distribution = sampler.pcvl_sampler_g2(distribution, effective_shots)
             # Return SectoredDistribution cast to match base class type annotation
             return distribution  # type: ignore[return-value]
         else:
-            distribution = apply_photon_loss(distribution)
-            distribution = apply_detectors(distribution)
-
             if apply_sampling and effective_shots > 0:
                 distribution = sampler.pcvl_sampler(distribution, effective_shots)
             if grouping is not None:
@@ -424,12 +419,14 @@ class MeasurementStrategy(metaclass=_MeasurementStrategyMeta):
         return NotImplemented
 
     def __hash__(self) -> int:
-        return hash((
-            self.type,
-            self.measured_modes,
-            self.computation_space,
-            self.grouping,
-        ))
+        return hash(
+            (
+                self.type,
+                self.measured_modes,
+                self.computation_space,
+                self.grouping,
+            )
+        )
 
     def validate_modes(self, n_modes: int) -> None:
         """Validate mode indices and warn when the selection covers all modes."""

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -31,11 +31,11 @@ from enum import Enum
 from typing import TYPE_CHECKING, ClassVar, TypeAlias
 
 import torch
-from merlin.measurement.process import SamplingProcess
+
 from merlin.core.computation_space import ComputationSpace
 from merlin.core.partial_measurement import PartialMeasurement
 from merlin.core.sectored_distribution import SectoredDistribution
-from merlin.measurement.process import partial_measurement
+from merlin.measurement.process import SamplingProcess, partial_measurement
 from merlin.utils.deprecations import warn_deprecated_enum_access
 from merlin.utils.grouping import LexGrouping, ModGrouping
 

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -82,7 +82,7 @@ class BaseMeasurementStrategy:
         apply_photon_loss: Callable[[torch.Tensor], torch.Tensor],
         apply_detectors: Callable[[torch.Tensor], torch.Tensor],
         grouping: Callable[[torch.Tensor], torch.Tensor] | None = None,
-    ) -> torch.Tensor | PartialMeasurement:
+    ) -> torch.Tensor | PartialMeasurement | SectoredDistribution:
         """Return the processed result for the selected measurement strategy.
 
         Parameters

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -79,8 +79,12 @@ class BaseMeasurementStrategy:
         apply_sampling: bool,
         effective_shots: int,
         sampler: SamplingProcess,
-        apply_photon_loss: Callable[[torch.Tensor], torch.Tensor],
-        apply_detectors: Callable[[torch.Tensor], torch.Tensor],
+        apply_photon_loss: Callable[
+            [torch.Tensor | SectoredDistribution], torch.Tensor | SectoredDistribution
+        ],
+        apply_detectors: Callable[
+            [torch.Tensor | SectoredDistribution], torch.Tensor | SectoredDistribution
+        ],
         grouping: Callable[[torch.Tensor], torch.Tensor] | None = None,
     ) -> torch.Tensor | PartialMeasurement | SectoredDistribution:
         """Return the processed result for the selected measurement strategy.
@@ -128,8 +132,12 @@ class DistributionStrategy(BaseMeasurementStrategy):
         apply_sampling: bool,
         effective_shots: int,
         sampler: SamplingProcess,
-        apply_photon_loss: Callable[[torch.Tensor], torch.Tensor],
-        apply_detectors: Callable[[torch.Tensor], torch.Tensor],
+        apply_photon_loss: Callable[
+            [torch.Tensor | SectoredDistribution], torch.Tensor | SectoredDistribution
+        ],
+        apply_detectors: Callable[
+            [torch.Tensor | SectoredDistribution], torch.Tensor | SectoredDistribution
+        ],
         grouping: Callable[[torch.Tensor], torch.Tensor] | None = None,
     ) -> torch.Tensor | SectoredDistribution:
         # Distribution strategies apply detector/noise transforms before sampling.
@@ -204,8 +212,12 @@ class PartialMeasurementStrategy(BaseMeasurementStrategy):
         apply_sampling: bool,
         effective_shots: int,
         sampler: SamplingProcess,
-        apply_photon_loss: Callable[[torch.Tensor], torch.Tensor],
-        apply_detectors: Callable[[torch.Tensor], torch.Tensor],
+        apply_photon_loss: Callable[
+            [torch.Tensor | SectoredDistribution], torch.Tensor | SectoredDistribution
+        ],
+        apply_detectors: Callable[
+            [torch.Tensor | SectoredDistribution], torch.Tensor | SectoredDistribution
+        ],
         grouping: Callable[[torch.Tensor], torch.Tensor] | None = None,
     ) -> PartialMeasurement:
         if apply_sampling and effective_shots > 0:

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -228,7 +228,10 @@ class PartialMeasurementStrategy(BaseMeasurementStrategy):
         # Cast to ensure type narrowing for the apply_photon_loss and apply_detectors calls.
         amplitudes_tensor = cast(torch.Tensor, amplitudes)
         # Apply photon loss before detectors to match detector basis configuration.
-        amplitudes_tensor = apply_photon_loss(amplitudes_tensor)
+        amplitudes_tensor = cast(
+            torch.Tensor,
+            apply_photon_loss(amplitudes_tensor),
+        )
         detector_output = apply_detectors(amplitudes_tensor)
         if not isinstance(detector_output, list):
             raise TypeError(

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -78,7 +78,7 @@ class BaseMeasurementStrategy:
         amplitudes: torch.Tensor,
         apply_sampling: bool,
         effective_shots: int,
-        sample_fn: Callable[[torch.Tensor, int], torch.Tensor],
+        sampler: SamplingProcess,
         apply_photon_loss: Callable[[torch.Tensor], torch.Tensor],
         apply_detectors: Callable[[torch.Tensor], torch.Tensor],
         grouping: Callable[[torch.Tensor], torch.Tensor] | None = None,
@@ -95,8 +95,8 @@ class BaseMeasurementStrategy:
             Whether sampling should be applied.
         effective_shots : int
             Effective number of shots used for sampling.
-        sample_fn : Callable[[torch.Tensor, int], torch.Tensor]
-            Sampling function.
+        sampler : SamplingProcess
+            Sampling process object providing sampling methods.
         apply_photon_loss : Callable[[torch.Tensor], torch.Tensor]
             Photon-loss transform.
         apply_detectors : Callable[[torch.Tensor], torch.Tensor]
@@ -173,7 +173,13 @@ class ModeExpectationsStrategy(DistributionStrategy):
 class AmplitudesStrategy(BaseMeasurementStrategy):
     """New API: return raw amplitudes (sampling is not supported)."""
 
-    def process(self, *, amplitudes: torch.Tensor, **kwargs: object) -> torch.Tensor:
+    def process(
+        self,
+        *,
+        amplitudes: torch.Tensor,
+        sampler: SamplingProcess | None = None,
+        **kwargs: object
+    ) -> torch.Tensor:
         # Amplitudes bypass detectors, photon loss, and sampling.
         apply_sampling = bool(kwargs.get("apply_sampling", False))
         if apply_sampling:
@@ -203,7 +209,7 @@ class PartialMeasurementStrategy(BaseMeasurementStrategy):
         amplitudes: torch.Tensor,
         apply_sampling: bool,
         effective_shots: int,
-        sample_fn: Callable[[torch.Tensor, int], torch.Tensor],
+        sampler: SamplingProcess,
         apply_photon_loss: Callable[[torch.Tensor], torch.Tensor],
         apply_detectors: Callable[[torch.Tensor], torch.Tensor],
         grouping: Callable[[torch.Tensor], torch.Tensor] | None = None,

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -28,7 +28,7 @@ import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, ClassVar, TypeAlias
+from typing import TYPE_CHECKING, ClassVar, TypeAlias, cast
 
 import torch
 
@@ -75,7 +75,7 @@ class BaseMeasurementStrategy:
         self,
         *,
         distribution: torch.Tensor,
-        amplitudes: torch.Tensor,
+        amplitudes: torch.Tensor | SectoredDistribution,
         apply_sampling: bool,
         effective_shots: int,
         sampler: SamplingProcess,
@@ -89,8 +89,9 @@ class BaseMeasurementStrategy:
         ----------
         distribution : torch.Tensor
             Probability distribution before final post-processing.
-        amplitudes : torch.Tensor
-            Raw amplitudes before measurement-specific processing.
+        amplitudes : torch.Tensor | SectoredDistribution
+            Raw amplitudes before measurement-specific processing, or a sectored
+            distribution in the g2 noise case.
         apply_sampling : bool
             Whether sampling should be applied.
         effective_shots : int
@@ -106,7 +107,7 @@ class BaseMeasurementStrategy:
 
         Returns
         -------
-        torch.Tensor | PartialMeasurement
+        torch.Tensor | PartialMeasurement | SectoredDistribution
             Processed measurement result.
         """
         raise NotImplementedError
@@ -122,7 +123,7 @@ class DistributionStrategy(BaseMeasurementStrategy):
         self,
         *,
         distribution: torch.Tensor | SectoredDistribution,
-        amplitudes: torch.Tensor,
+        amplitudes: torch.Tensor | SectoredDistribution,
         apply_sampling: bool,
         effective_shots: int,
         sampler: SamplingProcess,
@@ -173,10 +174,10 @@ class AmplitudesStrategy(BaseMeasurementStrategy):
     def process(
         self,
         *,
-        amplitudes: torch.Tensor,
+        amplitudes: torch.Tensor | SectoredDistribution,
         sampler: SamplingProcess | None = None,
         **kwargs: object,
-    ) -> torch.Tensor:
+    ) -> torch.Tensor | SectoredDistribution:
         # Amplitudes bypass detectors, photon loss, and sampling.
         apply_sampling = bool(kwargs.get("apply_sampling", False))
         if apply_sampling:
@@ -203,7 +204,7 @@ class PartialMeasurementStrategy(BaseMeasurementStrategy):
         self,
         *,
         distribution: torch.Tensor,
-        amplitudes: torch.Tensor,
+        amplitudes: torch.Tensor | SectoredDistribution,
         apply_sampling: bool,
         effective_shots: int,
         sampler: SamplingProcess,
@@ -215,9 +216,12 @@ class PartialMeasurementStrategy(BaseMeasurementStrategy):
             raise RuntimeError(
                 "Sampling cannot be applied when measurement_strategy=MeasurementStrategy.partial()."
             )
+        # In partial measurement, amplitudes should always be Tensor, not SectoredDistribution.
+        # Cast to ensure type narrowing for the apply_photon_loss and apply_detectors calls.
+        amplitudes_tensor = cast(torch.Tensor, amplitudes)
         # Apply photon loss before detectors to match detector basis configuration.
-        amplitudes = apply_photon_loss(amplitudes)
-        detector_output = apply_detectors(amplitudes)
+        amplitudes_tensor = apply_photon_loss(amplitudes_tensor)
+        detector_output = apply_detectors(amplitudes_tensor)
         if not isinstance(detector_output, list):
             raise TypeError(
                 "Partial measurement expects detector output in partial_measurement mode."

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -419,14 +419,12 @@ class MeasurementStrategy(metaclass=_MeasurementStrategyMeta):
         return NotImplemented
 
     def __hash__(self) -> int:
-        return hash(
-            (
-                self.type,
-                self.measured_modes,
-                self.computation_space,
-                self.grouping,
-            )
-        )
+        return hash((
+            self.type,
+            self.measured_modes,
+            self.computation_space,
+            self.grouping,
+        ))
 
     def validate_modes(self, n_modes: int) -> None:
         """Validate mode indices and warn when the selection covers all modes."""

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -135,17 +135,14 @@ class DistributionStrategy(BaseMeasurementStrategy):
             sample_fn = sampler.pcvl_sampler_g2
             if grouping:
                 raise RuntimeError(
-                    f"One grouping strategy can not be applied to the output of a simulation with g2 noise. Indeed, since this noise creates input states with more phtons than expected, multiple photon sectors are explored. The fock spaces explored are m={distribution.sectors[0].n_modes} modes and n_photons={min(distribution._photon_map.keys())} to 2*n_photons={max(distribution._photon_map.keys())} that all have different space dimensions. To still apply a grouping strategy, you can iterate over the :class:`~merlin.core.sectored_distribution.SectorResult`s of the :class:`~merlin.core.sectored_distribution.SectoredDistribution` and apply one grouping per sector."
+                    f"A grouping strategy can not be applied to the output of a simulation with g2 noise. Indeed, since this noise creates input states with more phtons than expected, multiple photon sectors are explored. The fock spaces explored are m={distribution.sectors[0].n_modes} modes and n_photons={min(distribution._photon_map.keys())} to 2*n_photons={max(distribution._photon_map.keys())} that all have different space dimensions. To still apply a grouping strategy, you can iterate over the :class:`~merlin.core.sectored_distribution.SectorResult`s of the :class:`~merlin.core.sectored_distribution.SectoredDistribution` and apply one grouping per sector."
                 )
             for sector_result in distribution.sectors:
                 sector_result.tensor = apply_photon_loss(sector_result.tensor)
                 sector_result.tensor = apply_detectors(sector_result.tensor)
 
-                if apply_sampling and effective_shots > 0:
-                    sector_result.tensor = sample_fn(
-                        sector_result.tensor, effective_shots
-                    )
-            distribution = sample_fn(distribution)
+            if apply_sampling and effective_shots > 0:
+                distribution = sample_fn(distribution, effective_shots)
         else:
             sample_fn = sampler.pcvl_sampler
             distribution = apply_photon_loss(distribution)
@@ -178,7 +175,7 @@ class AmplitudesStrategy(BaseMeasurementStrategy):
         *,
         amplitudes: torch.Tensor,
         sampler: SamplingProcess | None = None,
-        **kwargs: object
+        **kwargs: object,
     ) -> torch.Tensor:
         # Amplitudes bypass detectors, photon loss, and sampling.
         apply_sampling = bool(kwargs.get("apply_sampling", False))

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -424,14 +424,12 @@ class MeasurementStrategy(metaclass=_MeasurementStrategyMeta):
         return NotImplemented
 
     def __hash__(self) -> int:
-        return hash(
-            (
-                self.type,
-                self.measured_modes,
-                self.computation_space,
-                self.grouping,
-            )
-        )
+        return hash((
+            self.type,
+            self.measured_modes,
+            self.computation_space,
+            self.grouping,
+        ))
 
     def validate_modes(self, n_modes: int) -> None:
         """Validate mode indices and warn when the selection covers all modes."""

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -129,7 +129,7 @@ class DistributionStrategy(BaseMeasurementStrategy):
         apply_photon_loss: Callable[[torch.Tensor], torch.Tensor],
         apply_detectors: Callable[[torch.Tensor], torch.Tensor],
         grouping: Callable[[torch.Tensor], torch.Tensor] | None = None,
-    ) -> torch.Tensor:
+    ) -> torch.Tensor | SectoredDistribution:
         # Distribution strategies apply detector/noise transforms before sampling.
         if isinstance(distribution, SectoredDistribution):
             sample_fn = sampler.pcvl_sampler_g2

--- a/merlin/pcvl_pytorch/__init__.py
+++ b/merlin/pcvl_pytorch/__init__.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 from .locirc_to_tensor import CircuitConverter
-from .noisy_slos import NoisySLOSComputeGraph, NoisyG2SLOSComputeGraph
+from .noisy_slos import NoisyG2SLOSComputeGraph, NoisySLOSComputeGraph
 from .slos_torchscript import build_slos_distribution_computegraph
 
 __all__ = [

--- a/merlin/pcvl_pytorch/__init__.py
+++ b/merlin/pcvl_pytorch/__init__.py
@@ -21,11 +21,12 @@
 # SOFTWARE.
 
 from .locirc_to_tensor import CircuitConverter
-from .noisy_slos import NoisySLOSComputeGraph
+from .noisy_slos import NoisySLOSComputeGraph, NoisyG2SLOSComputeGraph
 from .slos_torchscript import build_slos_distribution_computegraph
 
 __all__ = [
     "build_slos_distribution_computegraph",
     "CircuitConverter",
     "NoisySLOSComputeGraph",
+    "NoisyG2SLOSComputeGraph",
 ]

--- a/merlin/pcvl_pytorch/noisy_slos.py
+++ b/merlin/pcvl_pytorch/noisy_slos.py
@@ -39,7 +39,6 @@ class NoisyG2SLOSComputeGraph:
         m: int,
         n_photons: int,
         computation_space: ComputationSpace = ComputationSpace.FOCK,
-        keep_keys: bool = True,
         device: str | torch.device | None = None,
         dtype: torch.dtype = torch.float,
     ) -> None:
@@ -61,8 +60,6 @@ class NoisyG2SLOSComputeGraph:
         self.m = m
         self.n_photons = n_photons
         self.computation_space = computation_space
-
-        self.keep_keys = keep_keys
         self.device = device
         self.dtype = dtype
         self.cdtype = resolve_float_complex(dtype)[1]
@@ -116,6 +113,13 @@ class NoisyG2SLOSComputeGraph:
             )
             for i in range(1, 2 * self.n_photons + 1)
         }
+
+        self.mapped_keys = [
+            tuple(state)
+            for state in Combinadics(
+                self.computation_space.casefold(), n=self.n_photons, m=self.m
+            ).enumerate_states()
+        ]
 
     def _get_extra_photon_combinations(
         self,
@@ -206,12 +210,16 @@ class NoisyG2SLOSComputeGraph:
                         ] + distributions_to_convolve
                         keys_list, probs_list = zip(*all_distributions)
                         keys, probs = convolve_distributions(keys_list, *probs_list)
-                        
+
                         # Reorder probs to match Fock order
-                        fock_states = self._fock_states_per_n[self.n_photons + num_photons_added]
-                        fock_states_list = [tuple(state.tolist()) for state in fock_states]
+                        fock_states = self._fock_states_per_n[
+                            self.n_photons + num_photons_added
+                        ]
+                        fock_states_list = [
+                            tuple(state.tolist()) for state in fock_states
+                        ]
                         key_to_idx = {key: idx for idx, key in enumerate(keys)}
-                        
+
                         reordered_probs = torch.zeros_like(probs)
                         for fock_idx, fock_state in enumerate(fock_states_list):
                             if fock_state in key_to_idx:
@@ -234,6 +242,10 @@ class NoisyG2SLOSComputeGraph:
 
             sector_outputs.append(sector)
         return SectoredDistribution(sector_outputs)
+
+    def to():
+        # TODO
+        pass
 
 
 class NoisySLOSComputeGraph:

--- a/merlin/pcvl_pytorch/noisy_slos.py
+++ b/merlin/pcvl_pytorch/noisy_slos.py
@@ -104,7 +104,7 @@ class NoisyG2SLOSComputeGraph:
                     for n_i in range(1, (2 * self.n_photons) + 1)
                 ],
             )
-            self._slos_graphs: list[NoisySLOSComputeGraph] | NoisySLOSComputeGraph = [
+            self._slos_graphs: list[NoisySLOSComputeGraph] = [
                 NoisySLOSComputeGraph(
                     noise_groups=noise_groups,
                     m=self.m,
@@ -138,7 +138,7 @@ class NoisyG2SLOSComputeGraph:
         input_state: list[int] | tuple[int, ...],
     ) -> list[list[tuple[int]]]:
         num_photons = sum(input_state)
-        output = [[]]
+        output: list[list[tuple[int]]] = [[]]
 
         # Convert to tensor if not already
         if not isinstance(input_state, Tensor):
@@ -185,7 +185,9 @@ class NoisyG2SLOSComputeGraph:
                     ].compute_probs(unitary, one_hot_state)
                     one_hot_slos_graphs[mode_idx] = (keys_one_hot, probs_one_hot)
         else:
-            probs_regular = self._slos_graphs[0].compute_probs(unitary, input_state)
+            # Cast for mypy: _slos_graphs is list when g2_distinguishable is False
+            slos_graphs_list = cast(list[NoisySLOSComputeGraph], self._slos_graphs)
+            probs_regular = slos_graphs_list[0].compute_probs(unitary, input_state)
 
         # Getting the photon combinations
         extra_photons_combinations = self._get_extra_photon_combinations(input_state)

--- a/merlin/pcvl_pytorch/noisy_slos.py
+++ b/merlin/pcvl_pytorch/noisy_slos.py
@@ -196,11 +196,15 @@ class NoisyG2SLOSComputeGraph:
         # probability p.  The two are related by g^(2)(0) = 2p/(1+p)^2, so:
         #   p = ((1 - g2) - sqrt(1 - 2*g2)) / g2,  valid for g2 in [0, 0.5].
         # For small g2, p ≈ g2/2 (L'Hôpital).  At g2=0 the limit is p=0.
-        _g2 = self.g2 if isinstance(self.g2, torch.Tensor) else torch.tensor(float(self.g2))
+        _g2 = (
+            self.g2
+            if isinstance(self.g2, torch.Tensor)
+            else torch.tensor(float(self.g2))
+        )
         _disc = (1.0 - 2.0 * _g2).clamp(min=0.0)
         p_emit = ((1.0 - _g2) - _disc.sqrt()) / _g2.clamp(min=1e-15)
         for num_photons_added in range(len(extra_photons_combinations)):
-            weight_k = (p_emit ** num_photons_added) * (
+            weight_k = (p_emit**num_photons_added) * (
                 (1 - p_emit) ** (num_input_photons - num_photons_added)
             )
 
@@ -228,7 +232,7 @@ class NoisyG2SLOSComputeGraph:
                         all_distributions = [
                             (keys_regular, probs_regular)
                         ] + distributions_to_convolve
-                        keys_list, probs_list = zip(*all_distributions)
+                        keys_list, probs_list = zip(*all_distributions, strict=True)
                         keys, probs = convolve_distributions(keys_list, *probs_list)
 
                         # Reorder probs to match Fock order
@@ -270,7 +274,7 @@ class NoisyG2SLOSComputeGraph:
             sector_outputs.append(sector)
         return SectoredDistribution(sector_outputs)
 
-    def to(self, device: str | torch.device) -> "NoisyG2SLOSComputeGraph":
+    def to(self, device: str | torch.device) -> NoisyG2SLOSComputeGraph:
         """Move cached tensors and subgraphs to a specific device.
 
         Parameters
@@ -517,7 +521,7 @@ class NoisySLOSComputeGraph:
             return keys, probs
         return probs
 
-    def to(self, device: str | torch.device) -> "NoisySLOSComputeGraph":
+    def to(self, device: str | torch.device) -> NoisySLOSComputeGraph:
         """Move cached tensors and subgraphs to a specific device.
 
         Parameters
@@ -673,7 +677,7 @@ class _InputStateNoisySLOSComputeGraph:
         }
 
     def compute_probs(
-        self, unitary: torch.Tensor, slos_graphs: list["SLOSComputeGraph"]
+        self, unitary: torch.Tensor, slos_graphs: list[SLOSComputeGraph]
     ) -> tuple[list[tuple[int, ...]], torch.Tensor]:
         """Compute noisy probabilities for the cached input state.
 

--- a/merlin/pcvl_pytorch/noisy_slos.py
+++ b/merlin/pcvl_pytorch/noisy_slos.py
@@ -77,7 +77,7 @@ class NoisyG2SLOSComputeGraph:
                 m=self.m,
                 n_photons=self.n_photons,
                 computation_space=self.computation_space,
-                keep_keys=keep_keys,
+                keep_keys=True,
                 device=device,
                 dtype=dtype,
             )
@@ -101,7 +101,7 @@ class NoisyG2SLOSComputeGraph:
                     m=self.m,
                     n_photons=self.n_photons + i,
                     computation_space=self.computation_space,
-                    keep_keys=keep_keys,
+                    keep_keys=False,
                     device=device,
                     dtype=dtype,
                     _slos_graphs=regular_slos_graphs[: n_photons + i],
@@ -109,54 +109,26 @@ class NoisyG2SLOSComputeGraph:
                 for i in range(self.n_photons + 1)
             ]
 
-    def _get_extra_photon_states(
+        # All fock states associated with each photon number n
+        self._fock_states_per_n = {
+            i: torch.tensor(Combinadics("fock", n=i, m=self.m).enumerate_states()).to(
+                device
+            )
+            for i in range(1, 2 * self.n_photons + 1)
+        }
+
+    def _get_extra_photon_combinations(
         self,
         input_state: list[int] | tuple[int, ...],
-    ) -> list[torch.Tensor]:
-        output = []
+    ) -> list[list[tuple[int]]]:
+        num_photons = sum(input_state)
+        output = [[]]
 
+        # Convert to tensor if not already
         if not isinstance(input_state, Tensor):
             input_state_tensor = torch.tensor(list(input_state), dtype=torch.int32)
         else:
             input_state_tensor = input_state.int()
-
-        output.append(input_state_tensor.unsqueeze(0))
-
-        positions = torch.arange(len(input_state_tensor), dtype=torch.long).to(
-            self.device
-        )
-        photon_positions = torch.repeat_interleave(positions, input_state_tensor).to(
-            self.device
-        )
-        for num_to_add in range(1, sum(input_state) + 1):
-            # All combinations of photons to add
-            photon_to_add_indices_list = list(
-                combinations(photon_positions.tolist(), num_to_add)
-            )
-            photon_to_add_indices = torch.tensor(
-                photon_to_add_indices_list, dtype=torch.long
-            )
-
-            n_comb = photon_to_add_indices.shape[0]
-
-            # Base matrix: original vector repeated for each combination
-            base = input_state_tensor.unsqueeze(0).repeat(n_comb, 1)
-            for i, remove_index in enumerate(photon_to_add_indices):
-                for j in remove_index:
-                    base[i, j] = base[i, j] + 1
-            output.append(base)
-
-    def _get_OBB_extra_photon_states(
-        self,
-        input_state: list[int] | tuple[int, ...],
-    ) -> torch.Tensor:
-        output = []
-        if not isinstance(input_state, Tensor):
-            input_state_tensor = torch.tensor(list(input_state), dtype=torch.int32)
-        else:
-            input_state_tensor = input_state.int()
-
-        output.append(input_state_tensor)
 
         positions = torch.arange(len(input_state_tensor), dtype=torch.long).to(
             self.device
@@ -165,11 +137,9 @@ class NoisyG2SLOSComputeGraph:
             self.device
         )
 
-        output = torch.zeros(
-            (photon_positions.size(0), len(input_state)), dtype=torch.long
-        )
-        for i, j in enumerate(photon_positions):
-            output[i, j] = 1
+        for i in range(1, num_photons + 1):
+            output.append(list(combinations(photon_positions.tolist(), i)))
+
         return output
 
     def compute_probs(
@@ -178,19 +148,92 @@ class NoisyG2SLOSComputeGraph:
         input_state: list[int] | tuple[int, ...],
     ) -> SectoredDistribution:
 
+        sector_outputs = []
+
         if unitary.size(0) == unitary.size(1) and unitary.ndim == 2:
             unitary = unitary.unsqueeze(0)
 
+        # Getting the non-g2 probs and the one hot runs for g2_distinguishable photons
         if self.g2_distinguishable:
-            OBB_states = self._get_OBB_extra_photon_states(input_state=input_state)
-            original_probs = self._slos_graphs.compute_probs(unitary, input_state)
-
+            keys_regular, probs_regular = self._slos_graphs.compute_probs(
+                unitary, input_state
+            )
+            # Generate one-hot states for each active mode and compute their probs
+            one_hot_slos_graphs = {}
+            for mode_idx in range(len(input_state)):
+                if input_state[mode_idx] > 0:  # Only for active modes
+                    one_hot_state = [0] * len(input_state)
+                    one_hot_state[mode_idx] = 1
+                    keys_one_hot, probs_one_hot = self._slos_graphs._slos_graphs[
+                        0
+                    ].compute_probs(unitary, one_hot_state)
+                    one_hot_slos_graphs[mode_idx] = (keys_one_hot, probs_one_hot)
         else:
-            input_states = self._get_extra_photon_states(input_state)
+            probs_regular = self._slos_graphs[0].compute_probs(unitary, input_state)
 
-            for i, states in enumerate(input_states):
-                for state in states:
-                    self._slos_graphs[i].compute_probs(unitary, state)
+        # Getting the photon combinations
+        extra_photons_combinations = self._get_extra_photon_combinations(input_state)
+
+        # Calculating for each sector
+        for num_photons_added in range(len(extra_photons_combinations)):
+            weight_k = (self.g2 ** (num_photons_added)) * (
+                (1 - self.g2) ** (len(input_state) - num_photons_added)
+            )
+
+            # Creating the n_photons + num_photons_added sector
+            sector = SectorResult(
+                torch.zeros(
+                    Combinadics(
+                        scheme="fock", n=self.n_photons + num_photons_added, m=self.m
+                    )
+                ),
+                n_modes=self.m,
+                n_photons=self.n_photons,
+            )
+
+            # For each combination in the sector
+            if num_photons_added == 0:
+                sector.tensor = sector.tensor + weight_k * probs_regular
+            else:
+                for combination in extra_photons_combinations[num_photons_added]:
+                    if self.g2_distinguishable:
+                        distributions_to_convolve = [
+                            one_hot_slos_graphs[photon] for photon in combination
+                        ]
+                        # Convolve probs_regular with all one-hot distributions
+                        all_distributions = [
+                            (keys_regular, probs_regular)
+                        ] + distributions_to_convolve
+                        keys_list, probs_list = zip(*all_distributions)
+                        keys, probs = convolve_distributions(keys_list, *probs_list)
+                        
+                        # Reorder probs to match Fock order
+                        fock_states = self._fock_states_per_n[self.n_photons + num_photons_added]
+                        fock_states_list = [tuple(state.tolist()) for state in fock_states]
+                        key_to_idx = {key: idx for idx, key in enumerate(keys)}
+                        
+                        reordered_probs = torch.zeros_like(probs)
+                        for fock_idx, fock_state in enumerate(fock_states_list):
+                            if fock_state in key_to_idx:
+                                conv_idx = key_to_idx[fock_state]
+                                if probs.ndim == 1:
+                                    reordered_probs[fock_idx] = probs[conv_idx]
+                                else:
+                                    reordered_probs[:, fock_idx] = probs[:, conv_idx]
+                        probs = reordered_probs
+
+                    else:
+                        input_state_to_run = input_state
+                        for photon in combination:
+                            input_state_to_run[photon] += 1
+                        probs = self._slos_graphs[num_photons_added].compute_probs(
+                            unitary, input_state_to_run
+                        )
+
+                    sector.tensor = sector.tensor + weight_k * probs
+
+            sector_outputs.append(sector)
+        return SectoredDistribution(sector_outputs)
 
 
 class NoisySLOSComputeGraph:

--- a/merlin/pcvl_pytorch/noisy_slos.py
+++ b/merlin/pcvl_pytorch/noisy_slos.py
@@ -172,7 +172,9 @@ class NoisyG2SLOSComputeGraph:
 
         # Getting the non-g2 probs and the one hot runs for g2_distinguishable photons
         if self.g2_distinguishable:
-            keys_regular, probs_regular = self._slos_graphs.compute_probs(
+            # Cast for mypy: _slos_graphs is single NoisySLOSComputeGraph when g2_distinguishable is True
+            single_graph = cast(NoisySLOSComputeGraph, self._slos_graphs)
+            keys_regular, probs_regular = single_graph.compute_probs(
                 unitary, input_state
             )
             # Generate one-hot states for each active mode and compute their probs
@@ -181,14 +183,14 @@ class NoisyG2SLOSComputeGraph:
                 if input_state[mode_idx] > 0:  # Only for active modes
                     one_hot_state = [0] * len(input_state)
                     one_hot_state[mode_idx] = 1
-                    keys_one_hot, probs_one_hot = self._slos_graphs._slos_graphs[
+                    keys_one_hot, probs_one_hot = single_graph._slos_graphs[
                         0
                     ].compute_probs(unitary, one_hot_state)
                     one_hot_slos_graphs[mode_idx] = (keys_one_hot, probs_one_hot)
         else:
             # Cast for mypy: _slos_graphs is list when g2_distinguishable is False
-            self._slos_graphs = cast(list[NoisySLOSComputeGraph], self._slos_graphs)
-            probs_regular = self._slos_graphs[0].compute_probs(unitary, input_state)
+            slos_graphs_list = cast(list[NoisySLOSComputeGraph], self._slos_graphs)
+            probs_regular = slos_graphs_list[0].compute_probs(unitary, input_state)
 
         # Getting the photon combinations
         extra_photons_combinations = self._get_extra_photon_combinations(input_state)
@@ -268,8 +270,11 @@ class NoisyG2SLOSComputeGraph:
                         input_state_to_run = list(input_state)
                         for photon in combination:
                             input_state_to_run[photon] += 1
-                        probs = self._slos_graphs[num_photons_added].compute_probs(
-                            unitary, input_state_to_run
+                        probs = cast(
+                            torch.Tensor,
+                            slos_graphs_list[num_photons_added].compute_probs(
+                                unitary, input_state_to_run
+                            ),
                         )
 
                     sector.tensor = sector.tensor + weight_k * probs

--- a/merlin/pcvl_pytorch/noisy_slos.py
+++ b/merlin/pcvl_pytorch/noisy_slos.py
@@ -243,7 +243,7 @@ class NoisyG2SLOSComputeGraph:
                         probs = reordered_probs
 
                     else:
-                        input_state_to_run = input_state
+                        input_state_to_run = input_state.copy()
                         for photon in combination:
                             input_state_to_run[photon] += 1
                         probs = self._slos_graphs[num_photons_added].compute_probs(
@@ -684,7 +684,6 @@ class _InputStateNoisySLOSComputeGraph:
         for state in self._obb_input_states:
             key = tuple(state.tolist())
             n = sum(key)
-
             _, probs = slos_graphs[n - 1].compute_probs(unitary, state)
 
             if probs.ndim == 1:

--- a/merlin/pcvl_pytorch/noisy_slos.py
+++ b/merlin/pcvl_pytorch/noisy_slos.py
@@ -12,6 +12,8 @@ subsets, and the corresponding probability distributions are convolved back
 together to obtain the final noisy output distribution.
 """
 
+from __future__ import annotations
+
 import os
 import warnings
 from collections.abc import Sequence
@@ -54,7 +56,9 @@ class NoisyG2SLOSComputeGraph:
         self.noise_groups = noise_groups
         self.indistinguishability = noise_groups.source.get("indistinguishability", 1.0)
 
-        self.g2_distinguishable = noise_groups.source.get("g2_distinguishable", None)
+        self.g2_distinguishable = noise_groups.source.get("g2_distinguishable", False)
+        if self.g2_distinguishable is None:
+            self.g2_distinguishable = False
         self.g2 = noise_groups.source.get("g2", 0.0)
 
         self.m = m

--- a/merlin/pcvl_pytorch/noisy_slos.py
+++ b/merlin/pcvl_pytorch/noisy_slos.py
@@ -128,10 +128,13 @@ class NoisyG2SLOSComputeGraph:
         }
 
         self.mapped_keys = [
-            tuple(state)
-            for state in Combinadics(
-                self.computation_space.casefold(), n=self.n_photons, m=self.m
-            ).enumerate_states()
+            [
+                tuple(state)
+                for state in Combinadics(
+                    self.computation_space.casefold(), n=self.n_photons + i, m=self.m
+                ).enumerate_states()
+            ]
+            for i in range(self.n_photons + 1)
         ]
 
     def _get_extra_photon_combinations(

--- a/merlin/pcvl_pytorch/noisy_slos.py
+++ b/merlin/pcvl_pytorch/noisy_slos.py
@@ -59,10 +59,18 @@ class NoisyG2SLOSComputeGraph:
 
         self.m = m
         self.n_photons = n_photons
-        self.computation_space = computation_space
+
         self.device = device
         self.dtype = dtype
-        self.cdtype = resolve_float_complex(dtype)[1]
+
+        self.computation_space = computation_space
+        if not self.computation_space == ComputationSpace.FOCK:
+            warnings.warn(
+                "Noisy simulations with source noise currently use ComputationSpace.FOCK. Other computation spaces are not yet supported for noise models.",
+                UserWarning,
+                stacklevel=2,
+            )
+            self.computation_space = ComputationSpace.FOCK
 
         from .slos_torchscript import (
             build_slos_distribution_computegraph as build_slos_graph,
@@ -272,8 +280,7 @@ class NoisyG2SLOSComputeGraph:
 
         # Move fock states tensors to device
         self._fock_states_per_n = {
-            n: states.to(self.device)
-            for n, states in self._fock_states_per_n.items()
+            n: states.to(self.device) for n, states in self._fock_states_per_n.items()
         }
 
         # Move SLOS graphs to device (handle both single graph and list cases)

--- a/merlin/pcvl_pytorch/noisy_slos.py
+++ b/merlin/pcvl_pytorch/noisy_slos.py
@@ -201,7 +201,7 @@ class NoisyG2SLOSComputeGraph:
                 torch.zeros(
                     Combinadics(
                         scheme="fock", n=self.n_photons + num_photons_added, m=self.m
-                    )
+                    ).compute_space_size()
                 ),
                 n_modes=self.m,
                 n_photons=self.n_photons,

--- a/merlin/pcvl_pytorch/noisy_slos.py
+++ b/merlin/pcvl_pytorch/noisy_slos.py
@@ -80,6 +80,7 @@ class NoisyG2SLOSComputeGraph:
             build_slos_distribution_computegraph as build_slos_graph,
         )
 
+        self._slos_graphs: NoisySLOSComputeGraph | list[NoisySLOSComputeGraph]
         if self.g2_distinguishable:
             self._slos_graphs = NoisySLOSComputeGraph(
                 noise_groups=noise_groups,
@@ -104,7 +105,7 @@ class NoisyG2SLOSComputeGraph:
                     for n_i in range(1, (2 * self.n_photons) + 1)
                 ],
             )
-            self._slos_graphs: list[NoisySLOSComputeGraph] = [
+            self._slos_graphs = [
                 NoisySLOSComputeGraph(
                     noise_groups=noise_groups,
                     m=self.m,
@@ -186,8 +187,8 @@ class NoisyG2SLOSComputeGraph:
                     one_hot_slos_graphs[mode_idx] = (keys_one_hot, probs_one_hot)
         else:
             # Cast for mypy: _slos_graphs is list when g2_distinguishable is False
-            slos_graphs_list = cast(list[NoisySLOSComputeGraph], self._slos_graphs)
-            probs_regular = slos_graphs_list[0].compute_probs(unitary, input_state)
+            self._slos_graphs = cast(list[NoisySLOSComputeGraph], self._slos_graphs)
+            probs_regular = self._slos_graphs[0].compute_probs(unitary, input_state)
 
         # Getting the photon combinations
         extra_photons_combinations = self._get_extra_photon_combinations(input_state)
@@ -264,7 +265,7 @@ class NoisyG2SLOSComputeGraph:
                         probs = reordered_probs
 
                     else:
-                        input_state_to_run = input_state.copy()
+                        input_state_to_run = list(input_state)
                         for photon in combination:
                             input_state_to_run[photon] += 1
                         probs = self._slos_graphs[num_photons_added].compute_probs(
@@ -274,7 +275,7 @@ class NoisyG2SLOSComputeGraph:
                     sector.tensor = sector.tensor + weight_k * probs
 
             sector_outputs.append(sector)
-        return SectoredDistribution(sector_outputs)
+        return SectoredDistribution(tuple(sector_outputs))
 
     def to(self, device: str | torch.device) -> NoisyG2SLOSComputeGraph:
         """Move cached tensors and subgraphs to a specific device.

--- a/merlin/pcvl_pytorch/noisy_slos.py
+++ b/merlin/pcvl_pytorch/noisy_slos.py
@@ -104,7 +104,7 @@ class NoisyG2SLOSComputeGraph:
                     for n_i in range(1, (2 * self.n_photons) + 1)
                 ],
             )
-            self._slos_graphs = [
+            self._slos_graphs: list[NoisySLOSComputeGraph] | NoisySLOSComputeGraph = [
                 NoisySLOSComputeGraph(
                     noise_groups=noise_groups,
                     m=self.m,

--- a/merlin/pcvl_pytorch/noisy_slos.py
+++ b/merlin/pcvl_pytorch/noisy_slos.py
@@ -243,9 +243,71 @@ class NoisyG2SLOSComputeGraph:
             sector_outputs.append(sector)
         return SectoredDistribution(sector_outputs)
 
-    def to():
-        # TODO
-        pass
+    def to(self, device: str | torch.device) -> "NoisyG2SLOSComputeGraph":
+        """Move cached tensors and subgraphs to a specific device.
+
+        Parameters
+        ----------
+        device : str | torch.device
+            Target device.
+
+        Returns
+        -------
+        NoisyG2SLOSComputeGraph
+            The graph instance moved to ``device``.
+
+        Raises
+        ------
+        TypeError
+            If ``device`` is neither a string nor a ``torch.device``.
+        """
+        if isinstance(device, str):
+            self.device = torch.device(device)
+        elif isinstance(device, torch.device):
+            self.device = device
+        else:
+            raise TypeError(
+                f"Expected a string or torch.device, but got {type(device).__name__}"
+            )
+
+        # Move fock states tensors to device
+        self._fock_states_per_n = {
+            n: states.to(self.device)
+            for n, states in self._fock_states_per_n.items()
+        }
+
+        # Move SLOS graphs to device (handle both single graph and list cases)
+        if isinstance(self._slos_graphs, NoisySLOSComputeGraph):
+            self._slos_graphs.to(self.device)
+        else:
+            for graph in self._slos_graphs:
+                graph.to(self.device)
+
+        return self
+
+    def save(self, path: str | os.PathLike[str]) -> None:
+        """Save the noisy g2 SLOS graph configuration to disk.
+
+        Parameters
+        ----------
+        path : str | os.PathLike[str]
+            Destination path for the serialized graph metadata.
+        """
+        dir_path = os.path.dirname(path)
+        if dir_path and not os.path.exists(dir_path):
+            os.makedirs(dir_path)
+
+        metadata = {
+            "noise_groups": self.noise_groups,
+            "m": self.m,
+            "n_photons": self.n_photons,
+            "computation_space": self.computation_space.value,
+            "g2_distinguishable": self.g2_distinguishable,
+            "g2": float(self.g2),
+            "dtype_str": str(self.dtype),
+        }
+
+        torch.save({"metadata": metadata}, path)
 
 
 class NoisySLOSComputeGraph:

--- a/merlin/pcvl_pytorch/noisy_slos.py
+++ b/merlin/pcvl_pytorch/noisy_slos.py
@@ -191,9 +191,17 @@ class NoisyG2SLOSComputeGraph:
         extra_photons_combinations = self._get_extra_photon_combinations(input_state)
 
         # Calculating for each sector
+        num_input_photons = sum(input_state)
+        # Convert g2 = g^(2)(0) second-order coherence to per-source emission
+        # probability p.  The two are related by g^(2)(0) = 2p/(1+p)^2, so:
+        #   p = ((1 - g2) - sqrt(1 - 2*g2)) / g2,  valid for g2 in [0, 0.5].
+        # For small g2, p ≈ g2/2 (L'Hôpital).  At g2=0 the limit is p=0.
+        _g2 = self.g2 if isinstance(self.g2, torch.Tensor) else torch.tensor(float(self.g2))
+        _disc = (1.0 - 2.0 * _g2).clamp(min=0.0)
+        p_emit = ((1.0 - _g2) - _disc.sqrt()) / _g2.clamp(min=1e-15)
         for num_photons_added in range(len(extra_photons_combinations)):
-            weight_k = (self.g2 ** (num_photons_added)) * (
-                (1 - self.g2) ** (len(input_state) - num_photons_added)
+            weight_k = (p_emit ** num_photons_added) * (
+                (1 - p_emit) ** (num_input_photons - num_photons_added)
             )
 
             # Creating the n_photons + num_photons_added sector
@@ -230,7 +238,14 @@ class NoisyG2SLOSComputeGraph:
                         fock_states_list = [
                             tuple(state.tolist()) for state in fock_states
                         ]
-                        key_to_idx = {key: idx for idx, key in enumerate(keys)}
+                        keys_as_tuples = (
+                            [tuple(k.tolist()) for k in keys]
+                            if isinstance(keys, torch.Tensor)
+                            else [tuple(k) for k in keys]
+                        )
+                        key_to_idx = {
+                            key: idx for idx, key in enumerate(keys_as_tuples)
+                        }
 
                         reordered_probs = torch.zeros_like(probs)
                         for fock_idx, fock_state in enumerate(fock_states_list):

--- a/merlin/pcvl_pytorch/noisy_slos.py
+++ b/merlin/pcvl_pytorch/noisy_slos.py
@@ -204,7 +204,7 @@ class NoisyG2SLOSComputeGraph:
                     ).compute_space_size()
                 ),
                 n_modes=self.m,
-                n_photons=self.n_photons,
+                n_photons=self.n_photons + num_photons_added,
             )
 
             # For each combination in the sector

--- a/merlin/pcvl_pytorch/noisy_slos.py
+++ b/merlin/pcvl_pytorch/noisy_slos.py
@@ -137,9 +137,9 @@ class NoisyG2SLOSComputeGraph:
     def _get_extra_photon_combinations(
         self,
         input_state: list[int] | tuple[int, ...],
-    ) -> list[list[tuple[int]]]:
+    ) -> list[list[tuple[int, ...]]]:
         num_photons = sum(input_state)
-        output: list[list[tuple[int]]] = [[]]
+        output: list[list[tuple[int, ...]]] = [[]]
 
         # Convert to tensor if not already
         if not isinstance(input_state, Tensor):
@@ -201,11 +201,7 @@ class NoisyG2SLOSComputeGraph:
         # probability p.  The two are related by g^(2)(0) = 2p/(1+p)^2, so:
         #   p = ((1 - g2) - sqrt(1 - 2*g2)) / g2,  valid for g2 in [0, 0.5].
         # For small g2, p ≈ g2/2 (L'Hôpital).  At g2=0 the limit is p=0.
-        _g2 = (
-            self.g2
-            if isinstance(self.g2, torch.Tensor)
-            else torch.tensor(float(self.g2))
-        )
+        _g2 = torch.as_tensor(self.g2, device=self.device, dtype=self.dtype)
         _disc = (1.0 - 2.0 * _g2).clamp(min=0.0)
         p_emit = ((1.0 - _g2) - _disc.sqrt()) / _g2.clamp(min=1e-15)
         for num_photons_added in range(len(extra_photons_combinations)):
@@ -218,7 +214,9 @@ class NoisyG2SLOSComputeGraph:
                 torch.zeros(
                     Combinadics(
                         scheme="fock", n=self.n_photons + num_photons_added, m=self.m
-                    ).compute_space_size()
+                    ).compute_space_size(),
+                    dtype=self.dtype,
+                    device=self.device,
                 ),
                 n_modes=self.m,
                 n_photons=self.n_photons + num_photons_added,

--- a/merlin/pcvl_pytorch/noisy_slos.py
+++ b/merlin/pcvl_pytorch/noisy_slos.py
@@ -24,11 +24,173 @@ from torch import Tensor
 
 from merlin.algorithms.layer_utils import NoiseGroups
 from merlin.core.computation_space import ComputationSpace
+from merlin.core.sectored_distribution import SectoredDistribution, SectorResult
 from merlin.utils.combinadics import Combinadics
 from merlin.utils.dtypes import resolve_float_complex
 
 if TYPE_CHECKING:
     from merlin.pcvl_pytorch.slos_torchscript import SLOSComputeGraph
+
+
+class NoisyG2SLOSComputeGraph:
+    def __init__(
+        self,
+        noise_groups: NoiseGroups | None,
+        m: int,
+        n_photons: int,
+        computation_space: ComputationSpace = ComputationSpace.FOCK,
+        keep_keys: bool = True,
+        device: str | torch.device | None = None,
+        dtype: torch.dtype = torch.float,
+    ) -> None:
+        if noise_groups is None:
+            raise RuntimeError(
+                "The NoisyG2SLOSComputeGraph should only be used if there is g2 noise in the circuit."
+            )
+        if noise_groups.source is None:
+            raise RuntimeError(
+                "The NoisyG2SLOSComputeGraph should only be used if there is g2 noise in the circuit."
+            )
+
+        self.noise_groups = noise_groups
+        self.indistinguishability = noise_groups.source.get("indistinguishability", 1.0)
+
+        self.g2_distinguishable = noise_groups.source.get("g2_distinguishable", None)
+        self.g2 = noise_groups.source.get("g2", 0.0)
+
+        self.m = m
+        self.n_photons = n_photons
+        self.computation_space = computation_space
+
+        self.keep_keys = keep_keys
+        self.device = device
+        self.dtype = dtype
+        self.cdtype = resolve_float_complex(dtype)[1]
+
+        from .slos_torchscript import (
+            build_slos_distribution_computegraph as build_slos_graph,
+        )
+
+        if self.g2_distinguishable:
+            self._slos_graphs = NoisySLOSComputeGraph(
+                noise_groups=noise_groups,
+                m=self.m,
+                n_photons=self.n_photons,
+                computation_space=self.computation_space,
+                keep_keys=keep_keys,
+                device=device,
+                dtype=dtype,
+            )
+        else:
+            regular_slos_graphs: list[SLOSComputeGraph] = cast(
+                list["SLOSComputeGraph"],
+                [
+                    build_slos_graph(
+                        self.m,
+                        n_i,
+                        computation_space=self.computation_space,
+                        device=device,
+                        dtype=dtype,
+                    )
+                    for n_i in range(1, (2 * self.n_photons) + 1)
+                ],
+            )
+            self._slos_graphs = [
+                NoisySLOSComputeGraph(
+                    noise_groups=noise_groups,
+                    m=self.m,
+                    n_photons=self.n_photons + i,
+                    computation_space=self.computation_space,
+                    keep_keys=keep_keys,
+                    device=device,
+                    dtype=dtype,
+                    _slos_graphs=regular_slos_graphs[: n_photons + i],
+                )
+                for i in range(self.n_photons + 1)
+            ]
+
+    def _get_extra_photon_states(
+        self,
+        input_state: list[int] | tuple[int, ...],
+    ) -> list[torch.Tensor]:
+        output = []
+
+        if not isinstance(input_state, Tensor):
+            input_state_tensor = torch.tensor(list(input_state), dtype=torch.int32)
+        else:
+            input_state_tensor = input_state.int()
+
+        output.append(input_state_tensor.unsqueeze(0))
+
+        positions = torch.arange(len(input_state_tensor), dtype=torch.long).to(
+            self.device
+        )
+        photon_positions = torch.repeat_interleave(positions, input_state_tensor).to(
+            self.device
+        )
+        for num_to_add in range(1, sum(input_state) + 1):
+            # All combinations of photons to add
+            photon_to_add_indices_list = list(
+                combinations(photon_positions.tolist(), num_to_add)
+            )
+            photon_to_add_indices = torch.tensor(
+                photon_to_add_indices_list, dtype=torch.long
+            )
+
+            n_comb = photon_to_add_indices.shape[0]
+
+            # Base matrix: original vector repeated for each combination
+            base = input_state_tensor.unsqueeze(0).repeat(n_comb, 1)
+            for i, remove_index in enumerate(photon_to_add_indices):
+                for j in remove_index:
+                    base[i, j] = base[i, j] + 1
+            output.append(base)
+
+    def _get_OBB_extra_photon_states(
+        self,
+        input_state: list[int] | tuple[int, ...],
+    ) -> torch.Tensor:
+        output = []
+        if not isinstance(input_state, Tensor):
+            input_state_tensor = torch.tensor(list(input_state), dtype=torch.int32)
+        else:
+            input_state_tensor = input_state.int()
+
+        output.append(input_state_tensor)
+
+        positions = torch.arange(len(input_state_tensor), dtype=torch.long).to(
+            self.device
+        )
+        photon_positions = torch.repeat_interleave(positions, input_state_tensor).to(
+            self.device
+        )
+
+        output = torch.zeros(
+            (photon_positions.size(0), len(input_state)), dtype=torch.long
+        )
+        for i, j in enumerate(photon_positions):
+            output[i, j] = 1
+        return output
+
+    def compute_probs(
+        self,
+        unitary: torch.Tensor,
+        input_state: list[int] | tuple[int, ...],
+    ) -> SectoredDistribution:
+
+        if unitary.size(0) == unitary.size(1) and unitary.ndim == 2:
+            unitary = unitary.unsqueeze(0)
+
+        if self.g2_distinguishable:
+            OBB_states = self._get_OBB_extra_photon_states(input_state=input_state)
+            original_probs = self._slos_graphs.compute_probs(unitary, input_state)
+
+        else:
+            input_states = self._get_extra_photon_states(input_state)
+
+            for i, states in enumerate(input_states):
+                for state in states:
+                    self._slos_graphs[i].compute_probs(unitary, state)
 
 
 class NoisySLOSComputeGraph:
@@ -75,6 +237,7 @@ class NoisySLOSComputeGraph:
         keep_keys: bool = True,
         device: str | torch.device | None = None,
         dtype: torch.dtype = torch.float,
+        _slos_graphs: list[SLOSComputeGraph] | None = None,
     ) -> None:
         if noise_groups is None:
             raise RuntimeError(
@@ -121,18 +284,22 @@ class NoisySLOSComputeGraph:
             build_slos_distribution_computegraph as build_slos_graph,
         )
 
-        self._slos_graphs: list[SLOSComputeGraph] = cast(
-            list["SLOSComputeGraph"],
-            [
-                build_slos_graph(
-                    self.m,
-                    n_i,
-                    computation_space=self.computation_space,
-                    device=device,
-                    dtype=dtype,
-                )
-                for n_i in range(1, self.n_photons + 1)
-            ],
+        self._slos_graphs: list[SLOSComputeGraph] = (
+            cast(
+                list["SLOSComputeGraph"],
+                [
+                    build_slos_graph(
+                        self.m,
+                        n_i,
+                        computation_space=self.computation_space,
+                        device=device,
+                        dtype=dtype,
+                    )
+                    for n_i in range(1, self.n_photons + 1)
+                ],
+            )
+            if _slos_graphs is None
+            else _slos_graphs
         )
 
     def compute_probs(

--- a/merlin/pcvl_pytorch/slos_torchscript.py
+++ b/merlin/pcvl_pytorch/slos_torchscript.py
@@ -1314,7 +1314,7 @@ def compute_slos_distribution(
         dtype=dtype,
         index_photons=index_photons,
     )
-    if isinstance(graph, NoisySLOSComputeGraph):
+    if isinstance(graph, (NoisySLOSComputeGraph, NoisyG2SLOSComputeGraph)):
         raise RuntimeError(
             "compute_slos_distribution does not support source-noise graphs; "
             "build a noisy graph explicitly and use compute_probs instead."
@@ -1349,7 +1349,7 @@ if __name__ == "__main__":
         graph = build_slos_distribution_computegraph(m, n_photons, dtype=dtype)
         build_time = time.time() - start_time
 
-        if isinstance(graph, NoisySLOSComputeGraph):
+        if isinstance(graph, (NoisySLOSComputeGraph, NoisyG2SLOSComputeGraph)):
             raise RuntimeError(
                 "Example expected a non-noisy SLOSComputeGraph, but a noisy graph was built."
             )

--- a/merlin/pcvl_pytorch/slos_torchscript.py
+++ b/merlin/pcvl_pytorch/slos_torchscript.py
@@ -1126,7 +1126,7 @@ def build_slos_distribution_computegraph(
     if computation_space is None:
         computation_space = ComputationSpace.UNBUNCHED
 
-    compute_graph: SLOSComputeGraph | NoisySLOSComputeGraph
+    compute_graph: SLOSComputeGraph | NoisySLOSComputeGraph | NoisyG2SLOSComputeGraph
 
     # If there is no source noise, use the regular SLOS graph
     # No noise at all

--- a/merlin/pcvl_pytorch/slos_torchscript.py
+++ b/merlin/pcvl_pytorch/slos_torchscript.py
@@ -39,8 +39,8 @@ import torch.jit as jit
 from merlin.algorithms.layer_utils import NoiseGroups
 from merlin.core.computation_space import ComputationSpace
 from merlin.pcvl_pytorch.noisy_slos import (
-    NoisySLOSComputeGraph,
     NoisyG2SLOSComputeGraph,
+    NoisySLOSComputeGraph,
 )
 from merlin.utils.deprecations import raise_no_bunching_deprecated
 from merlin.utils.dtypes import resolve_float_complex

--- a/merlin/pcvl_pytorch/slos_torchscript.py
+++ b/merlin/pcvl_pytorch/slos_torchscript.py
@@ -38,7 +38,10 @@ import torch.jit as jit
 
 from merlin.algorithms.layer_utils import NoiseGroups
 from merlin.core.computation_space import ComputationSpace
-from merlin.pcvl_pytorch.noisy_slos import NoisySLOSComputeGraph
+from merlin.pcvl_pytorch.noisy_slos import (
+    NoisySLOSComputeGraph,
+    NoisyG2SLOSComputeGraph,
+)
 from merlin.utils.deprecations import raise_no_bunching_deprecated
 from merlin.utils.dtypes import resolve_float_complex
 from merlin.utils.normalization import (
@@ -1083,7 +1086,7 @@ def build_slos_distribution_computegraph(
     device: torch.device | str | None = None,
     dtype: torch.dtype = torch.float,
     index_photons: list[tuple[int, ...]] | None = None,
-) -> SLOSComputeGraph | NoisySLOSComputeGraph:
+) -> SLOSComputeGraph | NoisySLOSComputeGraph | NoisyG2SLOSComputeGraph:
     """Construct a reusable SLOS computation graph.
 
     Parameters
@@ -1100,7 +1103,7 @@ def build_slos_distribution_computegraph(
     no_bunching : bool | None
         Deprecated legacy flag. Use ``computation_space`` instead.
     keep_keys : bool
-        Whether to keep the list of mapped Fock states. Default is ``True``.
+        Whether to keep the list of mapped Fock states. It does not apply for simulations with g2 noise. Default is ``True``.
     noise_groups : NoiseGroups|None
         The noise groups defined in the creation of the QuantumLayer. Default is None (no noise).
     device : torch.device | str | None
@@ -1112,7 +1115,7 @@ def build_slos_distribution_computegraph(
 
     Returns
     -------
-    SLOSComputeGraph
+    SLOSComputeGraph | NoisySLOSComputeGraph | NoisyG2SLOSComputeGraph
         Pre-built computation graph ready for repeated evaluations.
 
     """
@@ -1151,15 +1154,20 @@ def build_slos_distribution_computegraph(
             index_photons,
         )
     else:
-        compute_graph = NoisySLOSComputeGraph(
-            noise_groups,
-            m,
-            n_photons,
-            computation_space,
-            keep_keys,
-            device,
-            dtype,
-        )
+        if "g2" in noise_groups.source:
+            compute_graph = NoisyG2SLOSComputeGraph(
+                noise_groups, m, n_photons, computation_space, device, dtype
+            )
+        else:
+            compute_graph = NoisySLOSComputeGraph(
+                noise_groups,
+                m,
+                n_photons,
+                computation_space,
+                keep_keys,
+                device,
+                dtype,
+            )
 
     return compute_graph
 

--- a/tests/algorithms/test_layer.py
+++ b/tests/algorithms/test_layer.py
@@ -34,7 +34,9 @@ import torch.nn as nn
 from perceval import FFCircuitProvider
 
 import merlin as ML
+from merlin.measurement import MeasurementStrategy
 from merlin.core.computation_space import ComputationSpace
+from merlin.core.sectored_distribution import SectoredDistribution
 from merlin.core.partial_measurement import (
     PartialMeasurement,
 )
@@ -302,10 +304,12 @@ class TestQuantumLayer:
 
         amplitude = torch.rand(len(layer.output_keys))
         remaining_input = torch.rand(2)
-        amplitude_out, remaining, saved_state = layer._prepare_amplitude_input([
-            amplitude,
-            remaining_input,
-        ])
+        amplitude_out, remaining, saved_state = layer._prepare_amplitude_input(
+            [
+                amplitude,
+                remaining_input,
+            ]
+        )
 
         assert saved_state is original_state
         assert remaining[0] is remaining_input
@@ -346,10 +350,12 @@ class TestQuantumLayer:
             measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
-        params, batch_dim = layer._prepare_classical_parameters([
-            torch.rand(2, 2),
-            torch.rand(2, 2),
-        ])
+        params, batch_dim = layer._prepare_classical_parameters(
+            [
+                torch.rand(2, 2),
+                torch.rand(2, 2),
+            ]
+        )
 
         assert batch_dim == 2
         assert len(params) >= 2
@@ -937,9 +943,9 @@ class TestQuantumLayer:
         assert model[1].out_features == 3
         # Check that it has trainable parameters (only in Linear layer)
         trainable_params_layer = [p for p in layer.parameters() if p.requires_grad]
-        assert len(trainable_params_layer) == 0, (
-            "Layer should have no trainable parameters"
-        )
+        assert (
+            len(trainable_params_layer) == 0
+        ), "Layer should have no trainable parameters"
         trainable_params = [p for p in model.parameters() if p.requires_grad]
         assert len(trainable_params) > 0, "Model should have trainable parameters"
 
@@ -1350,29 +1356,28 @@ class TestQuantumLayer:
 
             assert has_trainable_params, "Model should have trainable parameters"
 
+    def test_g2_with_photon_loss_forward_applies_loss_per_sector() -> None:
+        """Check that photon loss is applied with the correct basis for every sector.
 
-def test_simple_num_photons_modes_and_input_state():
-    for i in range(1, 15):
-        ql = ML.QuantumLayer.simple(input_size=i)
-        assert ql.quantum_layer.n_photons == int(np.ceil((i + 1) / 2))
-        assert sum(ql.quantum_layer.input_state) == int(np.ceil((i + 1) / 2))
-        assert len(ql.quantum_layer.input_state) == i + 1
+        Correct result: a layer with both ``g2`` and post-measurement loss should
+        return a ``SectoredDistribution`` after applying photon loss independently to
+        each photon-number sector.
 
-        input_state = [0] * (i + 1)
-        for j in range(len(input_state)):
-            if j % 2 == 0:
-                input_state[j] = 1
-        assert ql.quantum_layer.input_state == pcvl.BasicState(input_state)
+        Branch result: the measurement path reuses the transform built for the
+        original 2-photon basis on the 3-photon sector, causing a matrix shape
+        mismatch during ``layer()``.
+        """
+        with pytest.warns(UserWarning, match="g2_distinguishable must be False"):
+            layer = ML.QuantumLayer(
+                circuit=pcvl.Circuit(3),
+                input_state=[1, 1, 0],
+                n_photons=2,
+                noise=pcvl.NoiseModel(g2=0.1, brightness=0.8),
+                measurement_strategy=MeasurementStrategy.probs(
+                    computation_space=ComputationSpace.FOCK
+                ),
+            )
 
+        output = layer()
 
-def test_simple_parameters():
-    for i in range(1, 15):
-        ql = ML.QuantumLayer.simple(input_size=i)
-        params = list(ql.quantum_layer.parameters())
-        named_params = [k[0] for k in ql.quantum_layer.named_parameters()]
-
-        assert params[0].numel() == i * (i + 1)
-        assert params[1].numel() == i * (i + 1)
-        assert len(params) == 2
-        assert "LI_simple" in named_params
-        assert "RI_simple" in named_params
+        assert isinstance(output, SectoredDistribution)

--- a/tests/algorithms/test_layer.py
+++ b/tests/algorithms/test_layer.py
@@ -1356,7 +1356,7 @@ class TestQuantumLayer:
 
             assert has_trainable_params, "Model should have trainable parameters"
 
-    def test_g2_with_photon_loss_forward_applies_loss_per_sector() -> None:
+    def test_g2_with_photon_loss_forward_applies_loss_per_sector(self) -> None:
         """Check that photon loss is applied with the correct basis for every sector.
 
         Correct result: a layer with both ``g2`` and post-measurement loss should

--- a/tests/algorithms/test_noise_contract.py
+++ b/tests/algorithms/test_noise_contract.py
@@ -1064,7 +1064,9 @@ def test_g2_gradient_regression():
     x = torch.randn(1, 2, requires_grad=True)
     output = layer(x)
 
-    loss = output.sectors[0].tensor.sum() ** 2 - output.sectors[1].tensor.sum() ** 2
+    loss = (100 * output.sectors[0].tensor.sum()) ** 2 - (
+        100 * output.sectors[1].tensor.sum()
+    ) ** 2
     loss.backward()
 
     # # Verify gradients are computed

--- a/tests/algorithms/test_noise_contract.py
+++ b/tests/algorithms/test_noise_contract.py
@@ -1063,10 +1063,9 @@ def test_g2_gradient_regression():
 
     x = torch.randn(1, 2, requires_grad=True)
     output = layer(x)
-
-    loss = (100 * output.sectors[0].tensor.sum()) ** 2 - (
-        100 * output.sectors[1].tensor.sum()
-    ) ** 2
+    state = torch.zeros_like(output.sectors[0].tensor)
+    state[0] = 1
+    loss = ((output.sectors[0].tensor - state) ** 2).mean()
     loss.backward()
 
     # # Verify gradients are computed

--- a/tests/algorithms/test_noise_contract.py
+++ b/tests/algorithms/test_noise_contract.py
@@ -532,9 +532,7 @@ def test_not_implemented_error_lists_classified_groups():
             )
 
     message = str(exc_info.value)
-    assert "Source" in message
     assert "Circuit" in message
-    assert "g2" in message
     assert "phase_error" in message
 
 
@@ -953,3 +951,165 @@ def test_computation_space_changed():
         assert layer.output_size == 15
         assert layer.input_size == 15
         assert layer(torch.ones(15)).size(0) == 15
+
+
+# Regression tests for g2 implementation (PML-286)
+
+
+def test_g2_with_probs_no_longer_raises_not_implemented():
+    """Regression: NoiseModel(g2=0.05) with probs output no longer raises NotImplementedError."""
+    circ = ml.CircuitBuilder(n_modes=3)
+    circ.add_entangling_layer()
+    circ.add_angle_encoding(modes=[0, 1])
+    circ.add_entangling_layer()
+
+    # Should not raise NotImplementedError anymore
+    layer = ml.QuantumLayer(
+        n_photons=2,
+        input_size=2,
+        builder=circ,
+        noise=pcvl.NoiseModel(g2=0.05),
+        measurement_strategy=ml.MeasurementStrategy.probs(
+            computation_space=ml.ComputationSpace.FOCK
+        ),
+    )
+
+    # Should be able to forward pass without error
+    x = torch.randn(1, 2)
+    output = layer(x)
+    assert output is not None
+
+
+def test_g2_indistinguishable_with_probs_no_longer_raises():
+    """Regression: NoiseModel(g2=0.05, g2_distinguishable=False) with probs no longer raises."""
+    circ = ml.CircuitBuilder(n_modes=3)
+    circ.add_entangling_layer()
+    circ.add_angle_encoding(modes=[0, 1])
+    circ.add_entangling_layer()
+
+    # Should not raise NotImplementedError anymore
+    layer = ml.QuantumLayer(
+        n_photons=2,
+        input_size=2,
+        builder=circ,
+        noise=pcvl.NoiseModel(g2=0.05, g2_distinguishable=False),
+        measurement_strategy=ml.MeasurementStrategy.probs(
+            computation_space=ml.ComputationSpace.FOCK
+        ),
+    )
+
+    # Should be able to forward pass without error
+    x = torch.randn(1, 2)
+    output = layer(x)
+    assert output is not None
+
+    # Should not raise NotImplementedError anymore
+    layer = ml.QuantumLayer(
+        n_photons=2,
+        input_size=2,
+        builder=circ,
+        noise=pcvl.NoiseModel(g2=0.05, g2_distinguishable=True),
+        measurement_strategy=ml.MeasurementStrategy.probs(
+            computation_space=ml.ComputationSpace.FOCK
+        ),
+    )
+
+    # Should be able to forward pass without error
+    x = torch.randn(1, 2)
+    output = layer(x)
+    assert output is not None
+
+
+def test_brightness_still_uses_post_measurement_approximation():
+    """Regression: NoiseModel(brightness=0.8) still uses post-measurement approximation path."""
+    circ = ml.CircuitBuilder(n_modes=3)
+    circ.add_entangling_layer()
+    circ.add_angle_encoding(modes=[0, 1])
+
+    layer = ml.QuantumLayer(
+        n_photons=2,
+        input_size=2,
+        builder=circ,
+        noise=pcvl.NoiseModel(brightness=0.8),
+        measurement_strategy=ml.MeasurementStrategy.probs(
+            computation_space=ml.ComputationSpace.FOCK
+        ),
+    )
+
+    # Verify brightness is classified as post_measurement
+    assert "brightness" in layer._noise_groups.post_measurement
+    assert layer._noise_groups.post_measurement["brightness"] == 0.8
+
+    # Should forward without error
+    x = torch.randn(1, 2)
+    output = layer(x)
+    assert output is not None
+
+
+def test_g2_layer_forward_returns_sectored_distribution():
+    """Regression: layer(x) returns SectoredDistribution when g2 > 0."""
+    circ = ml.CircuitBuilder(n_modes=3)
+    circ.add_entangling_layer()
+    circ.add_angle_encoding(modes=[0, 1])
+    circ.add_entangling_layer()
+
+    layer = ml.QuantumLayer(
+        n_photons=2,
+        input_size=2,
+        builder=circ,
+        noise=pcvl.NoiseModel(g2=0.1, g2_distinguishable=False),
+        measurement_strategy=ml.MeasurementStrategy.probs(
+            computation_space=ml.ComputationSpace.FOCK
+        ),
+    )
+
+    x = torch.randn(1, 2)
+    output = layer(x)
+
+    # Output should be SectoredDistribution when g2 > 0
+    from merlin.core import SectoredDistribution
+
+    assert isinstance(output, SectoredDistribution)
+    assert len(output.sectors) > 0
+
+
+def test_g2_gradient_regression():
+    """Regression: loss.backward() completes and layer.thetas.grad is not None for g2 > 0."""
+    circ = ml.CircuitBuilder(n_modes=3)
+    circ.add_entangling_layer(trainable=True)
+    circ.add_angle_encoding(modes=[0, 1])
+    circ.add_entangling_layer(trainable=True)
+
+    layer = ml.QuantumLayer(
+        n_photons=2,
+        input_size=2,
+        builder=circ,
+        noise=pcvl.NoiseModel(g2=0.05, g2_distinguishable=False),
+        measurement_strategy=ml.MeasurementStrategy.probs(
+            computation_space=ml.ComputationSpace.FOCK
+        ),
+    )
+
+    x = torch.randn(1, 2, requires_grad=True)
+    output = layer(x)
+
+    # Compute loss and backward
+    if hasattr(output, "tensor"):
+        # If it's a SectoredDistribution
+        loss = output.sectors[0].probs.sum()
+    else:
+        loss = output.sum()
+
+    loss.backward()
+
+    # Verify gradients are computed
+    assert x.grad is not None
+    assert torch.any(x.grad != 0)
+
+    # Verify layer parameters have gradients
+    for param in layer.parameters():
+        if param.requires_grad:
+            assert param.grad is not None
+
+    for param in layer.thetas:
+        assert param.grad is not None

--- a/tests/algorithms/test_noise_contract.py
+++ b/tests/algorithms/test_noise_contract.py
@@ -1064,16 +1064,10 @@ def test_g2_gradient_regression():
     x = torch.randn(1, 2, requires_grad=True)
     output = layer(x)
 
-    # Compute loss and backward
-    if hasattr(output, "tensor"):
-        # If it's a SectoredDistribution
-        loss = output.sectors[0].probs.sum()
-    else:
-        loss = output.sum()
-
+    loss = output.sectors[0].tensor.sum() - output.sectors[1].tensor.sum()
     loss.backward()
 
-    # Verify gradients are computed
+    # # Verify gradients are computed
     assert x.grad is not None
     assert torch.any(x.grad != 0)
 

--- a/tests/algorithms/test_noise_contract.py
+++ b/tests/algorithms/test_noise_contract.py
@@ -1064,7 +1064,7 @@ def test_g2_gradient_regression():
     x = torch.randn(1, 2, requires_grad=True)
     output = layer(x)
 
-    loss = output.sectors[0].tensor.sum() - output.sectors[1].tensor.sum()
+    loss = output.sectors[0].tensor.sum() ** 2 - output.sectors[1].tensor.sum() ** 2
     loss.backward()
 
     # # Verify gradients are computed

--- a/tests/algorithms/test_noise_contract.py
+++ b/tests/algorithms/test_noise_contract.py
@@ -216,64 +216,33 @@ def test_noisy_layer_with_probs_strategy_raises_not_implemented():
         UserWarning,
         match=r"g2_distinguishable must be False since indistinguishable g2 photons \(indistinguishability=1\.0\) cannot be distinguished\.",
     ):
-        with pytest.raises(
-            NotImplementedError,
-            match=re.escape(
-                "The following noises are not implemented yet for the QuantumLayer. Source noises: ['g2']."
+        _ = ml.QuantumLayer(
+            n_photons=2,
+            input_size=5,
+            builder=circ,
+            noise=pcvl.NoiseModel(
+                g2=0.2,
             ),
-        ):
-            _ = ml.QuantumLayer(
-                n_photons=2,
-                input_size=5,
-                builder=circ,
-                noise=pcvl.NoiseModel(
-                    g2=0.2,
-                ),
-                measurement_strategy=ml.MeasurementStrategy.probs(
-                    computation_space=ml.ComputationSpace.FOCK
-                ),
-            )
+            measurement_strategy=ml.MeasurementStrategy.probs(
+                computation_space=ml.ComputationSpace.FOCK
+            ),
+        )
     with pytest.warns(
         UserWarning,
         match=r"g2_distinguishable must be False since indistinguishable g2 photons \(indistinguishability=1\.0\) cannot be distinguished\.",
-    ):
-        with pytest.raises(
-            NotImplementedError,
-            match=re.escape(
-                "The following noises are not implemented yet for the QuantumLayer. Source noises: ['g2']."
-            ),
-        ):
-            _ = ml.QuantumLayer(
-                n_photons=2,
-                input_size=5,
-                builder=circ,
-                noise=pcvl.NoiseModel(
-                    g2=0.3,
-                ),
-                measurement_strategy=ml.MeasurementStrategy.probs(
-                    computation_space=ml.ComputationSpace.FOCK
-                ),
-            )
-
-    with pytest.raises(
-        NotImplementedError,
-        match=re.escape(
-            "The following noises are not implemented yet for the QuantumLayer. Source noises: ['g2_distinguishable', 'g2']."
-        ),
     ):
         _ = ml.QuantumLayer(
             n_photons=2,
             input_size=5,
             builder=circ,
             noise=pcvl.NoiseModel(
-                indistinguishability=0.3,
                 g2=0.3,
-                g2_distinguishable=True,
             ),
             measurement_strategy=ml.MeasurementStrategy.probs(
                 computation_space=ml.ComputationSpace.FOCK
             ),
         )
+
     with pytest.raises(
         NotImplementedError,
         match=re.escape(
@@ -411,13 +380,13 @@ def test_impossible_noise():
         UserWarning,
         match=r"g2_distinguishable must be False since indistinguishable g2 photons \(indistinguishability=1\.0\) cannot be distinguished\.",
     ):
-        with pytest.raises(
-            NotImplementedError,
-            match=re.escape(
-                "The following noises are not implemented yet for the QuantumLayer. Source noises: ['g2']."
-            ),
-        ):
-            _ = ml.QuantumLayer(n_photons=2, input_size=5, builder=circ, noise=noise)
+        _ = ml.QuantumLayer(
+            n_photons=2,
+            input_size=5,
+            builder=circ,
+            noise=noise,
+            computation_space=ml.ComputationSpace.FOCK,
+        )
 
     # Verify that g2_distinguishable was auto-corrected
     assert noise.g2_distinguishable is False
@@ -968,7 +937,7 @@ def test_g2_with_probs_no_longer_raises_not_implemented():
         n_photons=2,
         input_size=2,
         builder=circ,
-        noise=pcvl.NoiseModel(g2=0.05),
+        noise=pcvl.NoiseModel(indistinguishability=0.3, g2=0.05),
         measurement_strategy=ml.MeasurementStrategy.probs(
             computation_space=ml.ComputationSpace.FOCK
         ),
@@ -1008,7 +977,9 @@ def test_g2_indistinguishable_with_probs_no_longer_raises():
         n_photons=2,
         input_size=2,
         builder=circ,
-        noise=pcvl.NoiseModel(g2=0.05, g2_distinguishable=True),
+        noise=pcvl.NoiseModel(
+            indistinguishability=0.7, g2=0.05, g2_distinguishable=True
+        ),
         measurement_strategy=ml.MeasurementStrategy.probs(
             computation_space=ml.ComputationSpace.FOCK
         ),

--- a/tests/algorithms/test_noise_contract.py
+++ b/tests/algorithms/test_noise_contract.py
@@ -212,36 +212,6 @@ def test_noisy_layer_with_probs_strategy_raises_not_implemented():
     circ.add_entangling_layer()
     circ.add_angle_encoding()
     circ.add_entangling_layer()
-    with pytest.warns(
-        UserWarning,
-        match=r"g2_distinguishable must be False since indistinguishable g2 photons \(indistinguishability=1\.0\) cannot be distinguished\.",
-    ):
-        _ = ml.QuantumLayer(
-            n_photons=2,
-            input_size=5,
-            builder=circ,
-            noise=pcvl.NoiseModel(
-                g2=0.2,
-            ),
-            measurement_strategy=ml.MeasurementStrategy.probs(
-                computation_space=ml.ComputationSpace.FOCK
-            ),
-        )
-    with pytest.warns(
-        UserWarning,
-        match=r"g2_distinguishable must be False since indistinguishable g2 photons \(indistinguishability=1\.0\) cannot be distinguished\.",
-    ):
-        _ = ml.QuantumLayer(
-            n_photons=2,
-            input_size=5,
-            builder=circ,
-            noise=pcvl.NoiseModel(
-                g2=0.3,
-            ),
-            measurement_strategy=ml.MeasurementStrategy.probs(
-                computation_space=ml.ComputationSpace.FOCK
-            ),
-        )
 
     with pytest.raises(
         NotImplementedError,

--- a/tests/measurement/test_measurement_strategy.py
+++ b/tests/measurement/test_measurement_strategy.py
@@ -572,17 +572,22 @@ def test_probabilities_strategy_applies_transforms_and_sampling():
     def apply_detectors(dist: torch.Tensor) -> torch.Tensor:
         return dist + 1.0
 
-    def sample_fn(dist: torch.Tensor, shots: int) -> torch.Tensor:
-        assert torch.allclose(dist, torch.tensor([3.0]))
-        assert shots == 5
-        return dist * 0 + shots
+    # Create a mock sampler with the expected interface
+    class MockSampler:
+        def pcvl_sampler(self, dist: torch.Tensor, shots: int) -> torch.Tensor:
+            assert torch.allclose(dist, torch.tensor([3.0]))
+            assert shots == 5
+            return dist * 0 + shots
+
+        def pcvl_sampler_g2(self, dist: torch.Tensor, shots: int) -> torch.Tensor:
+            return dist
 
     result = strategy.process(
         distribution=distribution,
         amplitudes=amplitudes,
         apply_sampling=True,
         effective_shots=5,
-        sample_fn=sample_fn,
+        sampler=MockSampler(),
         apply_photon_loss=apply_photon_loss,
         apply_detectors=apply_detectors,
     )
@@ -602,15 +607,20 @@ def test_probabilities_strategy_skips_sampling_when_zero_shots():
     def apply_detectors(dist: torch.Tensor) -> torch.Tensor:
         return dist * 2.0
 
-    def sample_fn(dist: torch.Tensor, shots: int) -> torch.Tensor:
-        raise AssertionError("Sampling should not be called when shots are zero.")
+    # Create a mock sampler that should not be called
+    class MockSampler:
+        def pcvl_sampler(self, dist: torch.Tensor, shots: int) -> torch.Tensor:
+            raise AssertionError("Sampling should not be called when shots are zero.")
+
+        def pcvl_sampler_g2(self, dist: torch.Tensor, shots: int) -> torch.Tensor:
+            raise AssertionError("Sampling should not be called when shots are zero.")
 
     result = strategy.process(
         distribution=distribution,
         amplitudes=amplitudes,
         apply_sampling=True,
         effective_shots=0,
-        sample_fn=sample_fn,
+        sampler=MockSampler(),
         apply_photon_loss=apply_photon_loss,
         apply_detectors=apply_detectors,
     )
@@ -630,17 +640,22 @@ def test_mode_expectations_strategy_skips_sampling_when_disabled():
     def apply_detectors(dist: torch.Tensor) -> torch.Tensor:
         return dist - 1.0
 
-    def sample_fn(dist: torch.Tensor, shots: int) -> torch.Tensor:
-        nonlocal sample_called
-        sample_called = True
-        return dist
+    # Create a mock sampler
+    class MockSampler:
+        def pcvl_sampler(self, dist: torch.Tensor, shots: int) -> torch.Tensor:
+            nonlocal sample_called
+            sample_called = True
+            return dist
+
+        def pcvl_sampler_g2(self, dist: torch.Tensor, shots: int) -> torch.Tensor:
+            return dist
 
     result = strategy.process(
         distribution=distribution,
         amplitudes=amplitudes,
         apply_sampling=False,
         effective_shots=10,
-        sample_fn=sample_fn,
+        sampler=MockSampler(),
         apply_photon_loss=apply_photon_loss,
         apply_detectors=apply_detectors,
     )
@@ -734,12 +749,19 @@ def test_partial_measurement_strategy_applies_photon_loss_before_detectors():
             }
         ]
 
+    class MockSampler:
+        def pcvl_sampler(self, dist: torch.Tensor, shots: int) -> torch.Tensor:
+            return dist
+
+        def pcvl_sampler_g2(self, dist: torch.Tensor, shots: int) -> torch.Tensor:
+            return dist
+
     result = strategy.process(
         distribution=distribution,
         amplitudes=amplitudes,
         apply_sampling=False,
         effective_shots=0,
-        sample_fn=lambda dist, shots: dist,
+        sampler=MockSampler(),
         apply_photon_loss=apply_photon_loss,
         apply_detectors=apply_detectors,
     )
@@ -762,12 +784,19 @@ def test_partial_measurement_strategy_applies_grouping_to_tensor():
             }
         ]
 
+    class MockSampler:
+        def pcvl_sampler(self, dist: torch.Tensor, shots: int) -> torch.Tensor:
+            return dist
+
+        def pcvl_sampler_g2(self, dist: torch.Tensor, shots: int) -> torch.Tensor:
+            return dist
+
     result = strategy.process(
         distribution=torch.tensor([1.0]),
         amplitudes=torch.tensor([0.25]),
         apply_sampling=False,
         effective_shots=0,
-        sample_fn=lambda dist, shots: dist,
+        sampler=MockSampler(),
         apply_photon_loss=lambda amps: amps,
         apply_detectors=apply_detectors,
         grouping=grouping,

--- a/tests/pcvl_pytorch/test_noisy_g2_slos.py
+++ b/tests/pcvl_pytorch/test_noisy_g2_slos.py
@@ -1025,8 +1025,6 @@ def test_sectored_total_probability_stays_in_autograd() -> None:
 
 
 # Tests added after review
-
-
 def _g2_layer_with_loss() -> QuantumLayer:
     """Build a g2 layer whose photon-loss transform changes each sector basis."""
     with pytest.warns(UserWarning, match="g2_distinguishable must be False"):
@@ -1052,9 +1050,6 @@ def test_sector_result_preserves_explicit_basis_keys() -> None:
     can live in a different output basis from the fixed ``n_photons`` Fock basis.
     For example, loss from a one-photon sector can include the vacuum key
     ``(0, 0, 0)``. The container needs to preserve those transform-produced keys.
-
-    Current result: ``SectorResult.__post_init__`` always regenerates the fixed
-    one-photon Fock basis and discards the explicit keys supplied by the caller.
     """
     transformed_basis_keys = ((1, 0, 0), (0, 0, 0))
 
@@ -1075,10 +1070,6 @@ def test_g2_with_photon_loss_keeps_sector_keys_aligned_with_tensor() -> None:
     ``SectorResult.keys`` tuple should describe the transformed tensor basis.
     Therefore ``len(sector.keys)`` should equal ``sector.tensor.shape[-1]`` for
     every returned sector.
-
-    Current result: the tensor is transformed into the photon-loss output basis,
-    but the sector still carries the pre-loss fixed-photon Fock keys. The first
-    sector demonstrates the mismatch with a tensor length of 10 and only 6 keys.
     """
     output = _g2_layer_with_loss()()
 
@@ -1092,10 +1083,6 @@ def test_g2_layer_to_moves_per_sector_transforms() -> None:
 
     Correct result: calling ``layer.to("cpu")`` should move the g2 simulation
     graph and each per-sector photon-loss/detector transform without raising.
-
-    Current result: the g2 path stores transforms in lists, but
-    ``QuantumLayer.to()`` calls ``range()`` on those lists, raising ``TypeError``
-    before the transforms are moved.
     """
     layer = _g2_layer_with_loss()
 

--- a/tests/pcvl_pytorch/test_noisy_g2_slos.py
+++ b/tests/pcvl_pytorch/test_noisy_g2_slos.py
@@ -16,7 +16,7 @@ import numpy as np
 import perceval as pcvl
 from copy import deepcopy
 
-from merlin import ComputationSpace, CircuitBuilder
+from merlin import ComputationSpace, CircuitBuilder, Combinadics
 from merlin.core import SectoredDistribution
 from merlin.pcvl_pytorch.noisy_slos import NoisyG2SLOSComputeGraph
 from merlin.pcvl_pytorch.slos_torchscript import SLOSComputeGraph
@@ -25,43 +25,27 @@ from merlin.pcvl_pytorch.locirc_to_tensor import CircuitConverter
 
 
 @pytest.fixture
-def simple_bs_circuit():
-    """Simple 2-mode 50:50 beamsplitter."""
-    builder = CircuitBuilder(n_modes=2)
-    builder.add_superpositions()
+def circuit():
+    """4-mode input-dependent circuit: entangling-angle-entangling."""
+    builder = CircuitBuilder(n_modes=4)
+    builder.add_entangling_layer(trainable=False)
+    builder.add_rotations()  # Creates variable input-dependent angles
+    builder.add_entangling_layer(trainable=False)
     return builder.to_pcvl_circuit()
 
 
 @pytest.fixture
-def entangling_circuit():
-    """3-mode entangling circuit."""
-    builder = CircuitBuilder(n_modes=3)
-    builder.add_entangling_layer()
-    return builder.to_pcvl_circuit()
+def unitary(circuit):
+    """Convert input-dependent circuit to unitary tensor function."""
+    converter = CircuitConverter(circuit)
 
-
-@pytest.fixture
-def unitary_2mode(simple_bs_circuit):
-    """Convert simple circuit to unitary tensor."""
-    return CircuitConverter(simple_bs_circuit).to_tensor([])
-
-
-@pytest.fixture
-def unitary_3mode(entangling_circuit):
-    """Convert entangling circuit to unitary tensor."""
-    converter = CircuitConverter(entangling_circuit)
-    # Create dummy parameters for variable components
-    if converter.nb_input_tensor > 0:
-        dummy_params = [torch.zeros(1) for _ in range(converter.nb_input_tensor)]
-        return converter.to_tensor(*dummy_params)
-    else:
-        return converter.to_tensor()
+    return converter.to_tensor
 
 
 class TestG2SectorStructure:
     """Test g2 sector structure and metadata."""
 
-    def test_sector_count(self, unitary_2mode):
+    def test_sector_count(self, unitary):
         """SectoredDistribution returned with sectors for each photon number."""
         groups = NoiseGroups(
             source={"g2": 0.1, "g2_distinguishable": False},
@@ -70,18 +54,18 @@ class TestG2SectorStructure:
         )
         noisy_slos = NoisyG2SLOSComputeGraph(
             groups,
-            m=2,
-            n_photons=2,
+            m=4,
+            n_photons=3,
             computation_space=ComputationSpace.FOCK,
         )
 
-        result = noisy_slos.compute_probs(unitary_2mode, [1, 1])
+        result = noisy_slos.compute_probs(unitary(), [1, 1, 1, 0])
         # Result should be SectoredDistribution
         assert isinstance(result, SectoredDistribution)
-        # Should have at least 2 sectors (n-photon and (n+1)-photon)
-        assert len(result.sectors) >= 2
+        # Should have 4 sectors for n_photons=3 (3, 4, 5, 6 photons)
+        assert len(result.sectors) == 4
 
-    def test_sectored_distribution_structure(self, unitary_2mode):
+    def test_sectored_distribution_structure(self, unitary):
         """SectoredDistribution has correct structure."""
         groups = NoiseGroups(
             source={"g2": 0.1, "g2_distinguishable": False},
@@ -90,27 +74,30 @@ class TestG2SectorStructure:
         )
         noisy_slos = NoisyG2SLOSComputeGraph(
             groups,
-            m=2,
-            n_photons=2,
+            m=4,
+            n_photons=3,
             computation_space=ComputationSpace.FOCK,
         )
 
-        result = noisy_slos.compute_probs(unitary_2mode, [1, 1])
+        result = noisy_slos.compute_probs(unitary(), [1, 1, 1, 0])
         assert isinstance(result, SectoredDistribution)
 
         # Check each sector exists and is accessible
         for i, sector in enumerate(result.sectors):
             assert hasattr(sector, "tensor")
             assert isinstance(sector.tensor, torch.Tensor)
-            assert sector.tensor.shape[0] > 0
+            assert (
+                sector.tensor.squeeze().shape[0]
+                == Combinadics(scheme="fock", n=3 + i, m=4).compute_space_size()
+            )
 
-    def test_g2_zero_single_sector(self, unitary_2mode):
+    def test_g2_zero_single_sector(self, unitary):
         """g2=0 returns single sector matching pure SLOS."""
         # Pure SLOS (no noise)
         slos = SLOSComputeGraph(
-            m=2, n_photons=2, computation_space=ComputationSpace.FOCK
+            m=4, n_photons=3, computation_space=ComputationSpace.FOCK
         )
-        keys_pure, probs_pure = slos.compute_probs(unitary_2mode, [1, 1])
+        keys_pure, probs_pure = slos.compute_probs(unitary(), [1, 1, 1, 0])
 
         # g2 computation with g2=0
         groups = NoiseGroups(
@@ -120,12 +107,12 @@ class TestG2SectorStructure:
         )
         noisy_slos = NoisyG2SLOSComputeGraph(
             groups,
-            m=2,
-            n_photons=2,
+            m=4,
+            n_photons=3,
             computation_space=ComputationSpace.FOCK,
         )
 
-        result = noisy_slos.compute_probs(unitary_2mode, [1, 1])
+        result = noisy_slos.compute_probs(unitary(), [1, 1, 1, 0])
         assert isinstance(result, SectoredDistribution)
 
         # With g2=0, should have single sector
@@ -134,11 +121,58 @@ class TestG2SectorStructure:
         sector_0_probs = result.sectors[0].tensor
         assert torch.allclose(probs_pure, sector_0_probs, atol=1e-5)
 
+    def test_g2_zero_with_indistinguishability(self, unitary):
+        """g2 =0 produces multiple sectors; first sector related to indistinguishable noisy SLOS."""
+        indistinguishability = 0.8
+
+        # Noisy SLOS with indistinguishability but no g2
+        groups_noisy = NoiseGroups(
+            source={"indistinguishability": indistinguishability},
+            circuit=None,
+            post_measurement=None,
+        )
+        from merlin.pcvl_pytorch.noisy_slos import NoisySLOSComputeGraph
+
+        noisy_slos_hom = NoisySLOSComputeGraph(
+            groups_noisy,
+            m=4,
+            n_photons=3,
+            computation_space=ComputationSpace.FOCK,
+            keep_keys=False,
+        )
+        probs_hom = noisy_slos_hom.compute_probs(unitary(), [1, 1, 1, 0])
+
+        # g2 computation with g2 > 0 and same indistinguishability
+        groups_g2 = NoiseGroups(
+            source={
+                "g2": 0.0,
+                "g2_distinguishable": False,
+                "indistinguishability": indistinguishability,
+            },
+            circuit=None,
+            post_measurement=None,
+        )
+        noisy_slos_g2 = NoisyG2SLOSComputeGraph(
+            groups_g2,
+            m=4,
+            n_photons=3,
+            computation_space=ComputationSpace.FOCK,
+        )
+
+        result_g2 = noisy_slos_g2.compute_probs(unitary(), [1, 1, 1, 0])
+        assert isinstance(result_g2, SectoredDistribution)
+
+        # With g2 > 0, should have multiple sectors
+        assert len(result_g2.sectors) >= 2
+
+        sector_0_probs = result_g2.sectors[0].tensor
+        assert torch.allclose(sector_0_probs, probs_hom, atol=1e-4)
+
 
 class TestG2ProbabilityNormalization:
     """Test probability normalization across sectors."""
 
-    def test_all_sector_probs_sum_to_one(self, unitary_2mode):
+    def test_all_sector_probs_sum_to_one(self, unitary):
         """Sum across all photon sectors equals 1."""
         groups = NoiseGroups(
             source={"g2": 0.2, "g2_distinguishable": False},
@@ -147,12 +181,12 @@ class TestG2ProbabilityNormalization:
         )
         noisy_slos = NoisyG2SLOSComputeGraph(
             groups,
-            m=2,
-            n_photons=2,
+            m=4,
+            n_photons=3,
             computation_space=ComputationSpace.FOCK,
         )
 
-        result = noisy_slos.compute_probs(unitary_2mode, [1, 1])
+        result = noisy_slos.compute_probs(unitary(), [1, 1, 1, 0])
         assert isinstance(result, SectoredDistribution)
 
         # Sum all probabilities across all sectors
@@ -162,7 +196,7 @@ class TestG2ProbabilityNormalization:
 
         assert np.isclose(total_prob, 1.0, atol=1e-5)
 
-    def test_normalization_multiple_inputs(self, unitary_3mode):
+    def test_normalization_multiple_inputs(self, unitary):
         """Normalization holds for various input states."""
         groups = NoiseGroups(
             source={"g2": 0.15, "g2_distinguishable": True},
@@ -171,15 +205,15 @@ class TestG2ProbabilityNormalization:
         )
         noisy_slos = NoisyG2SLOSComputeGraph(
             groups,
-            m=3,
+            m=4,
             n_photons=3,
             computation_space=ComputationSpace.FOCK,
         )
 
         # Test multiple input states
-        test_states = [[1, 1, 1], [2, 1, 0], [3, 0, 0]]
+        test_states = [[1, 1, 1, 0], [2, 1, 0, 0], [1, 1, 1, 0]]
         for state in test_states:
-            result = noisy_slos.compute_probs(unitary_3mode, state)
+            result = noisy_slos.compute_probs(unitary(), state)
             assert isinstance(result, SectoredDistribution)
 
             total = sum(sector.tensor.sum().item() for sector in result.sectors)
@@ -189,12 +223,12 @@ class TestG2ProbabilityNormalization:
 class TestG2DistinguishabilityModes:
     """Test distinguishability modes (g2_distinguishable True/False)."""
 
-    def test_distinguishable_different_from_indistinguishable(self, unitary_2mode):
+    def test_distinguishable_different_from_indistinguishable(self, unitary):
         """Different output for g2_distinguishable=True vs False."""
         # Test with distinguishable photons
         groups_dist = NoiseGroups(
             source={
-                "g2": 0.2,
+                "g2": 0.25,
                 "g2_distinguishable": True,
                 "indistinguishability": 1.0,
             },
@@ -203,16 +237,16 @@ class TestG2DistinguishabilityModes:
         )
         noisy_slos_dist = NoisyG2SLOSComputeGraph(
             groups_dist,
-            m=2,
-            n_photons=2,
+            m=4,
+            n_photons=3,
             computation_space=ComputationSpace.FOCK,
         )
-        result_dist = noisy_slos_dist.compute_probs(unitary_2mode, [1, 1])
+        result_dist = noisy_slos_dist.compute_probs(unitary(), [1, 1, 1, 0])
 
         # Test with indistinguishable photons
         groups_indist = NoiseGroups(
             source={
-                "g2": 0.2,
+                "g2": 0.25,
                 "g2_distinguishable": False,
                 "indistinguishability": 1.0,
             },
@@ -221,21 +255,33 @@ class TestG2DistinguishabilityModes:
         )
         noisy_slos_indist = NoisyG2SLOSComputeGraph(
             groups_indist,
-            m=2,
-            n_photons=2,
+            m=4,
+            n_photons=3,
             computation_space=ComputationSpace.FOCK,
         )
-        result_indist = noisy_slos_indist.compute_probs(unitary_2mode, [1, 1])
+        result_indist = noisy_slos_indist.compute_probs(unitary(), [1, 1, 1, 0])
 
         # Both should be SectoredDistribution
         assert isinstance(result_dist, SectoredDistribution)
         assert isinstance(result_indist, SectoredDistribution)
 
-        # They should have sectors
-        assert len(result_dist.sectors) >= 1
-        assert len(result_indist.sectors) >= 1
+        # They should have same number of sectors
+        assert len(result_dist.sectors) == len(result_indist.sectors)
+        assert len(result_dist.sectors) == 4
 
-    def test_indistinguishable_has_bunching(self, unitary_2mode):
+        # Verify they are actually different across sectors
+        sectors_differ = False
+        for sector_indist, sector_dist in zip(
+            result_indist.sectors, result_dist.sectors
+        ):
+            if not torch.allclose(sector_indist.tensor, sector_dist.tensor, atol=1e-6):
+                sectors_differ = True
+                break
+        assert (
+            sectors_differ
+        ), "Distinguishable and indistinguishable modes should produce different results"
+
+    def test_indistinguishable_has_bunching(self, unitary):
         """For g2_distinguishable=False: multiple sectors present."""
         groups = NoiseGroups(
             source={"g2": 0.5, "g2_distinguishable": False},
@@ -244,12 +290,12 @@ class TestG2DistinguishabilityModes:
         )
         noisy_slos = NoisyG2SLOSComputeGraph(
             groups,
-            m=2,
-            n_photons=2,
+            m=4,
+            n_photons=3,
             computation_space=ComputationSpace.FOCK,
         )
 
-        result = noisy_slos.compute_probs(unitary_2mode, [1, 1])
+        result = noisy_slos.compute_probs(unitary(), [1, 1, 1, 0])
         assert isinstance(result, SectoredDistribution)
 
         # Should have multiple sectors due to bunching
@@ -259,7 +305,7 @@ class TestG2DistinguishabilityModes:
 class TestG2ExtraPhotonDistribution:
     """Test extra photon sector distributions."""
 
-    def test_extra_photon_sector_exists(self, unitary_2mode):
+    def test_extra_photon_sector_exists(self, unitary):
         """Extra photon sector is present when g2 > 0."""
         groups = NoiseGroups(
             source={"g2": 0.1, "g2_distinguishable": True},
@@ -268,18 +314,18 @@ class TestG2ExtraPhotonDistribution:
         )
         noisy_slos = NoisyG2SLOSComputeGraph(
             groups,
-            m=2,
-            n_photons=2,
+            m=4,
+            n_photons=3,
             computation_space=ComputationSpace.FOCK,
         )
 
-        result = noisy_slos.compute_probs(unitary_2mode, [1, 1])
+        result = noisy_slos.compute_probs(unitary(), [1, 1, 1, 0])
         assert isinstance(result, SectoredDistribution)
 
-        # Should have at least 2 sectors (n-photon and n+1-photon)
+        # Should have multiple sectors (3, 4, 5, 6 photons)
         assert len(result.sectors) >= 2
 
-        # Second sector should be for 3 photons
+        # Second sector should have 4 photons
         second_sector = result.sectors[1]
         assert second_sector.tensor.shape[0] > 0
 
@@ -287,9 +333,9 @@ class TestG2ExtraPhotonDistribution:
 class TestG2Gradients:
     """Test gradient flow through g2 parameters."""
 
-    def test_result_is_differentiable(self, unitary_2mode):
+    def test_result_is_differentiable(self, unitary):
         """SectoredDistribution probs maintain gradient connection."""
-        unitary_diff = unitary_2mode.clone().detach().requires_grad_(True)
+        unitary_diff = unitary().clone().detach().requires_grad_(True)
 
         groups = NoiseGroups(
             source={"g2": 0.2, "g2_distinguishable": True},
@@ -298,12 +344,12 @@ class TestG2Gradients:
         )
         noisy_slos = NoisyG2SLOSComputeGraph(
             groups,
-            m=2,
-            n_photons=2,
+            m=4,
+            n_photons=3,
             computation_space=ComputationSpace.FOCK,
         )
 
-        result = noisy_slos.compute_probs(unitary_diff, [1, 1])
+        result = noisy_slos.compute_probs(unitary_diff, [1, 1, 1, 0])
         assert isinstance(result, SectoredDistribution)
 
         # Get first sector probability sum
@@ -317,9 +363,9 @@ class TestG2Gradients:
 class TestG2PercevalComparison:
     """Compare g2 calculations with Perceval Simulator."""
 
-    def test_against_perceval_distinguishable(self, simple_bs_circuit):
+    def test_against_perceval_distinguishable(self, circuit, unitary):
         """g2_distinguishable=True output within tolerance of Perceval."""
-        unitary = CircuitConverter(simple_bs_circuit).to_tensor([])
+        unitary_tensor = unitary()
 
         groups = NoiseGroups(
             source={
@@ -332,12 +378,12 @@ class TestG2PercevalComparison:
         )
         noisy_slos = NoisyG2SLOSComputeGraph(
             groups,
-            m=2,
-            n_photons=2,
+            m=4,
+            n_photons=3,
             computation_space=ComputationSpace.FOCK,
         )
 
-        result_merlin = noisy_slos.compute_probs(unitary, [1, 1])
+        result_merlin = noisy_slos.compute_probs(unitary_tensor, [1, 1, 1, 0])
         assert isinstance(result_merlin, SectoredDistribution)
 
         # Get Perceval reference for comparison
@@ -347,8 +393,10 @@ class TestG2PercevalComparison:
         source = pcvl.Source.from_noise_model(noise)
         backend = pcvl.BackendFactory.get_backend("SLOS")
         sim = pcvl.Simulator(backend)
-        sim.set_circuit(deepcopy(simple_bs_circuit))
-        perceval_result = sim.probs_svd((source, pcvl.BasicState([1, 1])))["results"]
+        sim.set_circuit(deepcopy(circuit))
+        perceval_result = sim.probs_svd((source, pcvl.BasicState([1, 1, 1, 0])))[
+            "results"
+        ]
 
         # Basic sanity checks
         assert len(result_merlin.sectors) > 0
@@ -356,9 +404,9 @@ class TestG2PercevalComparison:
         # Perceval result should also be non-empty
         assert len(perceval_result) > 0
 
-    def test_against_perceval_indistinguishable(self, simple_bs_circuit):
+    def test_against_perceval_indistinguishable(self, circuit, unitary):
         """g2_distinguishable=False output has multi-sector structure."""
-        unitary = CircuitConverter(simple_bs_circuit).to_tensor([])
+        unitary_tensor = unitary()
 
         groups = NoiseGroups(
             source={
@@ -371,27 +419,19 @@ class TestG2PercevalComparison:
         )
         noisy_slos = NoisyG2SLOSComputeGraph(
             groups,
-            m=2,
-            n_photons=2,
+            m=4,
+            n_photons=3,
             computation_space=ComputationSpace.FOCK,
         )
 
-        result_merlin = noisy_slos.compute_probs(unitary, [1, 1])
+        result_merlin = noisy_slos.compute_probs(unitary_tensor, [1, 1, 1, 0])
         assert isinstance(result_merlin, SectoredDistribution)
 
         # Multiple sectors expected for indistinguishable case
         assert len(result_merlin.sectors) >= 2
 
-    def test_joint_g2_and_indistinguishability(self, entangling_circuit):
+    def test_joint_g2_and_indistinguishability(self, circuit, unitary):
         """Combined hom + g2 produces SectoredDistribution."""
-        converter = CircuitConverter(entangling_circuit)
-        # Create dummy parameters for variable components
-        if converter.nb_input_tensor > 0:
-            dummy_params = [torch.zeros(1) for _ in range(converter.nb_input_tensor)]
-            unitary = converter.to_tensor(*dummy_params)
-        else:
-            unitary = converter.to_tensor()
-
         groups = NoiseGroups(
             source={
                 "g2": 0.15,
@@ -403,14 +443,16 @@ class TestG2PercevalComparison:
         )
         noisy_slos = NoisyG2SLOSComputeGraph(
             groups,
-            m=3,
+            m=4,
             n_photons=3,
             computation_space=ComputationSpace.FOCK,
         )
 
-        result_merlin = noisy_slos.compute_probs(unitary, [1, 1, 1])
+        result_merlin = noisy_slos.compute_probs(unitary(), [1, 1, 1, 0])
         assert isinstance(result_merlin, SectoredDistribution)
 
         # Verify total probability is reasonable
         total_merlin = sum(s.tensor.sum().item() for s in result_merlin.sectors)
         assert np.isclose(total_merlin, 1.0, atol=1e-5)
+        # Verify multiple sectors for combined noise
+        assert len(result_merlin.sectors) >= 2

--- a/tests/pcvl_pytorch/test_noisy_g2_slos.py
+++ b/tests/pcvl_pytorch/test_noisy_g2_slos.py
@@ -16,7 +16,13 @@ import numpy as np
 import perceval as pcvl
 from copy import deepcopy
 
-from merlin import ComputationSpace, CircuitBuilder, Combinadics
+from merlin import (
+    ComputationSpace,
+    CircuitBuilder,
+    Combinadics,
+    MeasurementStrategy,
+    QuantumLayer,
+)
 from merlin.core import SectoredDistribution, SectorResult
 from merlin.pcvl_pytorch.noisy_slos import NoisyG2SLOSComputeGraph
 from merlin.pcvl_pytorch.slos_torchscript import SLOSComputeGraph
@@ -1016,3 +1022,81 @@ def test_sectored_total_probability_stays_in_autograd() -> None:
     total.backward()
     assert sector_1.tensor.grad is not None
     assert sector_2.tensor.grad is not None
+
+
+# Tests added after review
+
+
+def _g2_layer_with_loss() -> QuantumLayer:
+    """Build a g2 layer whose photon-loss transform changes each sector basis."""
+    with pytest.warns(UserWarning, match="g2_distinguishable must be False"):
+        return QuantumLayer(
+            circuit=pcvl.Circuit(3),
+            input_state=[1, 1, 0],
+            n_photons=2,
+            noise=pcvl.NoiseModel(g2=0.1, brightness=0.8),
+            measurement_strategy=MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
+        )
+
+
+def test_sector_result_preserves_explicit_basis_keys() -> None:
+    """Check that explicit sector basis metadata is not overwritten.
+
+    Correct result: when a caller passes ``keys=...`` to ``SectorResult``, those
+    keys should remain attached to the sector. Auto-generating Fock keys is useful
+    only when ``keys`` is omitted.
+
+    Why this matters: after photon loss or detector transforms, a sector tensor
+    can live in a different output basis from the fixed ``n_photons`` Fock basis.
+    For example, loss from a one-photon sector can include the vacuum key
+    ``(0, 0, 0)``. The container needs to preserve those transform-produced keys.
+
+    Current result: ``SectorResult.__post_init__`` always regenerates the fixed
+    one-photon Fock basis and discards the explicit keys supplied by the caller.
+    """
+    transformed_basis_keys = ((1, 0, 0), (0, 0, 0))
+
+    sector = SectorResult(
+        torch.ones(len(transformed_basis_keys)),
+        n_modes=3,
+        n_photons=1,
+        keys=transformed_basis_keys,
+    )
+
+    assert sector.keys == transformed_basis_keys
+
+
+def test_g2_with_photon_loss_keeps_sector_keys_aligned_with_tensor() -> None:
+    """Check transformed g2 sectors expose keys for their returned tensors.
+
+    Correct result: after photon loss is applied per sector, each
+    ``SectorResult.keys`` tuple should describe the transformed tensor basis.
+    Therefore ``len(sector.keys)`` should equal ``sector.tensor.shape[-1]`` for
+    every returned sector.
+
+    Current result: the tensor is transformed into the photon-loss output basis,
+    but the sector still carries the pre-loss fixed-photon Fock keys. The first
+    sector demonstrates the mismatch with a tensor length of 10 and only 6 keys.
+    """
+    output = _g2_layer_with_loss()()
+
+    assert isinstance(output, SectoredDistribution)
+    for sector in output.sectors:
+        assert sector.tensor.shape[-1] == len(sector.keys)
+
+
+def test_g2_layer_to_moves_per_sector_transforms() -> None:
+    """Check ``QuantumLayer.to()`` works with g2 per-sector transforms.
+
+    Correct result: calling ``layer.to("cpu")`` should move the g2 simulation
+    graph and each per-sector photon-loss/detector transform without raising.
+
+    Current result: the g2 path stores transforms in lists, but
+    ``QuantumLayer.to()`` calls ``range()`` on those lists, raising ``TypeError``
+    before the transforms are moved.
+    """
+    layer = _g2_layer_with_loss()
+
+    layer.to("cpu")

--- a/tests/pcvl_pytorch/test_noisy_g2_slos.py
+++ b/tests/pcvl_pytorch/test_noisy_g2_slos.py
@@ -21,6 +21,7 @@ from merlin.core import SectoredDistribution, SectorResult
 from merlin.pcvl_pytorch.noisy_slos import NoisyG2SLOSComputeGraph
 from merlin.pcvl_pytorch.slos_torchscript import SLOSComputeGraph
 from merlin.algorithms.layer_utils import NoiseGroups
+from merlin.core.process import ComputationProcess
 from merlin.pcvl_pytorch.locirc_to_tensor import CircuitConverter
 
 
@@ -727,3 +728,195 @@ class TestG2PercevalComparison:
         ]
 
         self._perceval_to_merlin_probs(perceval_result, result_merlin, n_photons=3, m=4)
+
+
+class TestG2AmplitudeEncodingMultipleActiveIndices:
+    """Test ComputationProcess.compute(amplitude_encoding=True) with g2 noise and multiple active states.
+
+    Each test builds a superposition tensor covering multiple Fock basis states
+    (multiple ``active_indices``) and verifies that the resulting
+    ``SectoredDistribution`` equals the |c_i|^2-weighted mixture of per-state
+    Perceval outputs.  This exercises the multi-active-indices loop in
+    ``ComputationProcess.compute()`` (the ``NoisyG2SLOSComputeGraph`` branch).
+
+    Mapping strategy: identical to ``TestG2PercevalComparison``.
+    """
+
+    @staticmethod
+    def _weighted_perceval_combined(
+        sim: pcvl.Simulator,
+        source: pcvl.Source,
+        states: list[tuple[int, ...]],
+        weights: list[float],
+    ) -> dict:
+        """Return the |c_i|^2-weighted mixture of per-state Perceval outputs.
+
+        Parameters
+        ----------
+        sim : pcvl.Simulator
+            Configured Perceval simulator (circuit already set).
+        source : pcvl.Source
+            Noise source built from the same NoiseModel.
+        states : list[tuple[int, ...]]
+            Fock input states corresponding to each superposition term.
+        weights : list[float]
+            |c_i|^2 mixture weights; must sum to 1.
+
+        Returns
+        -------
+        dict
+            Combined ``{BasicState: probability}`` mapping.
+        """
+        combined: dict = {}
+        for state, weight in zip(states, weights, strict=True):
+            result = sim.probs_svd((source, pcvl.BasicState(list(state))))["results"]
+            for bs, prob in result.items():
+                combined[bs] = combined.get(bs, 0.0) + weight * prob
+        return combined
+
+    @staticmethod
+    def _assert_combined_matches_merlin(
+        combined: dict,
+        result_merlin: SectoredDistribution,
+        n_photons: int,
+        m: int,
+    ) -> None:
+        """Assert each combined Perceval probability matches the Merlin sector value."""
+        for state, perceval_prob in combined.items():
+            occupations = tuple(state)
+            n = sum(occupations)
+            sector_idx = n - n_photons
+            assert (
+                0 <= sector_idx < len(result_merlin.sectors)
+            ), f"State {occupations} with {n} photons has no corresponding Merlin sector"
+            combo = Combinadics("fock", n=n, m=m)
+            tensor_idx = combo.fock_to_index(occupations)
+            merlin_prob = (
+                result_merlin.sectors[sector_idx].tensor.squeeze()[tensor_idx].item()
+            )
+            assert (
+                abs(merlin_prob - perceval_prob) < 1e-4
+            ), f"State {occupations}: Merlin={merlin_prob:.6f}, Perceval={perceval_prob:.6f}"
+
+    def _make_superposition(
+        self,
+        active_states: list[tuple[int, ...]],
+        weights: list[float],
+        n_photons: int,
+        m: int,
+    ) -> torch.Tensor:
+        """Build a 1-D complex superposition tensor for the given Fock states.
+
+        Parameters
+        ----------
+        active_states : list[tuple[int, ...]]
+            Fock states to superpose.
+        weights : list[float]
+            |c_i|^2 values; must sum to 1.
+        n_photons : int
+            Photon number of each state.
+        m : int
+            Number of modes.
+
+        Returns
+        -------
+        torch.Tensor
+            1-D complex64 tensor of length ``Combinadics('fock', n, m).compute_space_size()``.
+        """
+        combo = Combinadics("fock", n=n_photons, m=m)
+        superposition = torch.zeros(combo.compute_space_size(), dtype=torch.complex64)
+        for state, w in zip(active_states, weights, strict=True):
+            superposition[combo.fock_to_index(state)] = torch.tensor(
+                w, dtype=torch.float32
+            ).sqrt()
+        return superposition
+
+    def test_distinguishable_two_active_states(self, circuit):
+        """g2_distinguishable=True: superposition of two Fock states matches weighted Perceval mixture."""
+        n_photons, m = 2, 4
+        active_states = [(1, 0, 1, 0), (0, 1, 0, 1)]
+        weights = [0.6, 0.4]
+
+        noise_groups = NoiseGroups(
+            source={"g2": 0.1, "g2_distinguishable": True, "indistinguishability": 0.9},
+            circuit=None,
+            post_measurement=None,
+        )
+        proc = ComputationProcess(
+            circuit=circuit,
+            input_state=self._make_superposition(active_states, weights, n_photons, m),
+            trainable_parameters=[],
+            input_parameters=[],
+            n_photons=n_photons,
+            computation_space=ComputationSpace.FOCK,
+            noise_groups=noise_groups,
+        )
+        result = proc.compute([], amplitude_encoding=True)
+        assert isinstance(result, SectoredDistribution)
+
+        noise = pcvl.NoiseModel(g2=0.1, g2_distinguishable=True, indistinguishability=0.9)
+        source = pcvl.Source.from_noise_model(noise)
+        sim = pcvl.Simulator(pcvl.BackendFactory.get_backend("SLOS"))
+        sim.set_circuit(deepcopy(circuit))
+        combined = self._weighted_perceval_combined(sim, source, active_states, weights)
+        self._assert_combined_matches_merlin(combined, result, n_photons=n_photons, m=m)
+
+    def test_indistinguishable_two_active_states(self, circuit):
+        """g2_distinguishable=False: superposition of two Fock states matches weighted Perceval mixture."""
+        n_photons, m = 2, 4
+        active_states = [(1, 1, 0, 0), (0, 0, 1, 1)]
+        weights = [0.5, 0.5]
+
+        noise_groups = NoiseGroups(
+            source={"g2": 0.2, "g2_distinguishable": False, "indistinguishability": 0.9},
+            circuit=None,
+            post_measurement=None,
+        )
+        proc = ComputationProcess(
+            circuit=circuit,
+            input_state=self._make_superposition(active_states, weights, n_photons, m),
+            trainable_parameters=[],
+            input_parameters=[],
+            n_photons=n_photons,
+            computation_space=ComputationSpace.FOCK,
+            noise_groups=noise_groups,
+        )
+        result = proc.compute([], amplitude_encoding=True)
+        assert isinstance(result, SectoredDistribution)
+
+        noise = pcvl.NoiseModel(g2=0.2, g2_distinguishable=False, indistinguishability=0.9)
+        source = pcvl.Source.from_noise_model(noise)
+        sim = pcvl.Simulator(pcvl.BackendFactory.get_backend("SLOS"))
+        sim.set_circuit(deepcopy(circuit))
+        combined = self._weighted_perceval_combined(sim, source, active_states, weights)
+        self._assert_combined_matches_merlin(combined, result, n_photons=n_photons, m=m)
+
+    def test_three_active_states(self, circuit):
+        """Three active Fock states: SectoredDistribution equals weighted Perceval mixture."""
+        n_photons, m = 2, 4
+        active_states = [(1, 0, 1, 0), (0, 1, 0, 1), (1, 1, 0, 0)]
+        weights = [0.5, 0.3, 0.2]
+
+        noise_groups = NoiseGroups(
+            source={"g2": 0.15, "g2_distinguishable": True, "indistinguishability": 0.85},
+            circuit=None,
+            post_measurement=None,
+        )
+        proc = ComputationProcess(
+            circuit=circuit,
+            input_state=self._make_superposition(active_states, weights, n_photons, m),
+            trainable_parameters=[],
+            input_parameters=[],
+            n_photons=n_photons,
+            computation_space=ComputationSpace.FOCK,
+            noise_groups=noise_groups,
+        )
+        result = proc.compute([], amplitude_encoding=True)
+        assert isinstance(result, SectoredDistribution)
+
+        noise = pcvl.NoiseModel(g2=0.15, g2_distinguishable=True, indistinguishability=0.85)
+        source = pcvl.Source.from_noise_model(noise)
+        sim = pcvl.Simulator(pcvl.BackendFactory.get_backend("SLOS"))
+        sim.set_circuit(deepcopy(circuit))
+        combined = self._weighted_perceval_combined(sim, source, active_states, weights)
+        self._assert_combined_matches_merlin(combined, result, n_photons=n_photons, m=m)

--- a/tests/pcvl_pytorch/test_noisy_g2_slos.py
+++ b/tests/pcvl_pytorch/test_noisy_g2_slos.py
@@ -226,7 +226,6 @@ class TestG2ProbabilityNormalization:
         total_prob = 0.0
         for sector in result.sectors:
             total_prob += sector.tensor.sum().item()
-            print(sector.tensor)
 
         assert np.isclose(total_prob, 1.0, atol=1e-5)
 
@@ -257,9 +256,31 @@ class TestG2ProbabilityNormalization:
 class TestG2DistinguishabilityModes:
     """Test distinguishability modes (g2_distinguishable True/False)."""
 
-    def test_distinguishable_different_from_indistinguishable(self, unitary):
-        """Different output for g2_distinguishable=True vs False."""
-        # Test with distinguishable photons
+    def test_distinguishable_different_from_indistinguishable(self):
+        """Different output for g2_distinguishable=True vs False.
+
+        The 4×4 DFT unitary is used directly so the circuit is guaranteed to
+        be maximally mixing, making HOM bunching visible.  With a near-identity
+        circuit photons never scatter between modes, and both modes collapse to
+        the same result regardless of the g2_distinguishable flag.
+
+        g2_distinguishable=False: the extra photon bunches in the same mode as
+        the source photon and runs through SLOS together with the other photons
+        (quantum interference active).
+        g2_distinguishable=True: the extra photon is fully distinguishable and
+        its output distribution is convolved classically with the base SLOS.
+        The DFT unitary ensures these two paths produce different sector
+        distributions.
+        """
+        # 4×4 DFT: U_{jk} = exp(2πijk/4) / 2 — maximally mixing, unitary.
+        n = 4
+        idx = torch.arange(n, dtype=torch.float32)
+        dft = (
+            torch.exp(2j * torch.pi * idx[:, None] * idx[None, :] / n) / n**0.5
+        ).to(torch.complex64)
+        u_tensor = dft.unsqueeze(0)  # [1, 4, 4]
+
+        # Test with distinguishable extra photons (classical convolution)
         groups_dist = NoiseGroups(
             source={
                 "g2": 0.25,
@@ -275,9 +296,9 @@ class TestG2DistinguishabilityModes:
             n_photons=3,
             computation_space=ComputationSpace.FOCK,
         )
-        result_dist = noisy_slos_dist.compute_probs(unitary(), [1, 1, 1, 0])
+        result_dist = noisy_slos_dist.compute_probs(u_tensor, [1, 1, 1, 0])
 
-        # Test with indistinguishable photons
+        # Test with indistinguishable extra photons (HOM active)
         groups_indist = NoiseGroups(
             source={
                 "g2": 0.25,
@@ -293,7 +314,7 @@ class TestG2DistinguishabilityModes:
             n_photons=3,
             computation_space=ComputationSpace.FOCK,
         )
-        result_indist = noisy_slos_indist.compute_probs(unitary(), [1, 1, 1, 0])
+        result_indist = noisy_slos_indist.compute_probs(u_tensor, [1, 1, 1, 0])
 
         # Both should be SectoredDistribution
         assert isinstance(result_dist, SectoredDistribution)
@@ -303,25 +324,26 @@ class TestG2DistinguishabilityModes:
         assert len(result_dist.sectors) == len(result_indist.sectors)
         assert len(result_dist.sectors) == 4
 
-        # Verify they are actually different across sectors
-        sectors_differ = False
-        for sector_indist, sector_dist in zip(
-            result_indist.sectors, result_dist.sectors
-        ):
-            if not torch.allclose(sector_indist.tensor, sector_dist.tensor, atol=1e-6):
-                sectors_differ = True
-                break
+        # Sector 0 is identical (same base SLOS, indist=1.0).
+        # Sectors 1+ must differ: with the DFT unitary, HOM bunching changes
+        # the output of SLOS([2,1,1,0]) relative to the classical convolution
+        # conv(SLOS([1,1,1,0]), SLOS([1,0,0,0])).
+        sectors_higher_differ = any(
+            not torch.allclose(si.tensor, sd.tensor, atol=1e-6)
+            for si, sd in zip(result_indist.sectors[1:], result_dist.sectors[1:])
+        )
         assert (
-            sectors_differ
-        ), "Distinguishable and indistinguishable modes should produce different results"
+            sectors_higher_differ
+        ), "Extra-photon sectors must differ between distinguishable and indistinguishable modes"
 
     def test_indistinguishable_bunched_delegate(self, unitary):
         """g2_distinguishable=False: augmented input has the expected mode occupation.
 
         With a single extra photon added to a single-photon input [1,0,0,0]
-        (g2=1.0 puts all probability in sector 1) and indistinguishability=1.0
-        (NoisySLOS reduces to pure SLOS), the sector-1 distribution must equal
-        the pure SLOS output for the augmented input [2,0,0,0].
+        (g2=0.5, the maximum of g^(2)(0), gives p_emit=1.0 so all probability
+        is in sector 1) and indistinguishability=1.0 (NoisySLOS reduces to pure
+        SLOS), the sector-1 distribution must equal the pure SLOS output for
+        the augmented input [2,0,0,0].
 
         This confirms that the extra photon is bunched into mode 0—the same
         mode occupied by the original photon—rather than being placed in a
@@ -339,11 +361,12 @@ class TestG2DistinguishabilityModes:
         )
         _, probs_augmented = slos_augmented.compute_probs(unitary_tensor, [2, 0, 0, 0])
 
-        # g2=1.0 → weight_0=(1-1)^1=0, weight_1=1^1*(1-1)^0=1 (sector 1 carries everything)
+        # g2=0.5 → p_emit=1.0 → weight_0=(1-p)^1=0, weight_1=p*(1-p)^0=1 (sector 1 carries everything)
+        # (g2=0.5 is the maximum valid value of the second-order coherence; it gives p_emit=1.0)
         # indistinguishability=1.0 → NoisySLOSComputeGraph ≡ pure SLOS
         groups = NoiseGroups(
             source={
-                "g2": 1.0,
+                "g2": 0.5,
                 "g2_distinguishable": False,
                 "indistinguishability": 1.0,
             },
@@ -392,8 +415,9 @@ class TestG2ExtraPhotonDistribution:
     def test_distinguishable_extra_photon_distribution(self, unitary):
         """g2_distinguishable=True, single g2 event in mode m: extra-photon marginal = |U[:,m]|².
 
-        For n_photons=1, input=[e_m] (photon only in mode 0), g2=1.0 (all
-        weight in sector 1), g2_distinguishable=True, indistinguishability=1.0:
+        For n_photons=1, input=[e_m] (photon only in mode 0), g2=0.5 (the
+        maximum of g^(2)(0) giving p_emit=1.0 so all weight is in sector 1),
+        g2_distinguishable=True, indistinguishability=1.0:
 
         sector-1 = conv(P_regular, P_onehot_m) where both equal |U[:,m]|².
 
@@ -414,10 +438,11 @@ class TestG2ExtraPhotonDistribution:
 
         unitary_tensor = unitary()
 
-        # g2=1.0 → weight_0=0, weight_1=1 (sector 1 carries everything)
+        # g2=0.5 → p_emit=1.0 → weight_0=0, weight_1=1 (sector 1 carries everything)
+        # (g2=0.5 is the maximum valid value of g^(2)(0), corresponding to p_emit=1.0)
         # indistinguishability=1.0 → regular probs = pure SLOS = |U[:,m]|²
         groups = NoiseGroups(
-            source={"g2": 1.0, "g2_distinguishable": True, "indistinguishability": 1.0},
+            source={"g2": 0.5, "g2_distinguishable": True, "indistinguishability": 1.0},
             circuit=None,
             post_measurement=None,
         )
@@ -504,8 +529,10 @@ class TestG2Gradients:
             # Override with the differentiable tensor so autograd tracks g2.
             noisy_slos.g2 = g2.squeeze()
             result = noisy_slos.compute_probs(unitary_tensor, [1, 1, 0, 0])
-            # Each sector sum equals C(n,k)*g2^k*(1-g2)^(n-k), so the
-            # vector has non-zero Jacobian entries w.r.t. g2.
+            # Each sector sum equals C(n,k)*p_emit^k*(1-p_emit)^(n-k) where
+            # p_emit = p_emit(g2) is the per-source emission probability derived
+            # from the second-order coherence g^(2)(0)=2p/(1+p)^2.  The vector
+            # has non-zero Jacobian entries w.r.t. g2.
             return torch.stack([s.tensor.sum() for s in result.sectors])
 
         g2_input = torch.tensor([0.2], dtype=torch.float64, requires_grad=True)

--- a/tests/pcvl_pytorch/test_noisy_g2_slos.py
+++ b/tests/pcvl_pytorch/test_noisy_g2_slos.py
@@ -1,0 +1,398 @@
+"""Tests for g2 photon correlations in SLOS (Sampled Linear Optical Simulator).
+
+This module comprehensively tests:
+1. g2=0 sector matching (pure SLOS output)
+2. Sector probability normalization
+3. Sector structure and metadata
+4. Gradient flow through g2 parameters
+5. Distinguishability modes (g2_distinguishable True/False)
+6. Photon number distributions
+7. Comparison with Perceval Simulator
+"""
+
+import pytest
+import torch
+import numpy as np
+import perceval as pcvl
+
+from merlin import ComputationSpace, CircuitBuilder
+from merlin.core import SectoredDistribution
+from merlin.pcvl_pytorch.noisy_slos import NoisyG2SLOSComputeGraph
+from merlin.pcvl_pytorch.slos_torchscript import SLOSComputeGraph
+from merlin.algorithms.layer_utils import NoiseGroups
+from merlin.pcvl_pytorch.locirc_to_tensor import CircuitConverter
+
+
+@pytest.fixture
+def simple_bs_circuit():
+    """Simple 2-mode 50:50 beamsplitter."""
+    builder = CircuitBuilder(n_modes=2)
+    builder.add_superpositions()
+    return builder.to_pcvl_circuit()
+
+
+@pytest.fixture
+def entangling_circuit():
+    """3-mode entangling circuit."""
+    builder = CircuitBuilder(n_modes=3)
+    builder.add_entangling_layer()
+    return builder.to_pcvl_circuit()
+
+
+@pytest.fixture
+def unitary_2mode(simple_bs_circuit):
+    """Convert simple circuit to unitary tensor."""
+    return CircuitConverter(simple_bs_circuit).to_tensor([])
+
+
+@pytest.fixture
+def unitary_3mode(entangling_circuit):
+    """Convert entangling circuit to unitary tensor."""
+    return CircuitConverter(entangling_circuit).to_tensor([])
+
+
+class TestG2SectorStructure:
+    """Test g2 sector structure and metadata."""
+
+    def test_sector_count(self, unitary_2mode):
+        """SectoredDistribution returned with sectors for each photon number."""
+        groups = NoiseGroups(
+            source={"g2": 0.1, "g2_distinguishable": False},
+            circuit=None,
+            post_measurement=None,
+        )
+        noisy_slos = NoisyG2SLOSComputeGraph(
+            groups,
+            m=2,
+            n_photons=2,
+            computation_space=ComputationSpace.FOCK,
+        )
+
+        result = noisy_slos.compute_probs(unitary_2mode, [1, 1])
+        # Result should be SectoredDistribution
+        assert isinstance(result, SectoredDistribution)
+        # Should have at least 2 sectors (n-photon and (n+1)-photon)
+        assert len(result.sectors) >= 2
+
+    def test_sectored_distribution_structure(self, unitary_2mode):
+        """SectoredDistribution has correct structure."""
+        groups = NoiseGroups(
+            source={"g2": 0.1, "g2_distinguishable": False},
+            circuit=None,
+            post_measurement=None,
+        )
+        noisy_slos = NoisyG2SLOSComputeGraph(
+            groups,
+            m=2,
+            n_photons=2,
+            computation_space=ComputationSpace.FOCK,
+        )
+
+        result = noisy_slos.compute_probs(unitary_2mode, [1, 1])
+        assert isinstance(result, SectoredDistribution)
+
+        # Check each sector exists and is accessible
+        for i, sector in enumerate(result.sectors):
+            assert hasattr(sector, "probs")
+            assert isinstance(sector.probs, torch.Tensor)
+            assert sector.probs.shape[0] > 0
+
+    def test_g2_zero_single_sector(self, unitary_2mode):
+        """g2=0 returns single sector matching pure SLOS."""
+        # Pure SLOS (no noise)
+        slos = SLOSComputeGraph(
+            m=2, n_photons=2, computation_space=ComputationSpace.FOCK
+        )
+        keys_pure, probs_pure = slos.compute_probs(unitary_2mode, [1, 1])
+
+        # g2 computation with g2=0
+        groups = NoiseGroups(
+            source={"g2": 0.0, "g2_distinguishable": True},
+            circuit=None,
+            post_measurement=None,
+        )
+        noisy_slos = NoisyG2SLOSComputeGraph(
+            groups,
+            m=2,
+            n_photons=2,
+            computation_space=ComputationSpace.FOCK,
+        )
+
+        result = noisy_slos.compute_probs(unitary_2mode, [1, 1])
+        assert isinstance(result, SectoredDistribution)
+
+        # With g2=0, should have single sector
+        assert len(result.sectors) >= 1
+        # First sector probabilities should match pure SLOS
+        sector_0_probs = result.sectors[0].probs
+        assert torch.allclose(probs_pure, sector_0_probs, atol=1e-5)
+
+
+class TestG2ProbabilityNormalization:
+    """Test probability normalization across sectors."""
+
+    def test_all_sector_probs_sum_to_one(self, unitary_2mode):
+        """Sum across all photon sectors equals 1."""
+        groups = NoiseGroups(
+            source={"g2": 0.2, "g2_distinguishable": False},
+            circuit=None,
+            post_measurement=None,
+        )
+        noisy_slos = NoisyG2SLOSComputeGraph(
+            groups,
+            m=2,
+            n_photons=2,
+            computation_space=ComputationSpace.FOCK,
+        )
+
+        result = noisy_slos.compute_probs(unitary_2mode, [1, 1])
+        assert isinstance(result, SectoredDistribution)
+
+        # Sum all probabilities across all sectors
+        total_prob = 0.0
+        for sector in result.sectors:
+            total_prob += sector.probs.sum().item()
+
+        assert np.isclose(total_prob, 1.0, atol=1e-5)
+
+    def test_normalization_multiple_inputs(self, unitary_3mode):
+        """Normalization holds for various input states."""
+        groups = NoiseGroups(
+            source={"g2": 0.15, "g2_distinguishable": True},
+            circuit=None,
+            post_measurement=None,
+        )
+        noisy_slos = NoisyG2SLOSComputeGraph(
+            groups,
+            m=3,
+            n_photons=3,
+            computation_space=ComputationSpace.FOCK,
+        )
+
+        # Test multiple input states
+        test_states = [[1, 1, 1], [2, 1, 0], [3, 0, 0]]
+        for state in test_states:
+            result = noisy_slos.compute_probs(unitary_3mode, state)
+            assert isinstance(result, SectoredDistribution)
+
+            total = sum(sector.probs.sum().item() for sector in result.sectors)
+            assert np.isclose(total, 1.0, atol=1e-5)
+
+
+class TestG2DistinguishabilityModes:
+    """Test distinguishability modes (g2_distinguishable True/False)."""
+
+    def test_distinguishable_different_from_indistinguishable(self, unitary_2mode):
+        """Different output for g2_distinguishable=True vs False."""
+        # Test with distinguishable photons
+        groups_dist = NoiseGroups(
+            source={
+                "g2": 0.2,
+                "g2_distinguishable": True,
+                "indistinguishability": 1.0,
+            },
+            circuit=None,
+            post_measurement=None,
+        )
+        noisy_slos_dist = NoisyG2SLOSComputeGraph(
+            groups_dist,
+            m=2,
+            n_photons=2,
+            computation_space=ComputationSpace.FOCK,
+        )
+        result_dist = noisy_slos_dist.compute_probs(unitary_2mode, [1, 1])
+
+        # Test with indistinguishable photons
+        groups_indist = NoiseGroups(
+            source={
+                "g2": 0.2,
+                "g2_distinguishable": False,
+                "indistinguishability": 1.0,
+            },
+            circuit=None,
+            post_measurement=None,
+        )
+        noisy_slos_indist = NoisyG2SLOSComputeGraph(
+            groups_indist,
+            m=2,
+            n_photons=2,
+            computation_space=ComputationSpace.FOCK,
+        )
+        result_indist = noisy_slos_indist.compute_probs(unitary_2mode, [1, 1])
+
+        # Both should be SectoredDistribution
+        assert isinstance(result_dist, SectoredDistribution)
+        assert isinstance(result_indist, SectoredDistribution)
+
+        # They should have sectors
+        assert len(result_dist.sectors) >= 1
+        assert len(result_indist.sectors) >= 1
+
+    def test_indistinguishable_has_bunching(self, unitary_2mode):
+        """For g2_distinguishable=False: multiple sectors present."""
+        groups = NoiseGroups(
+            source={"g2": 0.5, "g2_distinguishable": False},
+            circuit=None,
+            post_measurement=None,
+        )
+        noisy_slos = NoisyG2SLOSComputeGraph(
+            groups,
+            m=2,
+            n_photons=2,
+            computation_space=ComputationSpace.FOCK,
+        )
+
+        result = noisy_slos.compute_probs(unitary_2mode, [1, 1])
+        assert isinstance(result, SectoredDistribution)
+
+        # Should have multiple sectors due to bunching
+        assert len(result.sectors) >= 2
+
+
+class TestG2ExtraPhotonDistribution:
+    """Test extra photon sector distributions."""
+
+    def test_extra_photon_sector_exists(self, unitary_2mode):
+        """Extra photon sector is present when g2 > 0."""
+        groups = NoiseGroups(
+            source={"g2": 0.1, "g2_distinguishable": True},
+            circuit=None,
+            post_measurement=None,
+        )
+        noisy_slos = NoisyG2SLOSComputeGraph(
+            groups,
+            m=2,
+            n_photons=2,
+            computation_space=ComputationSpace.FOCK,
+        )
+
+        result = noisy_slos.compute_probs(unitary_2mode, [1, 1])
+        assert isinstance(result, SectoredDistribution)
+
+        # Should have at least 2 sectors (n-photon and n+1-photon)
+        assert len(result.sectors) >= 2
+
+        # Second sector should be for 3 photons
+        second_sector = result.sectors[1]
+        assert second_sector.probs.shape[0] > 0
+
+
+class TestG2Gradients:
+    """Test gradient flow through g2 parameters."""
+
+    def test_result_is_differentiable(self, unitary_2mode):
+        """SectoredDistribution probs maintain gradient connection."""
+        unitary_diff = unitary_2mode.clone().detach().requires_grad_(True)
+
+        groups = NoiseGroups(
+            source={"g2": 0.2, "g2_distinguishable": True},
+            circuit=None,
+            post_measurement=None,
+        )
+        noisy_slos = NoisyG2SLOSComputeGraph(
+            groups,
+            m=2,
+            n_photons=2,
+            computation_space=ComputationSpace.FOCK,
+        )
+
+        result = noisy_slos.compute_probs(unitary_diff, [1, 1])
+        assert isinstance(result, SectoredDistribution)
+
+        # Get first sector probability sum
+        prob_sum = result.sectors[0].probs.sum()
+        prob_sum.backward()
+
+        # Unitary should have gradients
+        assert unitary_diff.grad is not None
+
+
+class TestG2PercevalComparison:
+    """Compare g2 calculations with Perceval Simulator."""
+
+    def test_against_perceval_distinguishable(self, simple_bs_circuit):
+        """g2_distinguishable=True output within tolerance of Perceval."""
+        unitary = CircuitConverter(simple_bs_circuit).to_tensor([])
+
+        groups = NoiseGroups(
+            source={
+                "g2": 0.1,
+                "g2_distinguishable": True,
+                "indistinguishability": 1.0,
+            },
+            circuit=None,
+            post_measurement=None,
+        )
+        noisy_slos = NoisyG2SLOSComputeGraph(
+            groups,
+            m=2,
+            n_photons=2,
+            computation_space=ComputationSpace.FOCK,
+        )
+
+        result_merlin = noisy_slos.compute_probs(unitary, [1, 1])
+        assert isinstance(result_merlin, SectoredDistribution)
+
+        # Get Perceval reference for comparison
+        experiment = pcvl.Experiment(simple_bs_circuit)
+        experiment.noise = pcvl.NoiseModel(
+            g2=0.1, g2_distinguishable=True, indistinguishability=1.0
+        )
+        perceval_result = experiment.probs_svd()
+
+        # Basic sanity checks
+        assert len(result_merlin.sectors) > 0
+        assert sum(s.probs.sum().item() for s in result_merlin.sectors) > 0
+
+    def test_against_perceval_indistinguishable(self, simple_bs_circuit):
+        """g2_distinguishable=False output has multi-sector structure."""
+        unitary = CircuitConverter(simple_bs_circuit).to_tensor([])
+
+        groups = NoiseGroups(
+            source={
+                "g2": 0.2,
+                "g2_distinguishable": False,
+                "indistinguishability": 0.95,
+            },
+            circuit=None,
+            post_measurement=None,
+        )
+        noisy_slos = NoisyG2SLOSComputeGraph(
+            groups,
+            m=2,
+            n_photons=2,
+            computation_space=ComputationSpace.FOCK,
+        )
+
+        result_merlin = noisy_slos.compute_probs(unitary, [1, 1])
+        assert isinstance(result_merlin, SectoredDistribution)
+
+        # Multiple sectors expected for indistinguishable case
+        assert len(result_merlin.sectors) >= 2
+
+    def test_joint_g2_and_indistinguishability(self, entangling_circuit):
+        """Combined hom + g2 produces SectoredDistribution."""
+        unitary = CircuitConverter(entangling_circuit).to_tensor([])
+
+        groups = NoiseGroups(
+            source={
+                "g2": 0.15,
+                "g2_distinguishable": False,
+                "indistinguishability": 0.8,
+            },
+            circuit=None,
+            post_measurement=None,
+        )
+        noisy_slos = NoisyG2SLOSComputeGraph(
+            groups,
+            m=3,
+            n_photons=3,
+            computation_space=ComputationSpace.FOCK,
+        )
+
+        result_merlin = noisy_slos.compute_probs(unitary, [1, 1, 1])
+        assert isinstance(result_merlin, SectoredDistribution)
+
+        # Verify total probability is reasonable
+        total_merlin = sum(s.probs.sum().item() for s in result_merlin.sectors)
+        assert np.isclose(total_merlin, 1.0, atol=1e-5)

--- a/tests/pcvl_pytorch/test_noisy_g2_slos.py
+++ b/tests/pcvl_pytorch/test_noisy_g2_slos.py
@@ -14,6 +14,7 @@ import pytest
 import torch
 import numpy as np
 import perceval as pcvl
+from copy import deepcopy
 
 from merlin import ComputationSpace, CircuitBuilder
 from merlin.core import SectoredDistribution
@@ -94,8 +95,8 @@ class TestG2SectorStructure:
         # Check each sector exists and is accessible
         for i, sector in enumerate(result.sectors):
             assert hasattr(sector, "probs")
-            assert isinstance(sector.probs, torch.Tensor)
-            assert sector.probs.shape[0] > 0
+            assert isinstance(sector.tensor, torch.Tensor)
+            assert sector.tensor.shape[0] > 0
 
     def test_g2_zero_single_sector(self, unitary_2mode):
         """g2=0 returns single sector matching pure SLOS."""
@@ -124,7 +125,7 @@ class TestG2SectorStructure:
         # With g2=0, should have single sector
         assert len(result.sectors) >= 1
         # First sector probabilities should match pure SLOS
-        sector_0_probs = result.sectors[0].probs
+        sector_0_probs = result.sectors[0].tensor
         assert torch.allclose(probs_pure, sector_0_probs, atol=1e-5)
 
 
@@ -151,7 +152,7 @@ class TestG2ProbabilityNormalization:
         # Sum all probabilities across all sectors
         total_prob = 0.0
         for sector in result.sectors:
-            total_prob += sector.probs.sum().item()
+            total_prob += sector.tensor.sum().item()
 
         assert np.isclose(total_prob, 1.0, atol=1e-5)
 
@@ -175,7 +176,7 @@ class TestG2ProbabilityNormalization:
             result = noisy_slos.compute_probs(unitary_3mode, state)
             assert isinstance(result, SectoredDistribution)
 
-            total = sum(sector.probs.sum().item() for sector in result.sectors)
+            total = sum(sector.tensor.sum().item() for sector in result.sectors)
             assert np.isclose(total, 1.0, atol=1e-5)
 
 
@@ -274,7 +275,7 @@ class TestG2ExtraPhotonDistribution:
 
         # Second sector should be for 3 photons
         second_sector = result.sectors[1]
-        assert second_sector.probs.shape[0] > 0
+        assert second_sector.tensor.shape[0] > 0
 
 
 class TestG2Gradients:
@@ -300,7 +301,7 @@ class TestG2Gradients:
         assert isinstance(result, SectoredDistribution)
 
         # Get first sector probability sum
-        prob_sum = result.sectors[0].probs.sum()
+        prob_sum = result.sectors[0].tensor.sum()
         prob_sum.backward()
 
         # Unitary should have gradients
@@ -318,7 +319,7 @@ class TestG2PercevalComparison:
             source={
                 "g2": 0.1,
                 "g2_distinguishable": True,
-                "indistinguishability": 1.0,
+                "indistinguishability": 0.9,
             },
             circuit=None,
             post_measurement=None,
@@ -334,15 +335,20 @@ class TestG2PercevalComparison:
         assert isinstance(result_merlin, SectoredDistribution)
 
         # Get Perceval reference for comparison
-        experiment = pcvl.Experiment(simple_bs_circuit)
-        experiment.noise = pcvl.NoiseModel(
-            g2=0.1, g2_distinguishable=True, indistinguishability=1.0
+        noise = pcvl.NoiseModel(
+            g2=0.1, g2_distinguishable=True, indistinguishability=0.9
         )
-        perceval_result = experiment.probs_svd()
+        source = pcvl.Source.from_noise_model(noise)
+        backend = pcvl.BackendFactory.get_backend("SLOS")
+        sim = pcvl.Simulator(backend)
+        sim.set_circuit(deepcopy(simple_bs_circuit))
+        perceval_result = sim.probs_svd((source, pcvl.BasicState([1, 1])))["results"]
 
         # Basic sanity checks
         assert len(result_merlin.sectors) > 0
-        assert sum(s.probs.sum().item() for s in result_merlin.sectors) > 0
+        assert sum(s.tensor.sum().item() for s in result_merlin.sectors) > 0
+        # Perceval result should also be non-empty
+        assert len(perceval_result) > 0
 
     def test_against_perceval_indistinguishable(self, simple_bs_circuit):
         """g2_distinguishable=False output has multi-sector structure."""
@@ -394,5 +400,5 @@ class TestG2PercevalComparison:
         assert isinstance(result_merlin, SectoredDistribution)
 
         # Verify total probability is reasonable
-        total_merlin = sum(s.probs.sum().item() for s in result_merlin.sectors)
+        total_merlin = sum(s.tensor.sum().item() for s in result_merlin.sectors)
         assert np.isclose(total_merlin, 1.0, atol=1e-5)

--- a/tests/pcvl_pytorch/test_noisy_g2_slos.py
+++ b/tests/pcvl_pytorch/test_noisy_g2_slos.py
@@ -49,7 +49,13 @@ def unitary_2mode(simple_bs_circuit):
 @pytest.fixture
 def unitary_3mode(entangling_circuit):
     """Convert entangling circuit to unitary tensor."""
-    return CircuitConverter(entangling_circuit).to_tensor([])
+    converter = CircuitConverter(entangling_circuit)
+    # Create dummy parameters for variable components
+    if converter.nb_input_tensor > 0:
+        dummy_params = [torch.zeros(1) for _ in range(converter.nb_input_tensor)]
+        return converter.to_tensor(*dummy_params)
+    else:
+        return converter.to_tensor()
 
 
 class TestG2SectorStructure:
@@ -94,7 +100,7 @@ class TestG2SectorStructure:
 
         # Check each sector exists and is accessible
         for i, sector in enumerate(result.sectors):
-            assert hasattr(sector, "probs")
+            assert hasattr(sector, "tensor")
             assert isinstance(sector.tensor, torch.Tensor)
             assert sector.tensor.shape[0] > 0
 
@@ -378,7 +384,13 @@ class TestG2PercevalComparison:
 
     def test_joint_g2_and_indistinguishability(self, entangling_circuit):
         """Combined hom + g2 produces SectoredDistribution."""
-        unitary = CircuitConverter(entangling_circuit).to_tensor([])
+        converter = CircuitConverter(entangling_circuit)
+        # Create dummy parameters for variable components
+        if converter.nb_input_tensor > 0:
+            dummy_params = [torch.zeros(1) for _ in range(converter.nb_input_tensor)]
+            unitary = converter.to_tensor(*dummy_params)
+        else:
+            unitary = converter.to_tensor()
 
         groups = NoiseGroups(
             source={

--- a/tests/pcvl_pytorch/test_noisy_g2_slos.py
+++ b/tests/pcvl_pytorch/test_noisy_g2_slos.py
@@ -342,7 +342,11 @@ class TestG2DistinguishabilityModes:
         # g2=1.0 → weight_0=(1-1)^1=0, weight_1=1^1*(1-1)^0=1 (sector 1 carries everything)
         # indistinguishability=1.0 → NoisySLOSComputeGraph ≡ pure SLOS
         groups = NoiseGroups(
-            source={"g2": 1.0, "g2_distinguishable": False, "indistinguishability": 1.0},
+            source={
+                "g2": 1.0,
+                "g2_distinguishable": False,
+                "indistinguishability": 1.0,
+            },
             circuit=None,
             post_measurement=None,
         )

--- a/tests/pcvl_pytorch/test_noisy_g2_slos.py
+++ b/tests/pcvl_pytorch/test_noisy_g2_slos.py
@@ -17,7 +17,7 @@ import perceval as pcvl
 from copy import deepcopy
 
 from merlin import ComputationSpace, CircuitBuilder, Combinadics
-from merlin.core import SectoredDistribution
+from merlin.core import SectoredDistribution, SectorResult
 from merlin.pcvl_pytorch.noisy_slos import NoisyG2SLOSComputeGraph
 from merlin.pcvl_pytorch.slos_torchscript import SLOSComputeGraph
 from merlin.algorithms.layer_utils import NoiseGroups
@@ -90,6 +90,39 @@ class TestG2SectorStructure:
                 sector.tensor.squeeze().shape[0]
                 == Combinadics(scheme="fock", n=3 + i, m=4).compute_space_size()
             )
+
+    def test_sectored_distribution_metadata(self, unitary):
+        """Each SectorResult has consistent n_photons, n_modes, and basis keys.
+
+        For n_photons=3, sector i must carry metadata for 3+i photons:
+        n_photons == 3+i, n_modes == 4, computation_space == FOCK, and every
+        key in the (possibly empty) keys tuple must have length 4 and sum to
+        3+i.
+        """
+        groups = NoiseGroups(
+            source={"g2": 0.15, "g2_distinguishable": False},
+            circuit=None,
+            post_measurement=None,
+        )
+        noisy_slos = NoisyG2SLOSComputeGraph(
+            groups,
+            m=4,
+            n_photons=3,
+            computation_space=ComputationSpace.FOCK,
+        )
+        result = noisy_slos.compute_probs(unitary(), [1, 1, 1, 0])
+
+        assert isinstance(result, SectoredDistribution)
+        for i, sector in enumerate(result.sectors):
+            assert isinstance(sector, SectorResult)
+            assert sector.n_modes == 4
+            assert sector.n_photons == 3 + i
+            assert sector.computation_space == ComputationSpace.FOCK
+            expected_size = Combinadics("fock", n=3 + i, m=4).compute_space_size()
+            assert sector.tensor.squeeze().shape[0] == expected_size
+            for key in sector.keys:
+                assert len(key) == 4
+                assert sum(key) == 3 + i
 
     def test_g2_zero_single_sector(self, unitary):
         """g2=0 returns single sector matching pure SLOS."""
@@ -193,6 +226,7 @@ class TestG2ProbabilityNormalization:
         total_prob = 0.0
         for sector in result.sectors:
             total_prob += sector.tensor.sum().item()
+            print(sector.tensor)
 
         assert np.isclose(total_prob, 1.0, atol=1e-5)
 
@@ -281,25 +315,47 @@ class TestG2DistinguishabilityModes:
             sectors_differ
         ), "Distinguishable and indistinguishable modes should produce different results"
 
-    def test_indistinguishable_has_bunching(self, unitary):
-        """For g2_distinguishable=False: multiple sectors present."""
+    def test_indistinguishable_bunched_delegate(self, unitary):
+        """g2_distinguishable=False: augmented input has the expected mode occupation.
+
+        With a single extra photon added to a single-photon input [1,0,0,0]
+        (g2=1.0 puts all probability in sector 1) and indistinguishability=1.0
+        (NoisySLOS reduces to pure SLOS), the sector-1 distribution must equal
+        the pure SLOS output for the augmented input [2,0,0,0].
+
+        This confirms that the extra photon is bunched into mode 0—the same
+        mode occupied by the original photon—rather than being placed in a
+        different mode.
+        """
+        input_state = [1, 0, 0, 0]
+        n_photons = 1
+        m = 4
+
+        unitary_tensor = unitary()
+
+        # Reference: pure SLOS on the augmented state (extra photon in mode 0)
+        slos_augmented = SLOSComputeGraph(
+            m=m, n_photons=2, computation_space=ComputationSpace.FOCK
+        )
+        _, probs_augmented = slos_augmented.compute_probs(unitary_tensor, [2, 0, 0, 0])
+
+        # g2=1.0 → weight_0=(1-1)^1=0, weight_1=1^1*(1-1)^0=1 (sector 1 carries everything)
+        # indistinguishability=1.0 → NoisySLOSComputeGraph ≡ pure SLOS
         groups = NoiseGroups(
-            source={"g2": 0.5, "g2_distinguishable": False},
+            source={"g2": 1.0, "g2_distinguishable": False, "indistinguishability": 1.0},
             circuit=None,
             post_measurement=None,
         )
         noisy_slos = NoisyG2SLOSComputeGraph(
-            groups,
-            m=4,
-            n_photons=3,
-            computation_space=ComputationSpace.FOCK,
+            groups, m=m, n_photons=n_photons, computation_space=ComputationSpace.FOCK
         )
+        result = noisy_slos.compute_probs(unitary_tensor, input_state)
 
-        result = noisy_slos.compute_probs(unitary(), [1, 1, 1, 0])
         assert isinstance(result, SectoredDistribution)
-
-        # Should have multiple sectors due to bunching
-        assert len(result.sectors) >= 2
+        assert len(result.sectors) == 2
+        # Sector 1 = 1.0 * NoisySLOS(n=2).compute_probs([2,0,0,0]) ≈ SLOS([2,0,0,0])
+        sector_1_probs = result.sectors[1].tensor.squeeze()
+        assert torch.allclose(sector_1_probs, probs_augmented.squeeze(), atol=1e-5)
 
 
 class TestG2ExtraPhotonDistribution:
@@ -329,6 +385,62 @@ class TestG2ExtraPhotonDistribution:
         second_sector = result.sectors[1]
         assert second_sector.tensor.shape[0] > 0
 
+    def test_distinguishable_extra_photon_distribution(self, unitary):
+        """g2_distinguishable=True, single g2 event in mode m: extra-photon marginal = |U[:,m]|².
+
+        For n_photons=1, input=[e_m] (photon only in mode 0), g2=1.0 (all
+        weight in sector 1), g2_distinguishable=True, indistinguishability=1.0:
+
+        sector-1 = conv(P_regular, P_onehot_m) where both equal |U[:,m]|².
+
+        For two independent distinguishable photons the expected mode
+        occupation factorises:
+
+            E[n_j | sector 1] = P_regular[j] + P_onehot[j] = 2 |U[j,m]|²
+
+        Equivalently, ``sector_1_probs @ fock_states`` (where fock_states is
+        the matrix of 2-photon Fock vectors) gives a vector whose j-th entry
+        equals 2|U[j,m]|², confirming that marginalising sector 1 over the
+        regular-photon output recovers |U[:,m]|².
+        """
+        m_mode = 0  # single photon injected in mode 0
+        input_state = [1, 0, 0, 0]
+        n_photons = 1
+        m = 4
+
+        unitary_tensor = unitary()
+
+        # g2=1.0 → weight_0=0, weight_1=1 (sector 1 carries everything)
+        # indistinguishability=1.0 → regular probs = pure SLOS = |U[:,m]|²
+        groups = NoiseGroups(
+            source={"g2": 1.0, "g2_distinguishable": True, "indistinguishability": 1.0},
+            circuit=None,
+            post_measurement=None,
+        )
+        noisy_slos = NoisyG2SLOSComputeGraph(
+            groups, m=m, n_photons=n_photons, computation_space=ComputationSpace.FOCK
+        )
+        result = noisy_slos.compute_probs(unitary_tensor, input_state)
+
+        assert isinstance(result, SectoredDistribution)
+        assert len(result.sectors) == 2
+
+        sector_1_probs = result.sectors[1].tensor.squeeze()  # shape [N_2photon]
+
+        # 2-photon Fock basis in Combinadics order: shape [N_2photon, m]
+        fock_states = torch.tensor(
+            Combinadics("fock", n=2, m=m).enumerate_states(), dtype=torch.float32
+        )
+
+        # E[n_j] = sum_s P(s) * s[j]  for each output mode j
+        actual_occupation = sector_1_probs @ fock_states  # shape [m]
+
+        # Expected: 2 * |U[j, m_mode]|² (two independent photons from mode m_mode)
+        u = unitary_tensor.squeeze()  # [m, m] complex tensor
+        expected_occupation = 2.0 * (u.abs() ** 2)[:, m_mode].float()
+
+        assert torch.allclose(actual_occupation, expected_occupation, atol=1e-4)
+
 
 class TestG2Gradients:
     """Test gradient flow through g2 parameters."""
@@ -338,7 +450,7 @@ class TestG2Gradients:
         unitary_diff = unitary().clone().detach().requires_grad_(True)
 
         groups = NoiseGroups(
-            source={"g2": 0.2, "g2_distinguishable": True},
+            source={"indistinguishability": 0.8, "g2": 0.2, "g2_distinguishable": True},
             circuit=None,
             post_measurement=None,
         )
@@ -359,12 +471,131 @@ class TestG2Gradients:
         # Unitary should have gradients
         assert unitary_diff.grad is not None
 
+    def test_gradient_flows_through_g2(self, unitary):
+        """torch.autograd.gradcheck confirms analytical gradients w.r.t. g2.
+
+        The g2 parameter enters through the binomial weights
+        ``weight_k = g2^k * (1-g2)^(n-k)`` that mix the per-sector SLOS
+        outputs.  Passing a differentiable tensor via ``noisy_slos.g2``
+        keeps autograd alive through those scalar multiplications.
+
+        Uses n_photons=2, m=4 to limit SLOS graph size and keep the check
+        fast.
+        """
+        unitary_tensor = unitary().to(torch.complex128)
+
+        def fn(g2: torch.Tensor) -> torch.Tensor:
+            groups = NoiseGroups(
+                source={"g2": float(g2.item()), "g2_distinguishable": False},
+                circuit=None,
+                post_measurement=None,
+            )
+            noisy_slos = NoisyG2SLOSComputeGraph(
+                groups,
+                m=4,
+                n_photons=2,
+                computation_space=ComputationSpace.FOCK,
+                dtype=torch.float64,
+            )
+            # Override with the differentiable tensor so autograd tracks g2.
+            noisy_slos.g2 = g2.squeeze()
+            result = noisy_slos.compute_probs(unitary_tensor, [1, 1, 0, 0])
+            # Each sector sum equals C(n,k)*g2^k*(1-g2)^(n-k), so the
+            # vector has non-zero Jacobian entries w.r.t. g2.
+            return torch.stack([s.tensor.sum() for s in result.sectors])
+
+        g2_input = torch.tensor([0.2], dtype=torch.float64, requires_grad=True)
+        assert torch.autograd.gradcheck(fn, (g2_input,), eps=1e-4, atol=1e-3)
+
+    def test_gradient_flows_through_hom_and_g2(self, unitary):
+        """torch.autograd.gradcheck confirms gradients flow through both g2 and indistinguishability.
+
+        Indistinguishability is passed as a differentiable tensor directly in
+        the NoiseGroups source dict.  ``torch.as_tensor`` in
+        ``_InputStateNoisySLOSComputeGraph`` returns it unchanged (same
+        memory), so ``_weights`` are computed with autograd active and
+        individual sector probabilities carry a gradient back to
+        ``indistinguishability``.
+
+        The sector-sum gradients w.r.t. indistinguishability are identically
+        zero (normalization cancels them), so ``sectors[0].tensor`` is
+        returned instead; its individual entries carry the indistinguishability
+        gradient.
+
+        Uses n_photons=2, m=4 to limit SLOS graph size.
+        """
+        unitary_tensor = unitary().to(torch.complex128)
+
+        def fn(g2: torch.Tensor, indist: torch.Tensor) -> torch.Tensor:
+            groups = NoiseGroups(
+                source={
+                    "g2": float(g2.item()),
+                    "g2_distinguishable": False,
+                    # Pass the tensor so requires_grad survives into
+                    # _InputStateNoisySLOSComputeGraph._weights.
+                    "indistinguishability": indist.squeeze(),
+                },
+                circuit=None,
+                post_measurement=None,
+            )
+            noisy_slos = NoisyG2SLOSComputeGraph(
+                groups,
+                m=4,
+                n_photons=2,
+                computation_space=ComputationSpace.FOCK,
+                dtype=torch.float64,
+            )
+            noisy_slos.g2 = g2.squeeze()
+            result = noisy_slos.compute_probs(unitary_tensor, [1, 1, 0, 0])
+            # Return individual entries of sector 0; each entry depends on
+            # indistinguishability through the OBB mixture weights.
+            return result.sectors[0].tensor.squeeze()
+
+        g2_input = torch.tensor([0.2], dtype=torch.float64, requires_grad=True)
+        indist_input = torch.tensor([0.9], dtype=torch.float64, requires_grad=True)
+        assert torch.autograd.gradcheck(
+            fn, (g2_input, indist_input), eps=1e-4, atol=1e-3
+        )
+
 
 class TestG2PercevalComparison:
-    """Compare g2 calculations with Perceval Simulator."""
+    """Compare g2 calculations with Perceval Simulator.
+
+    Each test verifies that Merlin's NoisyG2SLOSComputeGraph probabilities are
+    within 1e-4 of Perceval's probs_svd for the same NoiseModel and circuit.
+
+    Mapping strategy: Perceval returns a dict of BasicState -> probability.
+    Each BasicState belongs to a photon-number sector (sum of occupations).
+    For n_photons=3, sector i holds states with 3+i photons (i=0..3).
+    Within a sector, the index is given by Combinadics("fock", n, m).fock_to_index().
+    """
+
+    @staticmethod
+    def _perceval_to_merlin_probs(
+        perceval_result: dict,
+        result_merlin: SectoredDistribution,
+        n_photons: int,
+        m: int,
+    ) -> None:
+        """Assert each Perceval output probability matches the corresponding Merlin sector value."""
+        for state, perceval_prob in perceval_result.items():
+            occupations = tuple(state)
+            n = sum(occupations)
+            sector_idx = n - n_photons
+            assert (
+                0 <= sector_idx < len(result_merlin.sectors)
+            ), f"State {occupations} with {n} photons has no corresponding Merlin sector"
+            combo = Combinadics("fock", n=n, m=m)
+            tensor_idx = combo.fock_to_index(occupations)
+            merlin_prob = (
+                result_merlin.sectors[sector_idx].tensor.squeeze()[tensor_idx].item()
+            )
+            assert (
+                abs(merlin_prob - perceval_prob) < 1e-4
+            ), f"State {occupations}: Merlin={merlin_prob:.6f}, Perceval={perceval_prob:.6f}"
 
     def test_against_perceval_distinguishable(self, circuit, unitary):
-        """g2_distinguishable=True output within tolerance of Perceval."""
+        """g2_distinguishable=True probabilities are within 1e-4 of Perceval."""
         unitary_tensor = unitary()
 
         groups = NoiseGroups(
@@ -382,11 +613,9 @@ class TestG2PercevalComparison:
             n_photons=3,
             computation_space=ComputationSpace.FOCK,
         )
-
         result_merlin = noisy_slos.compute_probs(unitary_tensor, [1, 1, 1, 0])
         assert isinstance(result_merlin, SectoredDistribution)
 
-        # Get Perceval reference for comparison
         noise = pcvl.NoiseModel(
             g2=0.1, g2_distinguishable=True, indistinguishability=0.9
         )
@@ -398,14 +627,10 @@ class TestG2PercevalComparison:
             "results"
         ]
 
-        # Basic sanity checks
-        assert len(result_merlin.sectors) > 0
-        assert sum(s.tensor.sum().item() for s in result_merlin.sectors) > 0
-        # Perceval result should also be non-empty
-        assert len(perceval_result) > 0
+        self._perceval_to_merlin_probs(perceval_result, result_merlin, n_photons=3, m=4)
 
     def test_against_perceval_indistinguishable(self, circuit, unitary):
-        """g2_distinguishable=False output has multi-sector structure."""
+        """g2_distinguishable=False probabilities are within 1e-4 of Perceval."""
         unitary_tensor = unitary()
 
         groups = NoiseGroups(
@@ -423,15 +648,24 @@ class TestG2PercevalComparison:
             n_photons=3,
             computation_space=ComputationSpace.FOCK,
         )
-
         result_merlin = noisy_slos.compute_probs(unitary_tensor, [1, 1, 1, 0])
         assert isinstance(result_merlin, SectoredDistribution)
 
-        # Multiple sectors expected for indistinguishable case
-        assert len(result_merlin.sectors) >= 2
+        noise = pcvl.NoiseModel(
+            g2=0.2, g2_distinguishable=False, indistinguishability=0.95
+        )
+        source = pcvl.Source.from_noise_model(noise)
+        backend = pcvl.BackendFactory.get_backend("SLOS")
+        sim = pcvl.Simulator(backend)
+        sim.set_circuit(deepcopy(circuit))
+        perceval_result = sim.probs_svd((source, pcvl.BasicState([1, 1, 1, 0])))[
+            "results"
+        ]
+
+        self._perceval_to_merlin_probs(perceval_result, result_merlin, n_photons=3, m=4)
 
     def test_joint_g2_and_indistinguishability(self, circuit, unitary):
-        """Combined hom + g2 produces SectoredDistribution."""
+        """Combined g2 + indistinguishability probabilities are within 1e-4 of Perceval."""
         groups = NoiseGroups(
             source={
                 "g2": 0.15,
@@ -447,12 +681,18 @@ class TestG2PercevalComparison:
             n_photons=3,
             computation_space=ComputationSpace.FOCK,
         )
-
         result_merlin = noisy_slos.compute_probs(unitary(), [1, 1, 1, 0])
         assert isinstance(result_merlin, SectoredDistribution)
 
-        # Verify total probability is reasonable
-        total_merlin = sum(s.tensor.sum().item() for s in result_merlin.sectors)
-        assert np.isclose(total_merlin, 1.0, atol=1e-5)
-        # Verify multiple sectors for combined noise
-        assert len(result_merlin.sectors) >= 2
+        noise = pcvl.NoiseModel(
+            g2=0.15, g2_distinguishable=False, indistinguishability=0.8
+        )
+        source = pcvl.Source.from_noise_model(noise)
+        backend = pcvl.BackendFactory.get_backend("SLOS")
+        sim = pcvl.Simulator(backend)
+        sim.set_circuit(deepcopy(circuit))
+        perceval_result = sim.probs_svd((source, pcvl.BasicState([1, 1, 1, 0])))[
+            "results"
+        ]
+
+        self._perceval_to_merlin_probs(perceval_result, result_merlin, n_photons=3, m=4)

--- a/tests/pcvl_pytorch/test_noisy_g2_slos.py
+++ b/tests/pcvl_pytorch/test_noisy_g2_slos.py
@@ -854,7 +854,9 @@ class TestG2AmplitudeEncodingMultipleActiveIndices:
         result = proc.compute([], amplitude_encoding=True)
         assert isinstance(result, SectoredDistribution)
 
-        noise = pcvl.NoiseModel(g2=0.1, g2_distinguishable=True, indistinguishability=0.9)
+        noise = pcvl.NoiseModel(
+            g2=0.1, g2_distinguishable=True, indistinguishability=0.9
+        )
         source = pcvl.Source.from_noise_model(noise)
         sim = pcvl.Simulator(pcvl.BackendFactory.get_backend("SLOS"))
         sim.set_circuit(deepcopy(circuit))
@@ -868,7 +870,11 @@ class TestG2AmplitudeEncodingMultipleActiveIndices:
         weights = [0.5, 0.5]
 
         noise_groups = NoiseGroups(
-            source={"g2": 0.2, "g2_distinguishable": False, "indistinguishability": 0.9},
+            source={
+                "g2": 0.2,
+                "g2_distinguishable": False,
+                "indistinguishability": 0.9,
+            },
             circuit=None,
             post_measurement=None,
         )
@@ -884,7 +890,9 @@ class TestG2AmplitudeEncodingMultipleActiveIndices:
         result = proc.compute([], amplitude_encoding=True)
         assert isinstance(result, SectoredDistribution)
 
-        noise = pcvl.NoiseModel(g2=0.2, g2_distinguishable=False, indistinguishability=0.9)
+        noise = pcvl.NoiseModel(
+            g2=0.2, g2_distinguishable=False, indistinguishability=0.9
+        )
         source = pcvl.Source.from_noise_model(noise)
         sim = pcvl.Simulator(pcvl.BackendFactory.get_backend("SLOS"))
         sim.set_circuit(deepcopy(circuit))
@@ -898,7 +906,11 @@ class TestG2AmplitudeEncodingMultipleActiveIndices:
         weights = [0.5, 0.3, 0.2]
 
         noise_groups = NoiseGroups(
-            source={"g2": 0.15, "g2_distinguishable": True, "indistinguishability": 0.85},
+            source={
+                "g2": 0.15,
+                "g2_distinguishable": True,
+                "indistinguishability": 0.85,
+            },
             circuit=None,
             post_measurement=None,
         )
@@ -914,9 +926,93 @@ class TestG2AmplitudeEncodingMultipleActiveIndices:
         result = proc.compute([], amplitude_encoding=True)
         assert isinstance(result, SectoredDistribution)
 
-        noise = pcvl.NoiseModel(g2=0.15, g2_distinguishable=True, indistinguishability=0.85)
+        noise = pcvl.NoiseModel(
+            g2=0.15, g2_distinguishable=True, indistinguishability=0.85
+        )
         source = pcvl.Source.from_noise_model(noise)
         sim = pcvl.Simulator(pcvl.BackendFactory.get_backend("SLOS"))
         sim.set_circuit(deepcopy(circuit))
         combined = self._weighted_perceval_combined(sim, source, active_states, weights)
         self._assert_combined_matches_merlin(combined, result, n_photons=n_photons, m=m)
+
+
+def _identity_unitary(n_modes: int) -> torch.Tensor:
+    """Return an identity unitary with Merlin's default complex dtype."""
+    return torch.eye(n_modes, dtype=torch.complex64)
+
+
+def _g2_groups(
+    *,
+    g2: float = 0.1,
+    g2_distinguishable: bool = False,
+) -> NoiseGroups:
+    """Return a minimal source-noise group for direct graph tests."""
+    return NoiseGroups(
+        source={
+            "g2": g2,
+            "g2_distinguishable": g2_distinguishable,
+            "indistinguishability": 1.0,
+        },
+        circuit=None,
+        post_measurement=None,
+    )
+
+
+def test_g2_sector_results_include_fock_basis_keys() -> None:
+    """Check that each g2 output sector carries its Fock basis metadata.
+
+    Correct result: every ``SectorResult.keys`` tuple should contain exactly the
+    Fock basis states matching ``sector.tensor`` for that sector's photon count
+    and mode count.
+
+    Branch result: ``SectorResult.keys`` is empty, so downstream code cannot
+    safely apply per-sector transforms or interpret probabilities by basis key.
+    """
+    graph = NoisyG2SLOSComputeGraph(
+        _g2_groups(),
+        m=3,
+        n_photons=2,
+        computation_space=ComputationSpace.FOCK,
+    )
+
+    result = graph.compute_probs(_identity_unitary(3), [1, 1, 0])
+
+    assert isinstance(result, SectoredDistribution)
+    for sector in result.sectors:
+        expected_keys = tuple(
+            tuple(state)
+            for state in Combinadics(
+                "fock", n=sector.n_photons, m=sector.n_modes
+            ).enumerate_states()
+        )
+        assert sector.keys == expected_keys
+
+
+def test_sectored_total_probability_stays_in_autograd() -> None:
+    """Check that total probability remains differentiable.
+
+    Correct result: ``SectoredDistribution.total_probability()`` should return a
+    tensor connected to each sector tensor so callers can use it in losses and
+    call ``backward()``.
+
+    Branch result: the helper uses ``.item()``, returns a Python float, and
+    detaches the total from autograd.
+    """
+    sector_1 = SectorResult(
+        torch.tensor([0.2, 0.3], requires_grad=True),
+        n_modes=2,
+        n_photons=1,
+    )
+    sector_2 = SectorResult(
+        torch.tensor([0.5], requires_grad=True),
+        n_modes=2,
+        n_photons=2,
+    )
+    distribution = SectoredDistribution((sector_1, sector_2))
+
+    total = distribution.total_probability()
+
+    assert isinstance(total, torch.Tensor)
+    total.backward()
+    assert sector_1.tensor.grad is not None
+    assert sector_2.tensor.grad is not None


### PR DESCRIPTION
## Summary
Added the g2 noise simulations in the MerLin's quantum layer's pipeline. The simulations can now be .

## Related Issue
PML-286

## Type of change
- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor / Cleanup
- [ ] Performance improvement
- [ ] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)


## Proposed changes
- There is now a NoisyG2SLOSComputeGraph class that is used whenthere is g2 noise.
- This class simulates the probs of the circuit with the g2 noise.
- The same modifications in the pipeline as the NoisySLOSComputeGraph for indistinguishability wew done plus:
     - Added a guard preventing grouping strategies with g2 noises as the output is not a tensor and is sector dependant.
     - Changed the sampling function handling in the quantum layer. We do not pass a sampling function anymore but a class that has a normal sampler and a g2 sampler that samples across all photon sectors.  
- Added new types to handle those photon sectors.

## How to test / How to run

1. Command lines

```
pytest -q
```

## Performance considerations (optional)
- G2 SLOS simulations are heavier as expected

## Documentation
- [x] User docs updated (Sphinx)
- [ ] Examples / notebooks updated
- [x] Docstrings updated
- [x] Updated the API