### PR TITLE
PML-316 bug feed forward block

### DIFF
--- a/merlin/algorithms/feed_forward.py
+++ b/merlin/algorithms/feed_forward.py
@@ -1395,16 +1395,14 @@ class FeedForwardBlock(MerlinModule):
                     != MeasurementKind["PROBABILITIES"]
                 ):
                     continue
-                entries.append(
-                    (
-                        key,
-                        probability_total,
-                        amplitude_total,
-                        weight_total,
-                        basis_keys,
-                        remaining_n,
-                    )
-                )
+                entries.append((
+                    key,
+                    probability_total,
+                    amplitude_total,
+                    weight_total,
+                    basis_keys,
+                    remaining_n,
+                ))
 
         if not entries:
             self._output_keys = []
@@ -1672,19 +1670,19 @@ class FeedForwardBlock(MerlinModule):
                     if src_idx is not None:
                         reordered[..., tgt_idx] = src[..., src_idx]
                 normalized_amplitudes = reordered
-            mixed_states.append(
-                (
-                    key,
-                    branch_probability,
-                    remaining_n,
-                    normalized_amplitudes,
-                )
-            )
+            mixed_states.append((
+                key,
+                branch_probability,
+                remaining_n,
+                normalized_amplitudes,
+            ))
         self._output_keys = [entry[0] for entry in mixed_states]
         self._output_state_sizes = None
         return mixed_states
 
-    def _aggregate_branch_list(self, branch_list: list[BranchState]) -> tuple[
+    def _aggregate_branch_list(
+        self, branch_list: list[BranchState]
+    ) -> tuple[
         torch.Tensor | None,
         torch.Tensor | None,
         torch.Tensor | None,

--- a/merlin/algorithms/feed_forward.py
+++ b/merlin/algorithms/feed_forward.py
@@ -1368,16 +1368,14 @@ class FeedForwardBlock(MerlinModule):
                     != MeasurementKind["PROBABILITIES"]
                 ):
                     continue
-                entries.append(
-                    (
-                        key,
-                        probability_total,
-                        amplitude_total,
-                        weight_total,
-                        basis_keys,
-                        remaining_n,
-                    )
-                )
+                entries.append((
+                    key,
+                    probability_total,
+                    amplitude_total,
+                    weight_total,
+                    basis_keys,
+                    remaining_n,
+                ))
 
         if not entries:
             self._output_keys = []
@@ -1645,19 +1643,19 @@ class FeedForwardBlock(MerlinModule):
                     if src_idx is not None:
                         reordered[..., tgt_idx] = src[..., src_idx]
                 normalized_amplitudes = reordered
-            mixed_states.append(
-                (
-                    key,
-                    branch_probability,
-                    remaining_n,
-                    normalized_amplitudes,
-                )
-            )
+            mixed_states.append((
+                key,
+                branch_probability,
+                remaining_n,
+                normalized_amplitudes,
+            ))
         self._output_keys = [entry[0] for entry in mixed_states]
         self._output_state_sizes = None
         return mixed_states
 
-    def _aggregate_branch_list(self, branch_list: list[BranchState]) -> tuple[
+    def _aggregate_branch_list(
+        self, branch_list: list[BranchState]
+    ) -> tuple[
         torch.Tensor | None,
         torch.Tensor | None,
         torch.Tensor | None,

--- a/merlin/algorithms/feed_forward.py
+++ b/merlin/algorithms/feed_forward.py
@@ -280,7 +280,6 @@ class FeedForwardBlock(MerlinModule):
                 stage,
                 base_input_state=self._base_input_state,
                 initial_amplitudes=self._initial_amplitudes,
-                trainable_parameters=trainable_parameters,
                 input_parameters=input_parameters,
                 is_first=(idx == 0),
             )
@@ -554,7 +553,40 @@ class FeedForwardBlock(MerlinModule):
         trainable_parameters: list[str] | None = None,
         input_parameters: list[str] | None = None,
     ) -> None:
+        """Map parameter prefixes to their matching Perceval circuit parameters.
 
+        Validates that all circuit parameters are covered by exactly one prefix
+        (either trainable or input), and constructs bidirectional mapping tables
+        for parameter lookup during stage runtime construction. Parameters from
+        provider circuits are also scanned and included.
+
+        Parameters
+        ----------
+        experiment : pcvl.Experiment
+            Perceval experiment containing all circuit parameters to be mapped.
+        trainable_parameters : list[str] | None
+            Parameter name prefixes that should remain learnable. Each prefix
+            matches all parameters starting with that string.
+        input_parameters : list[str] | None
+            Parameter name prefixes that receive classical inputs. Each prefix
+            matches all parameters starting with that string.
+
+        Raises
+        ------
+        ValueError
+            If a prefix has no matching parameters, if a parameter matches
+            multiple prefixes, or if any parameter is not covered by a prefix.
+
+        Notes
+        -----
+        Sets three instance attributes:
+        - ``prefix_to_params_mapping`` : dict mapping prefixes to their matching
+          parameter names
+        - ``trainable_params_to_prefix_mapping`` : dict mapping trainable parameter
+          names to their prefix
+        - ``input_params_to_prefix_mapping`` : dict mapping input parameter names
+          to their prefix
+        """
         self.prefix_to_params_mapping = {}
         self.trainable_params_to_prefix_mapping = {}
         self.input_params_to_prefix_mapping = {}
@@ -623,7 +655,6 @@ class FeedForwardBlock(MerlinModule):
         *,
         base_input_state: list[int] | pcvl.BasicState | None,
         initial_amplitudes: torch.Tensor | None,
-        trainable_parameters: list[str] | None,
         input_parameters: list[str] | None,
         is_first: bool,
     ) -> StageRuntime:
@@ -696,6 +727,15 @@ class FeedForwardBlock(MerlinModule):
             conditional_circuits,
             default_key,
         ) = self._build_conditional_layers(stage.provider)
+
+        # Also include parameters from conditional circuits in the stage's trainable parameters
+        for circuit in conditional_circuits.values():
+            for param in circuit.params:
+                if param in self.trainable_params_to_prefix_mapping:
+                    trainable_params_set.add(
+                        self.trainable_params_to_prefix_mapping[param]
+                    )
+
         classical_input_size = (
             pre_layer.input_size
             if (pre_layer is not None and not amplitude_encoding)
@@ -1132,6 +1172,9 @@ class FeedForwardBlock(MerlinModule):
             raise ValueError("Remaining photon count cannot be negative.")
         layer = runtime.pre_layers.get(remaining_n)
         if layer is None:
+            trainable_params_set = set()
+            for param in runtime.circuit.params:
+                trainable_params_set.add(self.trainable_params_to_prefix_mapping[param])
             layer = QuantumLayer(
                 input_size=None,
                 circuit=runtime.circuit.copy(),
@@ -1142,7 +1185,7 @@ class FeedForwardBlock(MerlinModule):
                 ),
                 device=self.device,
                 dtype=self.dtype,
-                trainable_parameters=runtime.trainable_parameters,
+                trainable_parameters=list(trainable_params_set),
             )
             runtime.pre_layers[remaining_n] = layer
             self._register_layer(
@@ -1232,6 +1275,9 @@ class FeedForwardBlock(MerlinModule):
         layer = runtime.conditional_layer_cache.get(cache_key)
         if layer is None:
             circuit = circuits[actual_key]
+            trainable_params_set = set()
+            for param in circuit.params:
+                trainable_params_set.add(self.trainable_params_to_prefix_mapping[param])
             layer = QuantumLayer(
                 input_size=None,
                 circuit=circuit.copy(),
@@ -1242,7 +1288,7 @@ class FeedForwardBlock(MerlinModule):
                 ),
                 device=self.device,
                 dtype=self.dtype,
-                trainable_parameters=runtime.trainable_parameters,
+                trainable_parameters=list(trainable_params_set),
             )
             runtime.conditional_layer_cache[cache_key] = layer
             self._register_layer(

--- a/merlin/algorithms/feed_forward.py
+++ b/merlin/algorithms/feed_forward.py
@@ -267,6 +267,16 @@ class FeedForwardBlock(MerlinModule):
         ] = {}
         self._layer_registry_counter = 0
         self._basis_cache: dict[tuple[int, int], tuple[tuple[int, ...], ...]] = {}
+
+        # Global parameter validation
+        # TODO, Change because the trainable_parameters and input_parameters are prefixes, not all params names
+        self._experiment_params = experiment.get_circuit_parameters()
+        if self._experiment_params is not None:
+            if trainable_parameters is not None:
+                assert set(trainable_parameters).issubset(self._experiment_params)
+            if input_parameters is not None:
+                assert set(input_parameters).issubset(self._experiment_params)
+
         for idx, stage in enumerate(self.stages):
             runtime = self._build_stage_runtime(
                 stage,
@@ -1228,14 +1238,16 @@ class FeedForwardBlock(MerlinModule):
                     != MeasurementKind["PROBABILITIES"]
                 ):
                     continue
-                entries.append((
-                    key,
-                    probability_total,
-                    amplitude_total,
-                    weight_total,
-                    basis_keys,
-                    remaining_n,
-                ))
+                entries.append(
+                    (
+                        key,
+                        probability_total,
+                        amplitude_total,
+                        weight_total,
+                        basis_keys,
+                        remaining_n,
+                    )
+                )
 
         if not entries:
             self._output_keys = []
@@ -1503,19 +1515,19 @@ class FeedForwardBlock(MerlinModule):
                     if src_idx is not None:
                         reordered[..., tgt_idx] = src[..., src_idx]
                 normalized_amplitudes = reordered
-            mixed_states.append((
-                key,
-                branch_probability,
-                remaining_n,
-                normalized_amplitudes,
-            ))
+            mixed_states.append(
+                (
+                    key,
+                    branch_probability,
+                    remaining_n,
+                    normalized_amplitudes,
+                )
+            )
         self._output_keys = [entry[0] for entry in mixed_states]
         self._output_state_sizes = None
         return mixed_states
 
-    def _aggregate_branch_list(
-        self, branch_list: list[BranchState]
-    ) -> tuple[
+    def _aggregate_branch_list(self, branch_list: list[BranchState]) -> tuple[
         torch.Tensor | None,
         torch.Tensor | None,
         torch.Tensor | None,

--- a/merlin/algorithms/feed_forward.py
+++ b/merlin/algorithms/feed_forward.py
@@ -268,14 +268,12 @@ class FeedForwardBlock(MerlinModule):
         self._layer_registry_counter = 0
         self._basis_cache: dict[tuple[int, int], tuple[tuple[int, ...], ...]] = {}
 
-        # Global parameter validation
-        # TODO, Change because the trainable_parameters and input_parameters are prefixes, not all params names
-        self._experiment_params = experiment.get_circuit_parameters()
-        if self._experiment_params is not None:
-            if trainable_parameters is not None:
-                assert set(trainable_parameters).issubset(self._experiment_params)
-            if input_parameters is not None:
-                assert set(input_parameters).issubset(self._experiment_params)
+        # Global parameter validation and parameter mapping
+        self._map_prefix_to_params(
+            experiment=experiment,
+            trainable_parameters=trainable_parameters,
+            input_parameters=input_parameters,
+        )
 
         for idx, stage in enumerate(self.stages):
             runtime = self._build_stage_runtime(
@@ -550,6 +548,75 @@ class FeedForwardBlock(MerlinModule):
             partial_measurement=True,
         )
 
+    def _map_prefix_to_params(
+        self,
+        experiment: pcvl.Experiment,
+        trainable_parameters: list[str] | None = None,
+        input_parameters: list[str] | None = None,
+    ) -> None:
+
+        self.prefix_to_params_mapping = {}
+        self.trainable_params_to_prefix_mapping = {}
+        self.input_params_to_prefix_mapping = {}
+
+        assigned_params = {}
+        total_matching_params = set()
+        all_params = experiment.get_circuit_parameters().keys()
+
+        # Trainable parameters
+        if trainable_parameters is not None:
+            for prefix in trainable_parameters:
+                matching_params = [p for p in all_params if p.startswith(prefix)]
+
+                if not matching_params:
+                    raise ValueError(
+                        f"No parameters in the experiment matching prefix '{prefix}'"
+                    )
+
+                for p in matching_params:
+                    if p in assigned_params:
+                        raise ValueError(
+                            f"Parameter '{p}' matches multiple prefixes: "
+                            f"'{assigned_params[p]}' and '{prefix}'"
+                        )
+
+                    assigned_params[p] = prefix
+                    self.trainable_params_to_prefix_mapping[p] = prefix
+                    total_matching_params.add(p)
+
+                self.prefix_to_params_mapping[prefix] = matching_params
+
+        # Input parameters
+        if input_parameters is not None:
+            for prefix in input_parameters:
+                matching_params = [p for p in all_params if p.startswith(prefix)]
+
+                if not matching_params:
+                    raise ValueError(
+                        f"No parameters in the experiment matching prefix '{prefix}'"
+                    )
+
+                for p in matching_params:
+                    if p in assigned_params:
+                        raise ValueError(
+                            f"Parameter '{p}' matches multiple prefixes: "
+                            f"'{assigned_params[p]}' and '{prefix}'"
+                        )
+
+                    assigned_params[p] = prefix
+                    self.input_params_to_prefix_mapping[p] = prefix
+                    total_matching_params.add(p)
+
+                self.prefix_to_params_mapping[prefix] = matching_params
+
+        # Non matched parameters
+        non_matched_params = set(all_params) - total_matching_params
+        if non_matched_params:
+            raise ValueError(
+                f"Parameters '{non_matched_params}' not covered by any "
+                "trainable or input spec"
+            )
+
     def _build_stage_runtime(
         self,
         stage: FFStage,
@@ -580,13 +647,24 @@ class FeedForwardBlock(MerlinModule):
                 raise ValueError(
                     "Amplitude-encoded input states cannot be combined with classical input parameters."
                 )
+
+            input_params_set = set()
+            trainable_params_set = set()
+            for param in stage.unitary.params:
+                if param in self.input_params_to_prefix_mapping:
+                    input_params_set.add(self.input_params_to_prefix_mapping[param])
+                else:
+                    trainable_params_set.add(
+                        self.trainable_params_to_prefix_mapping[param]
+                    )
+
             pre_layer = QuantumLayer(
                 input_size=None if (amplitude_encoding or input_parameters) else 0,
                 circuit=stage.unitary,
                 input_state=base_input_state,
                 n_photons=self.n_photons,
-                trainable_parameters=trainable_parameters,
-                input_parameters=input_parameters,
+                trainable_parameters=list(trainable_params_set),
+                input_parameters=list(input_params_set),
                 measurement_strategy=MeasurementStrategy.amplitudes(
                     self.computation_space
                 ),
@@ -605,8 +683,13 @@ class FeedForwardBlock(MerlinModule):
             pre_layer = None
             detector_transform = None
             initial_amplitudes = None
+
+            trainable_params_set = set()
+            for param in stage.unitary.params:
+                trainable_params_set.add(self.trainable_params_to_prefix_mapping[param])
+
             pre_layers = self._initialize_amplitude_pre_layers(
-                stage, trainable_parameters
+                stage, list(trainable_params_set)
             )
 
         (
@@ -630,7 +713,7 @@ class FeedForwardBlock(MerlinModule):
             detectors=stage.detectors,
             provider=stage.provider,
             pre_layers=pre_layers,
-            trainable_parameters=trainable_parameters,
+            trainable_parameters=list(trainable_params_set),
             initial_amplitudes=initial_amplitudes if is_first else None,
             classical_input_size=classical_input_size,
         )

--- a/merlin/algorithms/feed_forward.py
+++ b/merlin/algorithms/feed_forward.py
@@ -701,6 +701,7 @@ class FeedForwardBlock(MerlinModule):
             if (pre_layer is not None and not amplitude_encoding)
             else 0
         )
+
         return StageRuntime(
             circuit=stage.unitary,
             pre_layer=pre_layer,

--- a/merlin/algorithms/feed_forward.py
+++ b/merlin/algorithms/feed_forward.py
@@ -591,7 +591,7 @@ class FeedForwardBlock(MerlinModule):
         self.trainable_params_to_prefix_mapping = {}
         self.input_params_to_prefix_mapping = {}
 
-        assigned_params = {}
+        assigned_params: dict[str, str] = {}
         total_matching_params = set()
         all_params = experiment.get_circuit_parameters().keys()
 

--- a/merlin/algorithms/feed_forward.py
+++ b/merlin/algorithms/feed_forward.py
@@ -580,16 +580,16 @@ class FeedForwardBlock(MerlinModule):
         Notes
         -----
         Sets three instance attributes:
-        - ``prefix_to_params_mapping`` : dict mapping prefixes to their matching
+        - ``_prefix_to_params_mapping`` : dict mapping prefixes to their matching
           parameter names
-        - ``trainable_params_to_prefix_mapping`` : dict mapping trainable parameter
+        - ``_trainable_params_to_prefix_mapping`` : dict mapping trainable parameter
           names to their prefix
-        - ``input_params_to_prefix_mapping`` : dict mapping input parameter names
+        - ``_input_params_to_prefix_mapping`` : dict mapping input parameter names
           to their prefix
         """
-        self.prefix_to_params_mapping = {}
-        self.trainable_params_to_prefix_mapping = {}
-        self.input_params_to_prefix_mapping = {}
+        self._prefix_to_params_mapping = {}
+        self._trainable_params_to_prefix_mapping = {}
+        self._input_params_to_prefix_mapping = {}
 
         assigned_params: dict[str, str] = {}
         total_matching_params = set()
@@ -613,10 +613,10 @@ class FeedForwardBlock(MerlinModule):
                         )
 
                     assigned_params[p] = prefix
-                    self.trainable_params_to_prefix_mapping[p] = prefix
+                    self._trainable_params_to_prefix_mapping[p] = prefix
                     total_matching_params.add(p)
 
-                self.prefix_to_params_mapping[prefix] = matching_params
+                self._prefix_to_params_mapping[prefix] = matching_params
 
         # Input parameters
         if input_parameters is not None:
@@ -636,10 +636,10 @@ class FeedForwardBlock(MerlinModule):
                         )
 
                     assigned_params[p] = prefix
-                    self.input_params_to_prefix_mapping[p] = prefix
+                    self._input_params_to_prefix_mapping[p] = prefix
                     total_matching_params.add(p)
 
-                self.prefix_to_params_mapping[prefix] = matching_params
+                self._prefix_to_params_mapping[prefix] = matching_params
 
         # Non matched parameters
         non_matched_params = set(all_params) - total_matching_params
@@ -682,12 +682,20 @@ class FeedForwardBlock(MerlinModule):
             input_params_set = set()
             trainable_params_set = set()
             for param in stage.unitary.params:
-                if param in self.input_params_to_prefix_mapping:
-                    input_params_set.add(self.input_params_to_prefix_mapping[param])
+                if param in self._input_params_to_prefix_mapping:
+                    input_params_set.add(self._input_params_to_prefix_mapping[param])
                 else:
                     trainable_params_set.add(
-                        self.trainable_params_to_prefix_mapping[param]
+                        self._trainable_params_to_prefix_mapping[param]
                     )
+
+            if not input_params_set == set(
+                self._input_params_to_prefix_mapping.values()
+            ):
+                raise ValueError(
+                    "The first stage must use all of the input parameters. Create you own stages with variable "
+                    "input parameters with the partial measurement strategy instead"
+                )
 
             pre_layer = QuantumLayer(
                 input_size=None if (amplitude_encoding or input_parameters) else 0,
@@ -717,7 +725,10 @@ class FeedForwardBlock(MerlinModule):
 
             trainable_params_set = set()
             for param in stage.unitary.params:
-                trainable_params_set.add(self.trainable_params_to_prefix_mapping[param])
+                if param in self._trainable_params_to_prefix_mapping:
+                    trainable_params_set.add(
+                        self._trainable_params_to_prefix_mapping[param]
+                    )
 
             pre_layers = self._initialize_amplitude_pre_layers(
                 stage, list(trainable_params_set)
@@ -731,9 +742,9 @@ class FeedForwardBlock(MerlinModule):
         # Also include parameters from conditional circuits in the stage's trainable parameters
         for circuit in conditional_circuits.values():
             for param in circuit.params:
-                if param in self.trainable_params_to_prefix_mapping:
+                if param in self._trainable_params_to_prefix_mapping:
                     trainable_params_set.add(
-                        self.trainable_params_to_prefix_mapping[param]
+                        self._trainable_params_to_prefix_mapping[param]
                     )
 
         classical_input_size = (
@@ -1174,7 +1185,15 @@ class FeedForwardBlock(MerlinModule):
         if layer is None:
             trainable_params_set = set()
             for param in runtime.circuit.params:
-                trainable_params_set.add(self.trainable_params_to_prefix_mapping[param])
+                if param in self._trainable_params_to_prefix_mapping:
+                    trainable_params_set.add(
+                        self._trainable_params_to_prefix_mapping[param]
+                    )
+                else:
+                    raise ValueError(
+                        "Stages that are not the initial one can not have input parameters. Create your"
+                        "own QuantumLayers for each stages with the partial measurement measurement strategy."
+                    )
             layer = QuantumLayer(
                 input_size=None,
                 circuit=runtime.circuit.copy(),
@@ -1277,7 +1296,15 @@ class FeedForwardBlock(MerlinModule):
             circuit = circuits[actual_key]
             trainable_params_set = set()
             for param in circuit.params:
-                trainable_params_set.add(self.trainable_params_to_prefix_mapping[param])
+                if param in self._trainable_params_to_prefix_mapping:
+                    trainable_params_set.add(
+                        self._trainable_params_to_prefix_mapping[param]
+                    )
+                else:
+                    raise ValueError(
+                        "Stages that are not the initial one can not have input parameters. Create your"
+                        "own QuantumLayers for each stages with the partial measurement measurement strategy."
+                    )
             layer = QuantumLayer(
                 input_size=None,
                 circuit=circuit.copy(),
@@ -1368,14 +1395,16 @@ class FeedForwardBlock(MerlinModule):
                     != MeasurementKind["PROBABILITIES"]
                 ):
                     continue
-                entries.append((
-                    key,
-                    probability_total,
-                    amplitude_total,
-                    weight_total,
-                    basis_keys,
-                    remaining_n,
-                ))
+                entries.append(
+                    (
+                        key,
+                        probability_total,
+                        amplitude_total,
+                        weight_total,
+                        basis_keys,
+                        remaining_n,
+                    )
+                )
 
         if not entries:
             self._output_keys = []
@@ -1643,19 +1672,19 @@ class FeedForwardBlock(MerlinModule):
                     if src_idx is not None:
                         reordered[..., tgt_idx] = src[..., src_idx]
                 normalized_amplitudes = reordered
-            mixed_states.append((
-                key,
-                branch_probability,
-                remaining_n,
-                normalized_amplitudes,
-            ))
+            mixed_states.append(
+                (
+                    key,
+                    branch_probability,
+                    remaining_n,
+                    normalized_amplitudes,
+                )
+            )
         self._output_keys = [entry[0] for entry in mixed_states]
         self._output_state_sizes = None
         return mixed_states
 
-    def _aggregate_branch_list(
-        self, branch_list: list[BranchState]
-    ) -> tuple[
+    def _aggregate_branch_list(self, branch_list: list[BranchState]) -> tuple[
         torch.Tensor | None,
         torch.Tensor | None,
         torch.Tensor | None,

--- a/tests/algorithms/test_feed_forward_block.py
+++ b/tests/algorithms/test_feed_forward_block.py
@@ -433,7 +433,7 @@ def test_feedforwardblock_params_only_in_branches():
     """Verify that trainable parameters are correctly assigned to stages and their layers."""
     m = 6
     k = 4
-    n = 4
+    n = 2
 
     possible_measurements = list(FSArray(k, n - 1))
 

--- a/tests/algorithms/test_feed_forward_block.py
+++ b/tests/algorithms/test_feed_forward_block.py
@@ -472,6 +472,8 @@ def test_feedforwardblock_params_only_in_branches():
 
     experiment.add(0, feedforward_config)
 
+    print(experiment.get_circuit_parameters().keys())
+
     FeedForwardBlock(
         experiment,
         input_state=BasicState([1] * n + [0] * (m - n)),

--- a/tests/algorithms/test_feed_forward_block.py
+++ b/tests/algorithms/test_feed_forward_block.py
@@ -430,6 +430,7 @@ def test_feedforward_block_matches_perceval_distribution():
 
 
 def test_feedforwardblock_params_only_in_branches():
+    """Verify that trainable parameters are correctly assigned to stages and their layers."""
     m = 6
     k = 4
     n = 4
@@ -448,7 +449,7 @@ def test_feedforwardblock_params_only_in_branches():
     def g(measurement):
         return possible_measurements.index(measurement) + 1
 
-    def adaptive_mzi(measurement):
+    def adaptive_mzi_stage1(measurement):
         g_val = g(measurement)
         return (
             Circuit(2)
@@ -460,9 +461,12 @@ def test_feedforwardblock_params_only_in_branches():
 
     gi = pcvl.GenericInterferometer(m, gi_func)
 
-    feedforward_config = pcvl.FFCircuitProvider(k, 0, Circuit(2))
+    # Stage 1: after first k detectors
+    feedforward_config_1 = pcvl.FFCircuitProvider(k, 0, Circuit(2))
     for measurement in possible_measurements:
-        feedforward_config.add_configuration(measurement, adaptive_mzi(measurement))
+        feedforward_config_1.add_configuration(
+            measurement, adaptive_mzi_stage1(measurement)
+        )
 
     experiment = pcvl.Experiment(m)
     experiment.add(0, gi)
@@ -470,11 +474,9 @@ def test_feedforwardblock_params_only_in_branches():
     for i in range(k):
         experiment.add(i, pcvl.Detector.pnr())
 
-    experiment.add(0, feedforward_config)
+    experiment.add(0, feedforward_config_1)
 
-    print(experiment.get_circuit_parameters().keys())
-
-    FeedForwardBlock(
+    ff_block = FeedForwardBlock(
         experiment,
         input_state=BasicState([1] * n + [0] * (m - n)),
         trainable_parameters=["A", "B"],

--- a/tests/algorithms/test_feed_forward_block.py
+++ b/tests/algorithms/test_feed_forward_block.py
@@ -482,3 +482,131 @@ def test_feedforwardblock_params_only_in_branches():
         trainable_parameters=["A", "B"],
         input_parameters=["x"],
     )
+
+    # Verify single stage was created
+    assert len(ff_block._stage_runtimes) == 1
+    stage_0 = ff_block._stage_runtimes[0]
+
+    # Verify trainable parameters include both unitary ("A") and provider ("B") parameters
+    assert stage_0.trainable_parameters is not None
+    trainable_set = set(stage_0.trainable_parameters)
+    assert "A" in trainable_set, "Stage should have 'A' parameters from unitary"
+    assert (
+        "B" in trainable_set
+    ), "Stage should have 'B' parameters from conditional branches"
+
+    # Verify pre_layer exists and has correct parameters
+    assert stage_0.pre_layer is not None
+    pre_layer_trainable = set(stage_0.pre_layer.trainable_parameters or [])
+    assert "A" in pre_layer_trainable, "Pre-layer should have 'A' from unitary"
+    # Note: "x" is in the provider circuits, not the unitary, so it won't appear in pre_layer.input_parameters
+    # The pre_layer was created with input_parameters=["x"] but "x" only appears in conditional branches
+    assert (
+        "B" not in pre_layer_trainable
+    ), "Pre-layer should not have 'B' (only in conditional branches)"
+
+    # Verify conditional circuits exist and contain "B" parameters
+    assert stage_0.conditional_circuits is not None
+    assert (
+        len(stage_0.conditional_circuits) > 0
+    ), "Stage should have conditional circuits"
+    for circuit in stage_0.conditional_circuits.values():
+        circuit_params = circuit.params
+        # At least some conditional circuits should have B parameters
+        if any(p.startswith("B") for p in circuit_params):
+            break
+    else:
+        pytest.fail("No conditional circuit found with 'B' parameters")
+
+    # Verify input parameters are handled by the FeedForwardBlock
+    # Note: "x" was specified as an input_parameter and exists in provider circuits.
+    # However, pre_layer is built from the unitary circuit where "x" doesn't exist,
+    # so "x" won't appear in pre_layer.input_parameters. The FeedForwardBlock will
+    # route classical inputs through the feed-forward provider circuits.
+
+    # Verify the FeedForwardBlock's input parameter mapping
+    assert ff_block.input_params_to_prefix_mapping is not None
+    assert (
+        "x" in ff_block.input_params_to_prefix_mapping
+    ), "Input parameter 'x' should be recognized by FeedForwardBlock"
+
+
+def test_feedforwardblock_params_multi_stage():
+    """Verify parameter assignment works correctly across multiple stages."""
+    # Build a 2-stage experiment with distinct parameters per stage
+    # Following the structure of _build_two_stage_experiment()
+    exp = pcvl.Experiment()
+
+    # Stage 0: 4-mode root circuit, measure mode 0, provider with A parameters
+    root = pcvl.Circuit(4)
+    root.add(0, pcvl.BS())
+    exp.add(0, root)
+
+    exp.add(0, pcvl.Detector.pnr())
+    v0_stage0 = Circuit(3) // pcvl.PS(pcvl.P("A0")) // pcvl.BS()
+    v1_stage0 = Circuit(3) // pcvl.PS(pcvl.P("A1")) // pcvl.BS()
+    provider0 = pcvl.FFCircuitProvider(1, 0, v0_stage0)
+    provider0.add_configuration([1], v1_stage0)
+    exp.add(0, provider0)
+
+    # Stage 1: measure mode 3 (remaining after mode 0 measurement), provider with C parameters
+    exp.add(3, pcvl.Detector.pnr())
+    v0_stage1 = Circuit(2) // pcvl.PS(pcvl.P("C0")) // pcvl.BS(theta=pcvl.P("C1"))
+    provider1 = pcvl.FFCircuitProvider(1, -1, v0_stage1)
+    exp.add(3, provider1)
+
+    # Add passive detectors on modes 1, 2 (these don't create feed-forward stages)
+    for mode in (1, 2):
+        exp.add(mode, pcvl.Detector.pnr())
+
+    ff_block = FeedForwardBlock(
+        exp,
+        input_state=[1, 1, 0, 0],
+        trainable_parameters=["A", "C"],
+    )
+
+    # Verify two stages were created
+    assert (
+        len(ff_block._stage_runtimes) == 2
+    ), f"Expected 2 stages, got {len(ff_block._stage_runtimes)}. Stages: {[s.measured_modes for s in ff_block._stage_runtimes]}"
+    stage_0 = ff_block._stage_runtimes[0]
+    stage_1 = ff_block._stage_runtimes[1]
+
+    # Stage 0: should have only "A" parameters
+    assert stage_0.trainable_parameters is not None
+    stage_0_params = set(stage_0.trainable_parameters)
+    assert "A" in stage_0_params, "Stage 0 should have 'A' parameters"
+    assert (
+        "C" not in stage_0_params
+    ), "Stage 0 should not have 'C' parameters (belongs to stage 1)"
+
+    # Stage 1: should have only "C" parameters
+    assert stage_1.trainable_parameters is not None
+    stage_1_params = set(stage_1.trainable_parameters)
+    assert "C" in stage_1_params, "Stage 1 should have 'C' parameters"
+    assert (
+        "A" not in stage_1_params
+    ), "Stage 1 should not have 'A' parameters (belongs to stage 0)"
+
+    # Verify each stage has its runtime objects (pre_layer may be None if root circuit has no parameters)
+    assert stage_0.pre_layer is not None, "Stage 0 should have pre_layer"
+    # Note: stage_1.pre_layer can be None if the root circuit for stage 1 has no parameters
+
+    # Verify each stage has conditional circuits with their respective parameters
+    assert stage_0.conditional_circuits is not None
+    assert (
+        len(stage_0.conditional_circuits) > 0
+    ), "Stage 0 should have conditional circuits"
+    assert any(
+        any(p.startswith("A") for p in circuit.params)
+        for circuit in stage_0.conditional_circuits.values()
+    ), "Stage 0 conditional circuits should contain 'A' parameters"
+
+    assert stage_1.conditional_circuits is not None
+    assert (
+        len(stage_1.conditional_circuits) > 0
+    ), "Stage 1 should have conditional circuits"
+    assert any(
+        any(p.startswith("C") for p in circuit.params)
+        for circuit in stage_1.conditional_circuits.values()
+    ), "Stage 1 conditional circuits should contain 'C' parameters"

--- a/tests/algorithms/test_feed_forward_block.py
+++ b/tests/algorithms/test_feed_forward_block.py
@@ -520,9 +520,9 @@ def test_feedforwardblock_params_only_in_branches():
 
     # Verify input parameters are handled by the FeedForwardBlock
     # Note: "x" was specified as an input_parameter and exists in provider circuits.
-    # However, pre_layer is built from the unitary circuit where "x" doesn't exist,
-    # so "x" won't appear in pre_layer.input_parameters. The FeedForwardBlock will
-    # route classical inputs through the feed-forward provider circuits.
+    # However, the first-stage pre_layer is built from the unitary circuit where "x" doesn't exist,
+    # so "x" won't appear in pre_layer.input_parameters. FeedForwardBlock currently consumes
+    # classical inputs in the first stage only; this assertion only verifies prefix mapping.
 
     # Verify the FeedForwardBlock's input parameter mapping
     assert ff_block.input_params_to_prefix_mapping is not None

--- a/tests/algorithms/test_feed_forward_block.py
+++ b/tests/algorithms/test_feed_forward_block.py
@@ -13,6 +13,7 @@ import numpy as np
 import perceval as pcvl
 import pytest
 import torch
+from exqalibur import FSArray
 from perceval import BasicState, Circuit, Matrix, Unitary
 from perceval.algorithm import Sampler
 from perceval.components import PERM
@@ -423,6 +424,57 @@ def test_feedforward_block_matches_perceval_distribution():
 
     assert set(block_probs.keys()) == set(perceval_probs.keys())
     for key, prob in block_probs.items():
-        assert math.isclose(prob, perceval_probs[key], rel_tol=1e-5, abs_tol=1e-5), (
-            f"Mismatch for key {key}: Merlin={prob}, Perceval={perceval_probs[key]}"
+        assert math.isclose(
+            prob, perceval_probs[key], rel_tol=1e-5, abs_tol=1e-5
+        ), f"Mismatch for key {key}: Merlin={prob}, Perceval={perceval_probs[key]}"
+
+
+def test_feedforwardblock_params_only_in_branches():
+    m = 6
+    k = 4
+    n = 4
+
+    possible_measurements = list(FSArray(k, n - 1))
+
+    def gi_func(idx):
+        return (
+            Circuit(2)
+            // pcvl.PS(pcvl.P(f"A{2 * idx}"))
+            // pcvl.BS()
+            // pcvl.PS(pcvl.P(f"A{2 * idx + 1}"))
+            // pcvl.BS()
         )
+
+    def g(measurement):
+        return possible_measurements.index(measurement) + 1
+
+    def adaptive_mzi(measurement):
+        g_val = g(measurement)
+        return (
+            Circuit(2)
+            // pcvl.PS(g_val * pcvl.P("x"))
+            // pcvl.BS()
+            // pcvl.PS(pcvl.P(f"B{g_val-1}"))
+            // pcvl.BS()
+        )
+
+    gi = pcvl.GenericInterferometer(m, gi_func)
+
+    feedforward_config = pcvl.FFCircuitProvider(k, 0, Circuit(2))
+    for measurement in possible_measurements:
+        feedforward_config.add_configuration(measurement, adaptive_mzi(measurement))
+
+    experiment = pcvl.Experiment(m)
+    experiment.add(0, gi)
+
+    for i in range(k):
+        experiment.add(i, pcvl.Detector.pnr())
+
+    experiment.add(0, feedforward_config)
+
+    FeedForwardBlock(
+        experiment,
+        input_state=BasicState([1] * n + [0] * (m - n)),
+        trainable_parameters=["A", "B"],
+        input_parameters=["x"],
+    )

--- a/tests/algorithms/test_feed_forward_block.py
+++ b/tests/algorithms/test_feed_forward_block.py
@@ -440,6 +440,9 @@ def test_feedforwardblock_params_only_in_branches():
     def gi_func(idx):
         return (
             Circuit(2)
+            // pcvl.BS()
+            // pcvl.PS(pcvl.P(f"x{idx}"))
+            // pcvl.BS()
             // pcvl.PS(pcvl.P(f"A{2 * idx}"))
             // pcvl.BS()
             // pcvl.PS(pcvl.P(f"A{2 * idx + 1}"))
@@ -451,13 +454,7 @@ def test_feedforwardblock_params_only_in_branches():
 
     def adaptive_mzi_stage1(measurement):
         g_val = g(measurement)
-        return (
-            Circuit(2)
-            // pcvl.PS(g_val * pcvl.P("x"))
-            // pcvl.BS()
-            // pcvl.PS(pcvl.P(f"B{g_val-1}"))
-            // pcvl.BS()
-        )
+        return Circuit(2) // pcvl.BS() // pcvl.PS(pcvl.P(f"B{g_val-1}")) // pcvl.BS()
 
     gi = pcvl.GenericInterferometer(m, gi_func)
 
@@ -499,8 +496,7 @@ def test_feedforwardblock_params_only_in_branches():
     assert stage_0.pre_layer is not None
     pre_layer_trainable = set(stage_0.pre_layer.trainable_parameters or [])
     assert "A" in pre_layer_trainable, "Pre-layer should have 'A' from unitary"
-    # Note: "x" is in the provider circuits, not the unitary, so it won't appear in pre_layer.input_parameters
-    # The pre_layer was created with input_parameters=["x"] but "x" only appears in conditional branches
+    # Note: "x" is included in the first-stage unitary, so it should be treated as a first-stage input parameter.
     assert (
         "B" not in pre_layer_trainable
     ), "Pre-layer should not have 'B' (only in conditional branches)"
@@ -525,10 +521,72 @@ def test_feedforwardblock_params_only_in_branches():
     # classical inputs in the first stage only; this assertion only verifies prefix mapping.
 
     # Verify the FeedForwardBlock's input parameter mapping
-    assert ff_block.input_params_to_prefix_mapping is not None
-    assert (
-        "x" in ff_block.input_params_to_prefix_mapping
+    assert ff_block._input_params_to_prefix_mapping is not None
+    assert "x" in ff_block._prefix_to_params_mapping
+    assert any(
+        prefix == "x" for prefix in ff_block._input_params_to_prefix_mapping.values()
     ), "Input parameter 'x' should be recognized by FeedForwardBlock"
+
+    # Verifying no forward bug
+    ff_block.forward(torch.rand([1, 15]))
+
+
+def test_feedforwardblock_input_at_send_layer_fails():
+    m = 6
+    k = 4
+    n = 4
+
+    possible_measurements = list(FSArray(k, n - 1))
+
+    def gi_func(idx):
+        return (
+            Circuit(2)
+            // pcvl.BS()
+            // pcvl.PS(pcvl.P(f"A{2 * idx}"))
+            // pcvl.BS()
+            // pcvl.PS(pcvl.P(f"A{2 * idx + 1}"))
+            // pcvl.BS()
+        )
+
+    def g(measurement):
+        return possible_measurements.index(measurement) + 1
+
+    def adaptive_mzi_stage1(measurement):
+        g_val = g(measurement)
+        return (
+            Circuit(2)
+            // pcvl.BS()
+            // pcvl.PS(g_val * pcvl.P("x"))
+            // pcvl.BS()
+            // pcvl.PS(pcvl.P(f"B{g_val-1}"))
+            // pcvl.BS()
+        )
+
+    gi = pcvl.GenericInterferometer(m, gi_func)
+
+    # Stage 1: after first k detectors
+    feedforward_config_1 = pcvl.FFCircuitProvider(k, 0, Circuit(2))
+    for measurement in possible_measurements:
+        feedforward_config_1.add_configuration(
+            measurement, adaptive_mzi_stage1(measurement)
+        )
+
+    experiment = pcvl.Experiment(m)
+    experiment.add(0, gi)
+
+    for i in range(k):
+        experiment.add(i, pcvl.Detector.pnr())
+
+    experiment.add(0, feedforward_config_1)
+    with pytest.raises(
+        ValueError, match="The first stage must use all of the input parameters"
+    ):
+        _ = FeedForwardBlock(
+            experiment,
+            input_state=BasicState([1] * n + [0] * (m - n)),
+            trainable_parameters=["A", "B"],
+            input_parameters=["x"],
+        )
 
 
 def test_feedforwardblock_params_multi_stage():


### PR DESCRIPTION
## Summary
FeedForwardBlock failed when global parameter specs include parameters that are only present in adaptive feed-forward branch circuits. 

Whole context with failing tests: https://gitlab.quandela.dev/-/snippets/11

## Related Issue
PML-316

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / Cleanup
- [ ] Performance improvement
- [ ] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)


## Proposed changes
- Verifying the global parameter-prefix assignement at the declaration of the feed forward block
- Creating parameter to prefix maps for the input and trainable parameters
- Only give the corresponding prefixes per experiment stage

## How to test / How to run
```
pytest -q
```

## Documentation
- [ ] User docs updated (Sphinx)
- [ ] Examples / notebooks updated
- [ ] Docstrings updated
- [ ] Updated the API