### PR TITLE
PML-351: MeasurementStrategy deprecations

### DIFF
--- a/docs/source/api_reference/api/merlin.algorithms.layer.rst
+++ b/docs/source/api_reference/api/merlin.algorithms.layer.rst
@@ -417,3 +417,7 @@ Deprecations
 .. warning:: *Deprecated since version 0.3:*
    The use of the ``no_bunching`` flag  is deprecated and is removed since version 0.3.0.
    Use the ``computation_space`` flag inside ``measurement_strategy`` instead. See :doc:`/user_guide/migration_guide`.
+
+.. warning::
+   *Deprecated since version 0.4:* The use of the ``computation_space`` argument in the QuantumLayer's constructor is no longer supported as 0.4.0.
+   Use the ``computation_space`` flag inside ``measurement_strategy`` instead. See :doc:`/user_guide/migration_guide`.

--- a/docs/source/notebooks/reproduced_papers/nn_embedding.ipynb
+++ b/docs/source/notebooks/reproduced_papers/nn_embedding.ipynb
@@ -295,7 +295,7 @@
     "    builder=circ,\n",
     "    n_photons=4,\n",
     "    amplitude_encoding=True,\n",
-    "    measurement_strategy=ml.MeasurementStrategy.PROBABILITIES,\n",
+    "    measurement_strategy=ml.MeasurementStrategy.probs(),\n",
     ")\n",
     "pcvl.pdisplay(circ.to_pcvl_circuit())"
    ]

--- a/docs/source/notebooks/reproduced_papers/nn_embedding.ipynb
+++ b/docs/source/notebooks/reproduced_papers/nn_embedding.ipynb
@@ -203,7 +203,7 @@
     "    input_size=0,\n",
     "    builder=circ,\n",
     "    n_photons=4,\n",
-    "    measurement_strategy=ml.MeasurementStrategy.AMPLITUDES,\n",
+    "    measurement_strategy=ml.MeasurementStrategy.amplitudes(),\n",
     ")\n",
     "pcvl.pdisplay(circ.to_pcvl_circuit())"
    ]

--- a/docs/source/reproduced_papers/reproductions/photonic_QGAN.rst
+++ b/docs/source/reproduced_papers/reproductions/photonic_QGAN.rst
@@ -173,8 +173,7 @@ The active implementation in ``lib/generators.py`` follows this structure:
                    input_parameters=pcvl_circuit.enc_param_names,
                    trainable_parameters=pcvl_circuit.var_param_names,
                    input_state=input_state,
-                   measurement_strategy=ml.MeasurementStrategy.PROBABILITIES,
-                   computation_space=ml.ComputationSpace.FOCK,
+                   measurement_strategy=ml.MeasurementStrategy.probs(computation_space=ml.ComputationSpace.FOCK),
                )
                self.layers.append(layer)
 

--- a/docs/source/reproduced_papers/reproductions/photonic_memristor.rst
+++ b/docs/source/reproduced_papers/reproductions/photonic_memristor.rst
@@ -56,7 +56,7 @@ Memristor ``QuantumLayer`` usage (from the implementation):
        trainable_parameters=["theta"],
        input_parameters=["px"],
        input_state=[0, 1, 0],
-       measurement_strategy=ml.MeasurementStrategy.PROBABILITIES,
+       measurement_strategy=ml.MeasurementStrategy.probs(),
        no_bunching=True,
    )
 

--- a/docs/source/reproduced_papers/reproductions/qssl.rst
+++ b/docs/source/reproduced_papers/reproductions/qssl.rst
@@ -76,8 +76,7 @@ In ``papers/qSSL/lib/model.py``, ``QuantumLayer`` is used as the MerLin
        ],
        input_parameters=["feature"],
        input_state=input_state,
-       computation_space=ComputationSpace.UNBUNCHED,
-       measurement_strategy=MeasurementStrategy.PROBABILITIES,
+       measurement_strategy=MeasurementStrategy.probs(computation_space=ComputationSpace.UNBUNCHED),
    )
 
    # forward: encoder -> quantum layer -> projection head

--- a/docs/source/user_guide/computation_space.rst
+++ b/docs/source/user_guide/computation_space.rst
@@ -64,7 +64,7 @@ We can choose from:
 - ``merlin.ComputationSpace.DUAL_RAIL``, use a dual rail encoding (two modes per photon).
 
 .. warning::
-   *Deprecated since version 0.4:* The use of the ``computation_space`` argument in the QuantumLayer's constructor  is deprecated and is removed since version 0.4.0.
+   *Deprecated since version 0.4:* The use of the ``computation_space`` argument in the QuantumLayer's constructor is no longer supported as 0.4.0.
    Use the ``computation_space`` flag inside ``measurement_strategy`` instead. See :doc:`/user_guide/migration_guide`.
 
 It will be the only way to control the computation space as the ``no_bunching`` flag is deprecated.

--- a/docs/source/user_guide/computation_space.rst
+++ b/docs/source/user_guide/computation_space.rst
@@ -63,14 +63,16 @@ We can choose from:
 - ``merlin.ComputationSpace.FOCK``, allow multiple photons per modes (i.e. explore the full Fock space).
 - ``merlin.ComputationSpace.DUAL_RAIL``, use a dual rail encoding (two modes per photon).
 
-Those computation spaces can also be assigned with the ``computation_space`` argument in the constructor but, it
-is preferred to exploit the ``measurement_strategy`` since ``computation_space`` will be deprecated in the future.
+.. warning::
+   *Deprecated since version 0.4:* The use of the ``computation_space`` argument in the QuantumLayer's constructor  is deprecated and is removed since version 0.4.0.
+   Use the ``computation_space`` flag inside ``measurement_strategy`` instead. See :doc:`/user_guide/migration_guide`.
 
 It will be the only way to control the computation space as the ``no_bunching`` flag is deprecated.
 
 .. warning:: *Deprecated since version 0.3:*
    The use of the ``no_bunching`` flag  is deprecated and is removed since version 0.3.0.
    Use the ``computation_space`` flag inside ``measurement_strategy`` instead. See :doc:`/user_guide/migration_guide`.
+
 
 Another parameter is also relevant.
 

--- a/docs/source/user_guide/layer.rst
+++ b/docs/source/user_guide/layer.rst
@@ -172,6 +172,11 @@ Notes
    *Deprecated since version 0.3:* The use of the ``no_bunching`` flag  is deprecated and is removed since version 0.3.0.
    Use the ``computation_space`` flag inside ``measurement_strategy`` instead. See :doc:`/user_guide/migration_guide`.
 
+.. warning::
+   *Deprecated since version 0.4:* The use of the ``computation_space`` argument in the QuantumLayer's constructor  is deprecated and is removed since version 0.4.0.
+   Use the ``computation_space`` flag inside ``measurement_strategy`` instead. See :doc:`/user_guide/migration_guide`.
+
+
 ----------------------
 API Reference
 ----------------------

--- a/docs/source/user_guide/layer.rst
+++ b/docs/source/user_guide/layer.rst
@@ -173,7 +173,7 @@ Notes
    Use the ``computation_space`` flag inside ``measurement_strategy`` instead. See :doc:`/user_guide/migration_guide`.
 
 .. warning::
-   *Deprecated since version 0.4:* The use of the ``computation_space`` argument in the QuantumLayer's constructor  is deprecated and is removed since version 0.4.0.
+   *Deprecated since version 0.4:* The use of the ``computation_space`` argument in the QuantumLayer's constructor is no longer supported as 0.4.0.
    Use the ``computation_space`` flag inside ``measurement_strategy`` instead. See :doc:`/user_guide/migration_guide`.
 
 

--- a/merlin/algorithms/feed_forward.py
+++ b/merlin/algorithms/feed_forward.py
@@ -1228,16 +1228,14 @@ class FeedForwardBlock(MerlinModule):
                     != MeasurementKind["PROBABILITIES"]
                 ):
                     continue
-                entries.append(
-                    (
-                        key,
-                        probability_total,
-                        amplitude_total,
-                        weight_total,
-                        basis_keys,
-                        remaining_n,
-                    )
-                )
+                entries.append((
+                    key,
+                    probability_total,
+                    amplitude_total,
+                    weight_total,
+                    basis_keys,
+                    remaining_n,
+                ))
 
         if not entries:
             self._output_keys = []
@@ -1505,19 +1503,19 @@ class FeedForwardBlock(MerlinModule):
                     if src_idx is not None:
                         reordered[..., tgt_idx] = src[..., src_idx]
                 normalized_amplitudes = reordered
-            mixed_states.append(
-                (
-                    key,
-                    branch_probability,
-                    remaining_n,
-                    normalized_amplitudes,
-                )
-            )
+            mixed_states.append((
+                key,
+                branch_probability,
+                remaining_n,
+                normalized_amplitudes,
+            ))
         self._output_keys = [entry[0] for entry in mixed_states]
         self._output_state_sizes = None
         return mixed_states
 
-    def _aggregate_branch_list(self, branch_list: list[BranchState]) -> tuple[
+    def _aggregate_branch_list(
+        self, branch_list: list[BranchState]
+    ) -> tuple[
         torch.Tensor | None,
         torch.Tensor | None,
         torch.Tensor | None,

--- a/merlin/algorithms/feed_forward.py
+++ b/merlin/algorithms/feed_forward.py
@@ -202,7 +202,7 @@ class FeedForwardBlock(MerlinModule):
           measurement keys. The :attr:`output_keys` attribute is retained for
           metadata while :attr:`output_state_sizes` reports ``num_modes`` for
           every key.
-        - ``MeasurementStrategy.AMPLITUDES`` yields a list of tuples
+        - ``MeasurementStrategy.amplitudes()`` yields a list of tuples
           ``(measurement_key, branch_probability, remaining_photons,
           amplitudes)`` so callers can reason about the mixed state left by each
           branch.
@@ -1228,14 +1228,16 @@ class FeedForwardBlock(MerlinModule):
                     != MeasurementKind["PROBABILITIES"]
                 ):
                     continue
-                entries.append((
-                    key,
-                    probability_total,
-                    amplitude_total,
-                    weight_total,
-                    basis_keys,
-                    remaining_n,
-                ))
+                entries.append(
+                    (
+                        key,
+                        probability_total,
+                        amplitude_total,
+                        weight_total,
+                        basis_keys,
+                        remaining_n,
+                    )
+                )
 
         if not entries:
             self._output_keys = []
@@ -1503,19 +1505,19 @@ class FeedForwardBlock(MerlinModule):
                     if src_idx is not None:
                         reordered[..., tgt_idx] = src[..., src_idx]
                 normalized_amplitudes = reordered
-            mixed_states.append((
-                key,
-                branch_probability,
-                remaining_n,
-                normalized_amplitudes,
-            ))
+            mixed_states.append(
+                (
+                    key,
+                    branch_probability,
+                    remaining_n,
+                    normalized_amplitudes,
+                )
+            )
         self._output_keys = [entry[0] for entry in mixed_states]
         self._output_state_sizes = None
         return mixed_states
 
-    def _aggregate_branch_list(
-        self, branch_list: list[BranchState]
-    ) -> tuple[
+    def _aggregate_branch_list(self, branch_list: list[BranchState]) -> tuple[
         torch.Tensor | None,
         torch.Tensor | None,
         torch.Tensor | None,

--- a/merlin/algorithms/feed_forward_legacy.py
+++ b/merlin/algorithms/feed_forward_legacy.py
@@ -226,9 +226,9 @@ class FeedForwardBlockLegacy(torch.nn.Module):
         else:
             tuples = self.generate_possible_tuples()
             self.tuples = tuples
-            assert len(tuples) == len(
-                layers
-            ), "Mismatch between number of tuples and provided layers."
+            assert len(tuples) == len(layers), (
+                "Mismatch between number of tuples and provided layers."
+            )
             self.layers = {tuples[k]: layers[k] for k in range(len(layers))}
 
             start = 0

--- a/merlin/algorithms/feed_forward_legacy.py
+++ b/merlin/algorithms/feed_forward_legacy.py
@@ -157,7 +157,7 @@ class FeedForwardBlockLegacy(torch.nn.Module):
     simulate complex conditional evolution of quantum systems.
 
     Detector support: The current feed-forward implementation expects amplitude access for
-    every intermediate layer (``MeasurementStrategy.AMPLITUDES``) and
+    every intermediate layer (``MeasurementStrategy.amplitudes()``) and
     therefore assumes ideal PNR detectors. Custom detector transforms or
     Perceval experiments with threshold / hybrid detectors are not yet
     supported inside this block.
@@ -226,9 +226,9 @@ class FeedForwardBlockLegacy(torch.nn.Module):
         else:
             tuples = self.generate_possible_tuples()
             self.tuples = tuples
-            assert len(tuples) == len(layers), (
-                "Mismatch between number of tuples and provided layers."
-            )
+            assert len(tuples) == len(
+                layers
+            ), "Mismatch between number of tuples and provided layers."
             self.layers = {tuples[k]: layers[k] for k in range(len(layers))}
 
             start = 0

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -120,7 +120,6 @@ class QuantumLayer(MerlinModule):
         input_parameters: list[str] | None = None,
         # Common parameters
         amplitude_encoding: bool = False,
-        computation_space: ComputationSpace | str | None = None,
         measurement_strategy: MeasurementStrategyLike | None = None,
         return_object: bool = False,
         # device and dtype
@@ -178,10 +177,6 @@ class QuantumLayer(MerlinModule):
             the first positional argument and propagates it through the quantum
             layer; ``input_size`` must not be set in this mode and
             ``n_photons`` must be provided.
-        computation_space : ComputationSpace | str | None
-            Logical computation subspace to use: one of ``{"fock", "unbunched",
-            "dual_rail"}``. If omitted, defaults to ``UNBUNCHED``. This argument
-            is deprecated; move it into ``MeasurementStrategy.probs(...)``.
         measurement_strategy : MeasurementStrategy | None, default: None
             Output mapping strategy. When omitted, defaults to
             ``MeasurementStrategy.probs(computation_space)``. Supported values
@@ -227,6 +222,8 @@ class QuantumLayer(MerlinModule):
             passing ``StateVector`` to ``forward()``).
             When ``torch.Tensor`` is passed as ``input_state`` (deprecated in favor
             of ``StateVector``).
+            When the computation space argument is used in the constructor. Please define it in
+            a measurement strategy.
 
         """
         super().__init__()
@@ -246,7 +243,7 @@ class QuantumLayer(MerlinModule):
         )
         # Phase 2: computation space resolution (legacy vs strategy-driven)
         measurement_strategy, computation_space = normalize_measurement_strategy(
-            measurement_strategy, computation_space
+            measurement_strategy
         )
 
         # Phase 3: circuit source resolution (builder/circuit/experiment)

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -207,6 +207,9 @@ class QuantumLayer(MerlinModule):
             annotated ``BasicState`` is passed (annotations are not supported).
         TypeError
             If an unknown measurement strategy is selected during setup.
+        AttributeError
+            When the computation space argument is used in the constructor. Please define it in
+            a measurement strategy.
 
         Warns
         -----
@@ -218,8 +221,6 @@ class QuantumLayer(MerlinModule):
             passing ``StateVector`` to ``forward()``).
             When ``torch.Tensor`` is passed as ``input_state`` (deprecated in favor
             of ``StateVector``).
-            When the computation space argument is used in the constructor. Please define it in
-            a measurement strategy.
 
         """
         super().__init__()

--- a/merlin/algorithms/layer_utils.py
+++ b/merlin/algorithms/layer_utils.py
@@ -668,11 +668,11 @@ def setup_noise_and_detectors(
     )
     if amplitude_readout and has_custom_noise:
         raise RuntimeError(
-            "measurement_strategy=MeasurementStrategy.AMPLITUDES cannot be used when the experiment defines a NoiseModel."
+            "measurement_strategy=MeasurementStrategy.amplitudes() cannot be used when the experiment defines a NoiseModel."
         )
     if amplitude_readout and has_custom_detectors:
         raise RuntimeError(
-            "measurement_strategy=MeasurementStrategy.AMPLITUDES does not support experiments with detectors. "
+            "measurement_strategy=MeasurementStrategy.amplitudes() does not support experiments with detectors. "
             "Compute amplitudes without detectors and apply a Partial DetectorTransform manually if needed."
         )
 

--- a/merlin/measurement/deprecations.py
+++ b/merlin/measurement/deprecations.py
@@ -26,6 +26,6 @@ Can be removed when MeasurementStrategy enum is fully deprecated."""
 
 from __future__ import annotations
 
-from ..utils.deprecations import warn_deprecated_enum_access
+from ..utils.deprecations import error_deprecated_enum_access
 
-__all__ = ["warn_deprecated_enum_access"]
+__all__ = ["error_deprecated_enum_access"]

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -54,7 +54,7 @@ from merlin.utils.grouping import LexGrouping, ModGrouping
 # - If external compatibility is still needed, provide a separate shim module.
 
 
-### Note, kept some Legacy to keep the None measurement strategy
+# Note: kept some Legacy to keep the None measurement strategy
 
 
 class _LegacyMeasurementStrategy(Enum):

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -35,7 +35,7 @@ import torch
 from merlin.core.computation_space import ComputationSpace
 from merlin.core.partial_measurement import PartialMeasurement
 from merlin.measurement.process import partial_measurement
-from merlin.utils.deprecations import warn_deprecated_enum_access
+from merlin.utils.deprecations import error_deprecated_enum_access
 from merlin.utils.grouping import LexGrouping, ModGrouping
 
 # Deprecation guide (target: v0.4):
@@ -58,9 +58,6 @@ class _LegacyMeasurementStrategy(Enum):
     """Legacy enum kept only for backward compatibility (deprecated API)."""
 
     NONE = "none"
-    PROBABILITIES = "probabilities"
-    MODE_EXPECTATIONS = "mode_expectations"
-    AMPLITUDES = "amplitudes"
 
 
 class BaseMeasurementStrategy:
@@ -224,9 +221,9 @@ class _MeasurementStrategyMeta(type):
         # Backward compatibility shim: allow MeasurementStrategy.NONE for amplitudes.
         if name == "NONE":
             return MeasurementStrategy.amplitudes()
-        # All other enum-style access is deprecated; warn and return legacy enum.
-        if warn_deprecated_enum_access("MeasurementStrategy", name):
-            return _LegacyMeasurementStrategy[name]
+        # All other enum-style access is deprecated; Fail
+        error_deprecated_enum_access("MeasurementStrategy", name)
+
         raise AttributeError(
             f"type object 'MeasurementStrategy' has no attribute {name!r}"
         )
@@ -256,10 +253,6 @@ class MeasurementStrategy(metaclass=_MeasurementStrategyMeta):
         # Type-checker-only legacy/compat attributes. At runtime, the metaclass
         # resolves these names to either a new API instance (NONE) or legacy enums.
         NONE: ClassVar[MeasurementStrategy]
-        # TODO: verify if we want NONE or method none()
-        PROBABILITIES: ClassVar[_LegacyMeasurementStrategy]
-        MODE_EXPECTATIONS: ClassVar[_LegacyMeasurementStrategy]
-        AMPLITUDES: ClassVar[_LegacyMeasurementStrategy]
 
     @staticmethod
     def probs(
@@ -398,12 +391,14 @@ class MeasurementStrategy(metaclass=_MeasurementStrategyMeta):
         return NotImplemented
 
     def __hash__(self) -> int:
-        return hash((
-            self.type,
-            self.measured_modes,
-            self.computation_space,
-            self.grouping,
-        ))
+        return hash(
+            (
+                self.type,
+                self.measured_modes,
+                self.computation_space,
+                self.grouping,
+            )
+        )
 
     def validate_modes(self, n_modes: int) -> None:
         """Validate mode indices and warn when the selection covers all modes."""

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -394,14 +394,12 @@ class MeasurementStrategy(metaclass=_MeasurementStrategyMeta):
         return NotImplemented
 
     def __hash__(self) -> int:
-        return hash(
-            (
-                self.type,
-                self.measured_modes,
-                self.computation_space,
-                self.grouping,
-            )
-        )
+        return hash((
+            self.type,
+            self.measured_modes,
+            self.computation_space,
+            self.grouping,
+        ))
 
     def validate_modes(self, n_modes: int) -> None:
         """Validate mode indices and warn when the selection covers all modes."""

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -44,7 +44,7 @@ from merlin.utils.grouping import LexGrouping, ModGrouping
 # - Delete compatibility paths in `resolve_measurement_strategy` and
 #   `_resolve_measurement_kind` that accept `_LegacyMeasurementStrategy`.
 # - Drop :data:`~merlin.measurement.strategies.MeasurementStrategyLike` alias and any tests that rely on legacy enums.
-# - Update all call sites to use the new factories (lots of tetsts to update!):
+# - Update all call sites to use the new factories (lots of tests to update!):
 #     - `MeasurementStrategy.probs(computation_space)`
 #     - `MeasurementStrategy.mode_expectations(computation_space)`
 #     - `MeasurementStrategy.amplitudes()`
@@ -52,6 +52,9 @@ from merlin.utils.grouping import LexGrouping, ModGrouping
 # - Remove related deprecations in `merlin/utils/deprecations.py` that map legacy
 #   enums to new factories, and update docs/examples accordingly.
 # - If external compatibility is still needed, provide a separate shim module.
+
+
+### Note, kept some Legacy to keep the None measurement strategy
 
 
 class _LegacyMeasurementStrategy(Enum):
@@ -217,7 +220,7 @@ class MeasurementKind(Enum):
 
 
 class _MeasurementStrategyMeta(type):
-    def __getattr__(cls, name: str) -> MeasurementStrategy | _LegacyMeasurementStrategy:
+    def __getattr__(cls, name: str) -> MeasurementStrategy:
         # Backward compatibility shim: allow MeasurementStrategy.NONE for amplitudes.
         if name == "NONE":
             return MeasurementStrategy.amplitudes()
@@ -434,7 +437,7 @@ def _resolve_measurement_kind(
         if measurement_strategy == _LegacyMeasurementStrategy.NONE:
             # Legacy NONE aliases amplitudes.
             return MeasurementKind.AMPLITUDES
-        return MeasurementKind[measurement_strategy.name]
+        error_deprecated_enum_access("MeasurementStrategy", measurement_strategy.name)
     raise TypeError(f"Unknown measurement_strategy: {measurement_strategy}")
 
 

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -435,7 +435,6 @@ def _resolve_measurement_kind(
         if measurement_strategy == _LegacyMeasurementStrategy.NONE:
             # Legacy NONE aliases amplitudes.
             return MeasurementKind.AMPLITUDES
-        error_deprecated_enum_access("MeasurementStrategy", measurement_strategy.name)
     raise TypeError(f"Unknown measurement_strategy: {measurement_strategy}")
 
 

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -160,7 +160,7 @@ class AmplitudesStrategy(BaseMeasurementStrategy):
         apply_sampling = bool(kwargs.get("apply_sampling", False))
         if apply_sampling:
             raise RuntimeError(
-                "Sampling cannot be applied when measurement_strategy=MeasurementStrategy.AMPLITUDES."
+                "Sampling cannot be applied when measurement_strategy=MeasurementStrategy.amplitudes()."
             )
         return amplitudes
 

--- a/merlin/utils/deprecations.py
+++ b/merlin/utils/deprecations.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 _MEASUREMENT_STRATEGY_ENUM_MIGRATIONS = {
     "PROBABILITIES": "probs(computation_space)",
     "MODE_EXPECTATIONS": "mode_expectations(computation_space)",
-    "AMPLITUDES": "amplitudes(computation_space) (amplitudes)",
+    "AMPLITUDES": "amplitudes(computation_space)",
 }
 
 _ACTIVE_DEPRECATION_MESSAGES: ContextVar[frozenset[str]] = ContextVar(
@@ -332,8 +332,7 @@ def normalize_measurement_strategy(
     TypeError
         If the provided strategy is a string: which is an invalid measurement strategy.
     AttributeError
-        - If ComputationSpace is defined in the quantum layer's constructor without a measurement strategy.
-        - If ComputationSpace is defined in the quantum layer's constructor with a valid measurement strategy.
+        - If ComputationSpace is defined in the quantum layer's constructor and not in a MeasurementStrategy factory method.
     ValueError
         If a modern ``MeasurementStrategy`` does not define a computation
         space.
@@ -347,7 +346,7 @@ def normalize_measurement_strategy(
     2. If measurement_strategy is None or MeasurementStrategy.NONE and computation_space provided
        → ERROR: user must define a measurement strategy with the computation space inside
     3. If measurement strategy factory is not None + constructor computation_space
-       → ERROR: user must define  the computation space inside the measurement strategy
+       → ERROR: user must define the computation space inside the measurement strategy
     4. If MeasurementStrategy instance only → use its computation_space
     5. If MeasurementStrategy.NONE -> use amplitudes with the default computation space
 
@@ -355,7 +354,6 @@ def normalize_measurement_strategy(
     from ..measurement.strategies import (
         MeasurementKind,
         MeasurementStrategy,
-        _LegacyMeasurementStrategy,
     )
 
     # Track whether computation_space was explicitly provided by user
@@ -369,14 +367,14 @@ def normalize_measurement_strategy(
         else:
             computation_space = ComputationSpace.coerce(computation_space)
             raise AttributeError(
-                "Passing 'computation_space' without an explicit measurement_strategy is deprecated since v0.4. "
+                "Passing 'computation_space' without an explicit measurement_strategy is no longer supported as of v0.4. "
                 "Use MeasurementStrategy.probs(computation_space=...) instead. "
             )
 
     if isinstance(measurement_strategy, str):
         raise TypeError(
-            "Passing measurement_strategy as a string is deprecated since v0.4. "
-            "Use MeasurementStrategy.probs(...) instead .",
+            "Passing measurement_strategy as a string is no longer supported as of v0.4. "
+            "Use MeasurementStrategy.probs(...) instead.",
         )
 
     if isinstance(measurement_strategy, MeasurementStrategy):
@@ -392,28 +390,18 @@ def normalize_measurement_strategy(
         if computation_space_provided:
             raise AttributeError(
                 "Cannot specify 'computation_space' in QuantumLayer's constructor. "
-                "Move 'computation_space' into the factory method instead. Deprecated since v0.4. "
+                "Move 'computation_space' into the factory method instead. It is no longer supported as of v0.4. "
                 "For example: MeasurementStrategy.probs(computation_space=ComputationSpace.FOCK) "
                 "instead of QuantumLayer(..., computation_space=..., measurement_strategy=...)."
             )
 
         return measurement_strategy, strategy_space
 
-    if isinstance(measurement_strategy, _LegacyMeasurementStrategy):
-        if computation_space_provided:
-            raise AttributeError(
-                "Cannot specify 'computation_space' in QuantumLayer's constructor. "
-                "Move 'computation_space' into the factory method instead. Deprecated since v0.4. "
-                "For example: MeasurementStrategy.probs(computation_space=ComputationSpace.FOCK) "
-                "instead of QuantumLayer(..., computation_space=..., measurement_strategy=...)."
-            )
-
     if isinstance(measurement_strategy, MeasurementKind):
         raise TypeError(
             "MeasurementKind is not a supported public measurement_strategy input. "
             "Use MeasurementStrategy.probs(...), MeasurementStrategy.mode_expectations(...), "
-            "MeasurementStrategy.amplitudes(), or legacy MeasurementStrategy.PROBABILITIES-style "
-            "aliases instead."
+            "MeasurementStrategy.amplitudes() or MeasurementStrategy.partial() instead"
         )
 
     # Only set default if not explicitly provided
@@ -422,16 +410,11 @@ def normalize_measurement_strategy(
     else:
         computation_space = ComputationSpace.coerce(computation_space)
 
-    if isinstance(measurement_strategy, _LegacyMeasurementStrategy):
-        if measurement_strategy == _LegacyMeasurementStrategy.NONE:
-            measurement_strategy = MeasurementStrategy.amplitudes(computation_space)
-
     return measurement_strategy, computation_space
 
 
 def error_deprecated_enum_access(owner: str, name: str) -> None:
-    """
-    Fails on deprecated enum-style attribute access.
+    """Fail on deprecated enum-style attribute access.
 
     Parameters
     ----------
@@ -443,12 +426,19 @@ def error_deprecated_enum_access(owner: str, name: str) -> None:
     Returns
     -------
     None
+
+    Raises
+    ------
+    AttributeError
+        If ``owner`` is ``"MeasurementStrategy"`` and ``name`` is one of the
+        deprecated enum-style attributes listed in
+        ``_MEASUREMENT_STRATEGY_ENUM_MIGRATIONS``.
     """
     if owner == "MeasurementStrategy" and name in _MEASUREMENT_STRATEGY_ENUM_MIGRATIONS:
         replacement = _MEASUREMENT_STRATEGY_ENUM_MIGRATIONS[name]
         raise AttributeError(
             f"{owner}.{name} is deprecated. Use {owner}.{replacement} instead. "
-            "(Deprecated since v0.4).",
+            "(No longer supported as of v0.4).",
         )
 
 

--- a/merlin/utils/deprecations.py
+++ b/merlin/utils/deprecations.py
@@ -386,7 +386,7 @@ def normalize_measurement_strategy(
 
         # CONFLICT CHECK: Constructor computation_space + new factory method
         if computation_space_provided:
-            raise TypeError(
+            raise AttributeError(
                 "Cannot specify 'computation_space' in QuantumLayer's constructor. "
                 "Move 'computation_space' into the factory method instead. Deprecated since v0.4. "
                 "For example: MeasurementStrategy.probs(computation_space=ComputationSpace.FOCK) "
@@ -408,26 +408,6 @@ def normalize_measurement_strategy(
         computation_space = ComputationSpace.UNBUNCHED
     else:
         computation_space = ComputationSpace.coerce(computation_space)
-
-    # if isinstance(measurement_strategy, _LegacyMeasurementStrategy):
-    #     # LEGACY API: Enum-style access (PROBABILITIES, MODE_EXPECTATIONS, AMPLITUDES)
-    #     # These are allowed with constructor computation_space for backward compat
-    #     if computation_space_provided:
-    #         warnings.warn(
-    #             "Passing 'computation_space' without a measurement strategy is deprecated since v0.4. "
-    #             "Move computation_space into MeasurementStrategy.probs(computation_space=...) instead. "
-    #         )
-
-    #     if measurement_strategy == _LegacyMeasurementStrategy.PROBABILITIES:
-    #         measurement_strategy = MeasurementStrategy.probs(computation_space)
-    #     elif measurement_strategy == _LegacyMeasurementStrategy.MODE_EXPECTATIONS:
-    #         measurement_strategy = MeasurementStrategy.mode_expectations(
-    #             computation_space
-    #         )
-    #     elif measurement_strategy == _LegacyMeasurementStrategy.AMPLITUDES:
-    #         measurement_strategy = MeasurementStrategy.amplitudes(computation_space)
-    #     elif measurement_strategy == _LegacyMeasurementStrategy.NONE:
-    #         measurement_strategy = MeasurementStrategy.amplitudes(computation_space)
 
     return measurement_strategy, computation_space
 

--- a/merlin/utils/deprecations.py
+++ b/merlin/utils/deprecations.py
@@ -78,6 +78,20 @@ def _remove_QuantumLayer_simple_n_params(
     return kwargs
 
 
+def _remove_QuantumLayer_computation_space(
+    method_qualname: str, kwargs: dict[str, Any]
+) -> None:
+    """
+    Remove the computation space arg from quantumlayer init
+    """
+    raise AttributeError(
+        "Cannot specify 'computation_space' in QuantumLayer's constructor. "
+        "Move 'computation_space' into the factory method instead. It is no longer supported as of v0.4. "
+        "For example: MeasurementStrategy.probs(computation_space=ComputationSpace.FOCK) "
+        "instead of QuantumLayer(..., computation_space=..., measurement_strategy=...)."
+    )
+
+
 def _remove_FeatureMap_simple_n_photons(
     method_qualname: str, kwargs: dict[str, Any]
 ) -> dict[str, Any]:
@@ -141,6 +155,11 @@ DEPRECATION_REGISTRY: dict[
         None,
         None,
         _reject_no_bunching_init,
+    ),
+    "QuantumLayer.__init__.computation_space": (
+        None,
+        None,
+        _remove_QuantumLayer_computation_space,
     ),
     # QuantumLayer.simple deprecations
     "QuantumLayer.simple.no_bunching": (
@@ -306,7 +325,6 @@ def _collect_deprecations_and_converters(
 
 def normalize_measurement_strategy(
     measurement_strategy: MeasurementStrategyLike | str | None,
-    computation_space: ComputationSpace | str | None,
 ) -> tuple[MeasurementStrategyLike, ComputationSpace]:
     """
     Normalize measurement strategy and computation space with deprecation errors.
@@ -357,19 +375,11 @@ def normalize_measurement_strategy(
     )
 
     # Track whether computation_space was explicitly provided by user
-    computation_space_provided = computation_space is not None
 
     if measurement_strategy is None:
-        if computation_space is None:
-            computation_space = ComputationSpace.UNBUNCHED
-            measurement_strategy = MeasurementStrategy.probs(computation_space)
-            return measurement_strategy, computation_space
-        else:
-            computation_space = ComputationSpace.coerce(computation_space)
-            raise AttributeError(
-                "Passing 'computation_space' without an explicit measurement_strategy is no longer supported as of v0.4. "
-                "Use MeasurementStrategy.probs(computation_space=...) instead. "
-            )
+        computation_space = ComputationSpace.UNBUNCHED
+        measurement_strategy = MeasurementStrategy.probs(computation_space)
+        return measurement_strategy, computation_space
 
     if isinstance(measurement_strategy, str):
         raise TypeError(
@@ -384,15 +394,6 @@ def normalize_measurement_strategy(
             raise ValueError(
                 "MeasurementStrategy must define computation_space. "
                 "Use MeasurementStrategy.probs(computation_space) instead."
-            )
-
-        # CONFLICT CHECK: Constructor computation_space + new factory method
-        if computation_space_provided:
-            raise AttributeError(
-                "Cannot specify 'computation_space' in QuantumLayer's constructor. "
-                "Move 'computation_space' into the factory method instead. It is no longer supported as of v0.4. "
-                "For example: MeasurementStrategy.probs(computation_space=ComputationSpace.FOCK) "
-                "instead of QuantumLayer(..., computation_space=..., measurement_strategy=...)."
             )
 
         return measurement_strategy, strategy_space

--- a/merlin/utils/deprecations.py
+++ b/merlin/utils/deprecations.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 _MEASUREMENT_STRATEGY_ENUM_MIGRATIONS = {
     "PROBABILITIES": "probs(computation_space)",
     "MODE_EXPECTATIONS": "mode_expectations(computation_space)",
-    "AMPLITUDES": "NONE (amplitudes)",
+    "AMPLITUDES": "amplitudes(computation_space) (amplitudes)",
 }
 
 _ACTIVE_DEPRECATION_MESSAGES: ContextVar[frozenset[str]] = ContextVar(
@@ -352,7 +352,6 @@ def normalize_measurement_strategy(
     from ..measurement.strategies import (
         MeasurementKind,
         MeasurementStrategy,
-        _LegacyMeasurementStrategy,
     )
 
     # Track whether computation_space was explicitly provided by user
@@ -361,32 +360,20 @@ def normalize_measurement_strategy(
     if measurement_strategy is None:
         if computation_space is None:
             computation_space = ComputationSpace.UNBUNCHED
+            measurement_strategy = MeasurementStrategy.probs(computation_space)
+            return measurement_strategy, computation_space
         else:
             computation_space = ComputationSpace.coerce(computation_space)
-            warnings.warn(
-                "Passing 'computation_space' without an explicit measurement_strategy is deprecated. "
+            raise AttributeError(
+                "Passing 'computation_space' without an explicit measurement_strategy is deprecated since v0.4. "
                 "Use MeasurementStrategy.probs(computation_space=...) instead. "
-                "Will be removed in 0.4 (v0.4).",
-                DeprecationWarning,
-                stacklevel=2,
             )
-        measurement_strategy = MeasurementStrategy.probs(computation_space)
-        return measurement_strategy, computation_space
 
     if isinstance(measurement_strategy, str):
-        warnings.warn(
-            "Passing measurement_strategy as a string is deprecated. "
-            "Use MeasurementStrategy.probs(...) instead. Will be removed in v0.4.",
-            DeprecationWarning,
-            stacklevel=2,
+        raise TypeError(
+            "Passing measurement_strategy as a string is deprecated since v0.4. "
+            "Use MeasurementStrategy.probs(...) instead .",
         )
-        normalized = measurement_strategy.upper()
-        try:
-            measurement_strategy = _LegacyMeasurementStrategy[normalized]
-        except KeyError as exc:
-            raise TypeError(
-                f"Unknown measurement_strategy: {measurement_strategy}"
-            ) from exc
 
     if isinstance(measurement_strategy, MeasurementStrategy):
         # NEW API: MeasurementStrategy instance (e.g., from .probs(), .partial(), etc)
@@ -400,9 +387,8 @@ def normalize_measurement_strategy(
         # CONFLICT CHECK: Constructor computation_space + new factory method
         if computation_space_provided:
             raise TypeError(
-                "Cannot specify 'computation_space' in QuantumLayer constructor "
-                "when using MeasurementStrategy.probs(), .mode_expectations(), or .partial(). "
-                "Move 'computation_space' into the factory method instead. "
+                "Cannot specify 'computation_space' in QuantumLayer's constructor. "
+                "Move 'computation_space' into the factory method instead. Deprecated since v0.4. "
                 "For example: MeasurementStrategy.probs(computation_space=ComputationSpace.FOCK) "
                 "instead of QuantumLayer(..., computation_space=..., measurement_strategy=...)."
             )
@@ -423,34 +409,30 @@ def normalize_measurement_strategy(
     else:
         computation_space = ComputationSpace.coerce(computation_space)
 
-    if isinstance(measurement_strategy, _LegacyMeasurementStrategy):
-        # LEGACY API: Enum-style access (PROBABILITIES, MODE_EXPECTATIONS, AMPLITUDES)
-        # These are allowed with constructor computation_space for backward compat
-        if computation_space_provided:
-            warnings.warn(
-                "Passing 'computation_space' as a separate argument with legacy "
-                "MeasurementStrategy enum values is deprecated. "
-                "Move computation_space into MeasurementStrategy.probs(computation_space=...) instead. "
-                "Will be removed in 0.4 (v0.4).",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+    # if isinstance(measurement_strategy, _LegacyMeasurementStrategy):
+    #     # LEGACY API: Enum-style access (PROBABILITIES, MODE_EXPECTATIONS, AMPLITUDES)
+    #     # These are allowed with constructor computation_space for backward compat
+    #     if computation_space_provided:
+    #         warnings.warn(
+    #             "Passing 'computation_space' without a measurement strategy is deprecated since v0.4. "
+    #             "Move computation_space into MeasurementStrategy.probs(computation_space=...) instead. "
+    #         )
 
-        if measurement_strategy == _LegacyMeasurementStrategy.PROBABILITIES:
-            measurement_strategy = MeasurementStrategy.probs(computation_space)
-        elif measurement_strategy == _LegacyMeasurementStrategy.MODE_EXPECTATIONS:
-            measurement_strategy = MeasurementStrategy.mode_expectations(
-                computation_space
-            )
-        elif measurement_strategy == _LegacyMeasurementStrategy.AMPLITUDES:
-            measurement_strategy = MeasurementStrategy.amplitudes(computation_space)
-        elif measurement_strategy == _LegacyMeasurementStrategy.NONE:
-            measurement_strategy = MeasurementStrategy.amplitudes(computation_space)
+    #     if measurement_strategy == _LegacyMeasurementStrategy.PROBABILITIES:
+    #         measurement_strategy = MeasurementStrategy.probs(computation_space)
+    #     elif measurement_strategy == _LegacyMeasurementStrategy.MODE_EXPECTATIONS:
+    #         measurement_strategy = MeasurementStrategy.mode_expectations(
+    #             computation_space
+    #         )
+    #     elif measurement_strategy == _LegacyMeasurementStrategy.AMPLITUDES:
+    #         measurement_strategy = MeasurementStrategy.amplitudes(computation_space)
+    #     elif measurement_strategy == _LegacyMeasurementStrategy.NONE:
+    #         measurement_strategy = MeasurementStrategy.amplitudes(computation_space)
 
     return measurement_strategy, computation_space
 
 
-def warn_deprecated_enum_access(owner: str, name: str) -> bool:
+def error_deprecated_enum_access(owner: str, name: str) -> bool:
     """
     Warn on deprecated enum-style attribute access.
 
@@ -469,14 +451,10 @@ def warn_deprecated_enum_access(owner: str, name: str) -> bool:
     """
     if owner == "MeasurementStrategy" and name in _MEASUREMENT_STRATEGY_ENUM_MIGRATIONS:
         replacement = _MEASUREMENT_STRATEGY_ENUM_MIGRATIONS[name]
-        warnings.warn(
+        raise AttributeError(
             f"{owner}.{name} is deprecated. Use {owner}.{replacement} instead. "
-            "Will be removed in 0.4 (v0.4).",
-            DeprecationWarning,
-            stacklevel=2,
+            "(Deprecated since v0.4).",
         )
-        return True
-    return False
 
 
 # ---------------------------------------------------------------------------

--- a/merlin/utils/deprecations.py
+++ b/merlin/utils/deprecations.py
@@ -309,7 +309,7 @@ def normalize_measurement_strategy(
     computation_space: ComputationSpace | str | None,
 ) -> tuple[MeasurementStrategyLike, ComputationSpace]:
     """
-    Normalize measurement strategy and computation space with deprecation warnings.
+    Normalize measurement strategy and computation space with deprecation errors.
 
     Enforces the v0.3 requirement that ``computation_space`` must live inside
     ``MeasurementStrategy`` when using the new factory methods.
@@ -330,8 +330,10 @@ def normalize_measurement_strategy(
     Raises
     ------
     TypeError
-        If the provided strategy is incompatible with the separate
-        ``computation_space`` argument or cannot be normalized.
+        If the provided strategy is a string: which is an invalid measurement strategy.
+    AttributeError
+        - If ComputationSpace is defined in the quantum layer's constructor without a measurement strategy.
+        - If ComputationSpace is defined in the quantum layer's constructor with a valid measurement strategy.
     ValueError
         If a modern ``MeasurementStrategy`` does not define a computation
         space.
@@ -342,16 +344,18 @@ def normalize_measurement_strategy(
 
     1. If MeasurementStrategy instance (new API) + constructor computation_space provided
        → ERROR: user must move computation_space into the factory method
-    2. If measurement_strategy is None and computation_space provided
-       → OK with deprecation warning (default to MeasurementStrategy.probs(computation_space))
-    3. If legacy enum (PROBABILITIES, etc) + constructor computation_space
-       → OK with deprecation warning (backward compat)
+    2. If measurement_strategy is None or MeasurementStrategy.NONE and computation_space provided
+       → ERROR: user must define a measurement strategy with the computation space inside
+    3. If measurement strategy factory is not None + constructor computation_space
+       → ERROR: user must define  the computation space inside the measurement strategy
     4. If MeasurementStrategy instance only → use its computation_space
-    5. If legacy enum only → wrap with computation_space param
+    5. If MeasurementStrategy.NONE -> use amplitudes with the default computation space
+
     """
     from ..measurement.strategies import (
         MeasurementKind,
         MeasurementStrategy,
+        _LegacyMeasurementStrategy,
     )
 
     # Track whether computation_space was explicitly provided by user
@@ -395,6 +399,15 @@ def normalize_measurement_strategy(
 
         return measurement_strategy, strategy_space
 
+    if isinstance(measurement_strategy, _LegacyMeasurementStrategy):
+        if computation_space_provided:
+            raise AttributeError(
+                "Cannot specify 'computation_space' in QuantumLayer's constructor. "
+                "Move 'computation_space' into the factory method instead. Deprecated since v0.4. "
+                "For example: MeasurementStrategy.probs(computation_space=ComputationSpace.FOCK) "
+                "instead of QuantumLayer(..., computation_space=..., measurement_strategy=...)."
+            )
+
     if isinstance(measurement_strategy, MeasurementKind):
         raise TypeError(
             "MeasurementKind is not a supported public measurement_strategy input. "
@@ -409,12 +422,16 @@ def normalize_measurement_strategy(
     else:
         computation_space = ComputationSpace.coerce(computation_space)
 
+    if isinstance(measurement_strategy, _LegacyMeasurementStrategy):
+        if measurement_strategy == _LegacyMeasurementStrategy.NONE:
+            measurement_strategy = MeasurementStrategy.amplitudes(computation_space)
+
     return measurement_strategy, computation_space
 
 
-def error_deprecated_enum_access(owner: str, name: str) -> bool:
+def error_deprecated_enum_access(owner: str, name: str) -> None:
     """
-    Warn on deprecated enum-style attribute access.
+    Fails on deprecated enum-style attribute access.
 
     Parameters
     ----------
@@ -425,9 +442,7 @@ def error_deprecated_enum_access(owner: str, name: str) -> bool:
 
     Returns
     -------
-    bool
-        ``True`` if the access was recognized and handled, ``False``
-        otherwise.
+    None
     """
     if owner == "MeasurementStrategy" and name in _MEASUREMENT_STRATEGY_ENUM_MIGRATIONS:
         replacement = _MEASUREMENT_STRATEGY_ENUM_MIGRATIONS[name]

--- a/merlin/utils/deprecations.py
+++ b/merlin/utils/deprecations.py
@@ -351,16 +351,11 @@ def normalize_measurement_strategy(
     """
     Normalize measurement strategy and computation space with deprecation errors.
 
-    Enforces the v0.3 requirement that ``computation_space`` must live inside
-    ``MeasurementStrategy`` when using the new factory methods.
-
     Parameters
     ----------
     measurement_strategy : :data:`~merlin.measurement.strategies.MeasurementStrategyLike` | str | None
         Measurement strategy provided by the caller. Supports the modern
         strategy object, legacy enum aliases, legacy strings, or ``None``.
-    computation_space : ComputationSpace | str | None
-        Computation space provided alongside the strategy.
 
     Returns
     -------
@@ -371,8 +366,6 @@ def normalize_measurement_strategy(
     ------
     TypeError
         If the provided strategy is a string: which is an invalid measurement strategy.
-    AttributeError
-        - If ComputationSpace is defined in the quantum layer's constructor and not in a MeasurementStrategy factory method.
     ValueError
         If a modern ``MeasurementStrategy`` does not define a computation
         space.
@@ -383,12 +376,8 @@ def normalize_measurement_strategy(
 
     1. If MeasurementStrategy instance (new API) + constructor computation_space provided
        → ERROR: user must move computation_space into the factory method
-    2. If measurement_strategy is None or MeasurementStrategy.NONE and computation_space provided
-       → ERROR: user must define a measurement strategy with the computation space inside
-    3. If measurement strategy factory is not None + constructor computation_space
-       → ERROR: user must define the computation space inside the measurement strategy
-    4. If MeasurementStrategy instance only → use its computation_space
-    5. If MeasurementStrategy.NONE -> use amplitudes with the default computation space
+    2. If MeasurementStrategy instance only → use its computation_space
+    3. If MeasurementStrategy.NONE -> use amplitudes with the default computation space
 
     """
     from ..measurement.strategies import (

--- a/tests/algorithms/test_dtype_propagation.py
+++ b/tests/algorithms/test_dtype_propagation.py
@@ -120,9 +120,9 @@ class TestQuantumLayerDtypePropagation:
         )
 
         mask = qlayer.measurement_mapping.mask
-        assert mask.dtype == torch.float64, (
-            f"Expected mask dtype=torch.float64, got {mask.dtype}"
-        )
+        assert (
+            mask.dtype == torch.float64
+        ), f"Expected mask dtype=torch.float64, got {mask.dtype}"
 
     def test_mode_expectations_float32_mask_dtype(self, circuit_2mode):
         """Verify float32 still works (backward compatibility)."""
@@ -291,7 +291,7 @@ class TestQuantumLayerDtypePropagation:
         self, circuit_2mode_no_params
     ):
         """
-        MeasurementStrategy.AMPLITUDES (amplitude_encoding=True):
+        MeasurementStrategy.amnplitudes() (amplitude_encoding=True):
         ensure dtype=torch.float32 leads to complex64 (torch.cfloat) amplitudes.
 
         IMPORTANT: use a circuit with *no symbolic parameters* to avoid requiring
@@ -311,9 +311,9 @@ class TestQuantumLayerDtypePropagation:
 
         psi_out = layer(psi_in)
 
-        assert psi_out.dtype == torch.cfloat, (
-            f"Expected AMPLITUDES output dtype=torch.cfloat, got {psi_out.dtype}"
-        )
+        assert (
+            psi_out.dtype == torch.cfloat
+        ), f"Expected AMPLITUDES output dtype=torch.cfloat, got {psi_out.dtype}"
         assert psi_out.shape in {(num_states,), (1, num_states)}
 
     def test_amplitudes_amplitude_encoding_float64_outputs_cdouble(
@@ -337,9 +337,9 @@ class TestQuantumLayerDtypePropagation:
 
         psi_out = layer(psi_in)
 
-        assert psi_out.dtype == torch.cdouble, (
-            f"Expected AMPLITUDES output dtype=torch.cdouble, got {psi_out.dtype}"
-        )
+        assert (
+            psi_out.dtype == torch.cdouble
+        ), f"Expected AMPLITUDES output dtype=torch.cdouble, got {psi_out.dtype}"
         assert psi_out.shape in {(num_states,), (1, num_states)}
 
 
@@ -386,9 +386,9 @@ class TestOriginalBugReproduction:
 
         # Verify mask dtype is now correct
         mask = qlayer.measurement_mapping.mask
-        assert mask.dtype == torch.float64, (
-            f"BUG NOT FIXED: mask dtype is {mask.dtype}, expected torch.float64"
-        )
+        assert (
+            mask.dtype == torch.float64
+        ), f"BUG NOT FIXED: mask dtype is {mask.dtype}, expected torch.float64"
 
         # Verify forward pass succeeds (this was the crash point)
         x = torch.zeros(1, 1, dtype=torch_dtype)

--- a/tests/algorithms/test_dtype_propagation.py
+++ b/tests/algorithms/test_dtype_propagation.py
@@ -320,7 +320,7 @@ class TestQuantumLayerDtypePropagation:
         self, circuit_2mode_no_params
     ):
         """
-        MeasurementStrategy.AMPLITUDES (amplitude_encoding=True):
+        MeasurementStrategy.amplitudes() (amplitude_encoding=True):
         ensure dtype=torch.float64 leads to complex128 (torch.cdouble) amplitudes.
         """
         layer = QuantumLayer(

--- a/tests/measurement/test_detectors.py
+++ b/tests/measurement/test_detectors.py
@@ -164,7 +164,7 @@ class TestDetectorsWithQuantumLayer:
 
         with pytest.raises(
             RuntimeError,
-            match="MeasurementStrategy\\.AMPLITUDES does not support experiments with detectors",
+            match=r"measurement_strategy=MeasurementStrategy\.amplitudes\(\) does not support experiments with detectors",
         ):
             ML.QuantumLayer(
                 input_size=0,
@@ -927,8 +927,12 @@ class TestDetectorsWithKernels:
         keys_pnr = kernel_pnr._quantum_layer._detector_transform.output_keys
         keys_threshold = kernel_threshold._quantum_layer._detector_transform.output_keys
 
-        assert kernel_pnr._quantum_layer._detector_transform.output_size == len(keys_pnr)
-        assert kernel_threshold._quantum_layer._detector_transform.output_size == len(keys_threshold)
+        assert kernel_pnr._quantum_layer._detector_transform.output_size == len(
+            keys_pnr
+        )
+        assert kernel_threshold._quantum_layer._detector_transform.output_size == len(
+            keys_threshold
+        )
         assert len(keys_pnr) > len(keys_threshold)
         assert all(sum(key) == sum(input_state) for key in keys_pnr)
         assert any(sum(key) < sum(input_state) for key in keys_threshold)
@@ -980,6 +984,6 @@ def test_detector_transform_row():
     transform = DetectorTransform(simulation_keys, detectors, partial_measurement=False)
     row = transform.row(index=0)
     expected = torch.tensor([1.0])
-    assert torch.allclose(row, expected), (
-        f"Unexpected value for row: got {row}, expected: {expected}"
-    )
+    assert torch.allclose(
+        row, expected
+    ), f"Unexpected value for row: got {row}, expected: {expected}"

--- a/tests/measurement/test_measurement_deprecations.py
+++ b/tests/measurement/test_measurement_deprecations.py
@@ -28,25 +28,40 @@ from merlin.core.computation_space import ComputationSpace
 
 
 class TestMeasurementStrategyDeprecations:
-    def test_probabilities_enum_raises_deprecation_warning(self):
-        with pytest.warns(DeprecationWarning, match="v0.4"):
+    def test_probabilities_enum_raises_deprecation_error(self):
+        with pytest.raises(
+            AttributeError,
+            match="v0.4",
+        ):
             _ = MeasurementStrategy.PROBABILITIES
 
-    def test_mode_expectations_enum_raises_deprecation_warning(self):
-        with pytest.warns(DeprecationWarning, match="v0.4"):
+    def test_mode_expectations_enum_raises_deprecation_error(self):
+        with pytest.raises(
+            AttributeError,
+            match="v0.4",
+        ):
             _ = MeasurementStrategy.MODE_EXPECTATIONS
 
-    def test_amplitudes_enum_raises_deprecation_warning(self):
-        with pytest.warns(DeprecationWarning, match="v0.4"):
+    def test_amplitudes_enum_raises_deprecation_error(self):
+        with pytest.raises(
+            AttributeError,
+            match="v0.4",
+        ):
             _ = MeasurementStrategy.AMPLITUDES
 
-    def test_deprecation_warning_includes_migration_hint(self):
-        with pytest.warns(DeprecationWarning, match="Use MeasurementStrategy.probs"):
+    def test_deprecation_error_includes_migration_hint(self):
+        with pytest.raises(
+            AttributeError,
+            match="Use MeasurementStrategy.probs",
+        ):
             _ = MeasurementStrategy.PROBABILITIES
 
     def test_deprecated_enum_still_works_in_quantum_layer(self):
         circuit = pcvl.Circuit(2)
-        with pytest.warns(DeprecationWarning):
+        with pytest.raises(
+            AttributeError,
+            match="Use MeasurementStrategy.probs",
+        ):
             layer = QuantumLayer(
                 input_size=0,
                 circuit=circuit,
@@ -54,10 +69,3 @@ class TestMeasurementStrategyDeprecations:
                 computation_space=ComputationSpace.FOCK,
                 measurement_strategy=MeasurementStrategy.PROBABILITIES,
             )
-        assert layer.measurement_strategy is not None
-
-    def test_multiple_enum_accesses_warn_each_time(self):
-        with pytest.warns(DeprecationWarning):
-            _ = MeasurementStrategy.PROBABILITIES
-        with pytest.warns(DeprecationWarning):
-            _ = MeasurementStrategy.PROBABILITIES

--- a/tests/measurement/test_measurement_deprecations.py
+++ b/tests/measurement/test_measurement_deprecations.py
@@ -49,6 +49,9 @@ class TestMeasurementStrategyDeprecations:
         ):
             _ = MeasurementStrategy.AMPLITUDES
 
+    def test_none_enum_raises_no_error(self):
+        _ = MeasurementStrategy.NONE
+
     def test_deprecation_error_includes_migration_hint(self):
         with pytest.raises(
             AttributeError,
@@ -56,7 +59,7 @@ class TestMeasurementStrategyDeprecations:
         ):
             _ = MeasurementStrategy.PROBABILITIES
 
-    def test_deprecated_enum_still_works_in_quantum_layer(self):
+    def test_deprecated_enum_fails_in_quantum_layer(self):
         circuit = pcvl.Circuit(2)
         with pytest.raises(
             AttributeError,
@@ -69,3 +72,233 @@ class TestMeasurementStrategyDeprecations:
                 computation_space=ComputationSpace.FOCK,
                 measurement_strategy=MeasurementStrategy.PROBABILITIES,
             )
+
+        with pytest.raises(
+            AttributeError,
+            match="Use MeasurementStrategy.amplitudes",
+        ):
+            layer = QuantumLayer(
+                input_size=0,
+                circuit=circuit,
+                input_state=[1, 0],
+                computation_space=ComputationSpace.FOCK,
+                measurement_strategy=MeasurementStrategy.AMPLITUDES,
+            )
+
+        with pytest.raises(
+            AttributeError,
+            match="Use MeasurementStrategy.mode_expectations",
+        ):
+            layer = QuantumLayer(
+                input_size=0,
+                circuit=circuit,
+                input_state=[1, 0],
+                computation_space=ComputationSpace.FOCK,
+                measurement_strategy=MeasurementStrategy.MODE_EXPECTATIONS,
+            )
+
+    def test_deprecated_enum_none_sill_passes_in_quantum_layer(self):
+        circuit = pcvl.Circuit(2)
+        layer = QuantumLayer(
+            input_size=0,
+            circuit=circuit,
+            input_state=[1, 0],
+            measurement_strategy=MeasurementStrategy.NONE,
+        )
+
+    def test_probabilities_str_raises_deprecation_error(self):
+        circuit = pcvl.Circuit(2)
+        with pytest.raises(
+            TypeError,
+            match="Passing measurement_strategy as a string is deprecated since v0.4.",
+        ):
+            layer = QuantumLayer(
+                input_size=0,
+                circuit=circuit,
+                input_state=[1, 0],
+                computation_space=ComputationSpace.FOCK,
+                measurement_strategy="PROBABILITIES",
+            )
+
+    def test_amplitudes_str_raises_deprecation_error(self):
+        circuit = pcvl.Circuit(2)
+        with pytest.raises(
+            TypeError,
+            match="Passing measurement_strategy as a string is deprecated since v0.4.",
+        ):
+            layer = QuantumLayer(
+                input_size=0,
+                circuit=circuit,
+                input_state=[1, 0],
+                computation_space=ComputationSpace.FOCK,
+                measurement_strategy="AMPLITUDES",
+            )
+
+    def test_mode_expectations_str_raises_deprecation_error(self):
+        circuit = pcvl.Circuit(2)
+        with pytest.raises(
+            TypeError,
+            match="Passing measurement_strategy as a string is deprecated since v0.4.",
+        ):
+            layer = QuantumLayer(
+                input_size=0,
+                circuit=circuit,
+                input_state=[1, 0],
+                computation_space=ComputationSpace.FOCK,
+                measurement_strategy="MODE_EXPECTATIONS",
+            )
+
+    def test_computation_space_in_constructor_fails(self):
+        circuit = pcvl.Circuit(2)
+        with pytest.raises(
+            AttributeError,
+            match="Passing 'computation_space' without an explicit measurement_strategy is deprecated since v0.4.",
+        ):
+            layer = QuantumLayer(
+                input_size=0,
+                circuit=circuit,
+                input_state=[1, 0],
+                computation_space=ComputationSpace.FOCK,
+            )
+        with pytest.raises(
+            AttributeError,
+            match="Cannot specify 'computation_space' in QuantumLayer's constructor.",
+        ):
+            layer = QuantumLayer(
+                input_size=0,
+                circuit=circuit,
+                input_state=[1, 0],
+                computation_space=ComputationSpace.FOCK,
+                measurement_strategy=MeasurementStrategy.probs(),
+            )
+        with pytest.raises(
+            AttributeError,
+            match="Cannot specify 'computation_space' in QuantumLayer's constructor.",
+        ):
+            layer = QuantumLayer(
+                input_size=0,
+                circuit=circuit,
+                input_state=[1, 0],
+                computation_space=ComputationSpace.FOCK,
+                measurement_strategy=MeasurementStrategy.amplitudes(),
+            )
+
+        with pytest.raises(
+            AttributeError,
+            match="Cannot specify 'computation_space' in QuantumLayer's constructor.",
+        ):
+            layer = QuantumLayer(
+                input_size=0,
+                circuit=circuit,
+                input_state=[1, 0],
+                computation_space=ComputationSpace.FOCK,
+                measurement_strategy=MeasurementStrategy.mode_expectations(),
+            )
+
+        with pytest.raises(
+            AttributeError,
+            match="Cannot specify 'computation_space' in QuantumLayer's constructor.",
+        ):
+            layer = QuantumLayer(
+                input_size=0,
+                circuit=circuit,
+                input_state=[1, 0],
+                computation_space=ComputationSpace.FOCK,
+                measurement_strategy=MeasurementStrategy.partial(modes=[0]),
+            )
+
+        with pytest.raises(
+            AttributeError,
+            match="Cannot specify 'computation_space' in QuantumLayer's constructor.",
+        ):
+            layer = QuantumLayer(
+                input_size=0,
+                circuit=circuit,
+                input_state=[1, 0],
+                computation_space=ComputationSpace.FOCK,
+                measurement_strategy=MeasurementStrategy.NONE,
+            )
+
+    def modern_factory_raises_no_error():
+        circuit = pcvl.Circuit(2)
+
+        layer = QuantumLayer(
+            input_size=0,
+            circuit=circuit,
+            input_state=[1, 0],
+        )
+
+        layer = QuantumLayer(
+            input_size=0,
+            circuit=circuit,
+            input_state=[1, 0],
+            measurement_strategy=MeasurementStrategy.NONE,
+        )
+
+        # probs
+        layer = QuantumLayer(
+            input_size=0,
+            circuit=circuit,
+            input_state=[1, 0],
+            measurement_strategy=MeasurementStrategy.probs(),
+        )
+
+        layer = QuantumLayer(
+            input_size=0,
+            circuit=circuit,
+            input_state=[1, 0],
+            measurement_strategy=MeasurementStrategy.probs(
+                computation_space=ComputationSpace.FOCK
+            ),
+        )
+
+        # amplitudes
+        layer = QuantumLayer(
+            input_size=0,
+            circuit=circuit,
+            input_state=[1, 0],
+            measurement_strategy=MeasurementStrategy.amplitudes(),
+        )
+
+        layer = QuantumLayer(
+            input_size=0,
+            circuit=circuit,
+            input_state=[1, 0],
+            measurement_strategy=MeasurementStrategy.amplitudes(
+                computation_space=ComputationSpace.FOCK
+            ),
+        )
+
+        # mode expectation
+        layer = QuantumLayer(
+            input_size=0,
+            circuit=circuit,
+            input_state=[1, 0],
+            measurement_strategy=MeasurementStrategy.mode_expectations(),
+        )
+
+        layer = QuantumLayer(
+            input_size=0,
+            circuit=circuit,
+            input_state=[1, 0],
+            measurement_strategy=MeasurementStrategy.mode_expectations(
+                computation_space=ComputationSpace.FOCK
+            ),
+        )
+
+        # Partial
+        layer = QuantumLayer(
+            input_size=0,
+            circuit=circuit,
+            input_state=[1, 0],
+            measurement_strategy=MeasurementStrategy.partial(modes=[0]),
+        )
+
+        layer = QuantumLayer(
+            input_size=0,
+            circuit=circuit,
+            input_state=[1, 0],
+            measurement_strategy=MeasurementStrategy.partial(
+                modes=[0], computation_space=ComputationSpace.FOCK
+            ),
+        )

--- a/tests/measurement/test_measurement_deprecations.py
+++ b/tests/measurement/test_measurement_deprecations.py
@@ -110,7 +110,7 @@ class TestMeasurementStrategyDeprecations:
         circuit = pcvl.Circuit(2)
         with pytest.raises(
             TypeError,
-            match="Passing measurement_strategy as a string is deprecated since v0.4.",
+            match="Passing measurement_strategy as a string is no longer supported as of v0.4.",
         ):
             layer = QuantumLayer(
                 input_size=0,
@@ -124,7 +124,7 @@ class TestMeasurementStrategyDeprecations:
         circuit = pcvl.Circuit(2)
         with pytest.raises(
             TypeError,
-            match="Passing measurement_strategy as a string is deprecated since v0.4.",
+            match="Passing measurement_strategy as a string is no longer supported as of v0.4.",
         ):
             layer = QuantumLayer(
                 input_size=0,
@@ -138,7 +138,7 @@ class TestMeasurementStrategyDeprecations:
         circuit = pcvl.Circuit(2)
         with pytest.raises(
             TypeError,
-            match="Passing measurement_strategy as a string is deprecated since v0.4.",
+            match="Passing measurement_strategy as a string is no longer supported as of v0.4.",
         ):
             layer = QuantumLayer(
                 input_size=0,
@@ -152,7 +152,7 @@ class TestMeasurementStrategyDeprecations:
         circuit = pcvl.Circuit(2)
         with pytest.raises(
             AttributeError,
-            match="Passing 'computation_space' without an explicit measurement_strategy is deprecated since v0.4.",
+            match="Passing 'computation_space' without an explicit measurement_strategy is no longer supported as of v0.4.",
         ):
             layer = QuantumLayer(
                 input_size=0,

--- a/tests/measurement/test_measurement_deprecations.py
+++ b/tests/measurement/test_measurement_deprecations.py
@@ -116,7 +116,6 @@ class TestMeasurementStrategyDeprecations:
                 input_size=0,
                 circuit=circuit,
                 input_state=[1, 0],
-                computation_space=ComputationSpace.FOCK,
                 measurement_strategy="PROBABILITIES",
             )
 
@@ -130,7 +129,6 @@ class TestMeasurementStrategyDeprecations:
                 input_size=0,
                 circuit=circuit,
                 input_state=[1, 0],
-                computation_space=ComputationSpace.FOCK,
                 measurement_strategy="AMPLITUDES",
             )
 
@@ -144,7 +142,6 @@ class TestMeasurementStrategyDeprecations:
                 input_size=0,
                 circuit=circuit,
                 input_state=[1, 0],
-                computation_space=ComputationSpace.FOCK,
                 measurement_strategy="MODE_EXPECTATIONS",
             )
 
@@ -152,7 +149,7 @@ class TestMeasurementStrategyDeprecations:
         circuit = pcvl.Circuit(2)
         with pytest.raises(
             AttributeError,
-            match="Passing 'computation_space' without an explicit measurement_strategy is no longer supported as of v0.4.",
+            match="Cannot specify 'computation_space' in QuantumLayer's constructor. Move",
         ):
             layer = QuantumLayer(
                 input_size=0,

--- a/tests/measurement/test_measurement_strategy.py
+++ b/tests/measurement/test_measurement_strategy.py
@@ -991,7 +991,7 @@ class TestComputationSpaceConflictResolution:
         assert layer.measurement_strategy.type == MeasurementKind.PROBABILITIES
 
     def test_constructor_computation_space_fails(self):
-        """Legacy enum (PROBABILITIES) with constructor computation_space should WARN but work."""
+        """Legacy enum (PROBABILITIES) with constructor computation_space should fail."""
         builder = ML.CircuitBuilder(n_modes=3)
         builder.add_entangling_layer(trainable=True, name="U1")
         builder.add_angle_encoding(modes=[0, 1], name="input")
@@ -1010,7 +1010,7 @@ class TestComputationSpaceConflictResolution:
             )
 
     def test_new_ms_without_constructor_computation_space_defaults(self):
-        """Legacy enum without computation_space should default to UNBUNCHED."""
+        """New factory method should default to UNBUNCHED."""
         builder = ML.CircuitBuilder(n_modes=3)
         builder.add_entangling_layer(trainable=True, name="U1")
         builder.add_angle_encoding(modes=[0, 1], name="input")

--- a/tests/measurement/test_measurement_strategy.py
+++ b/tests/measurement/test_measurement_strategy.py
@@ -405,13 +405,12 @@ class TestQuantumLayerMeasurementStrategy:
 
         x = torch.rand(2, 2)
 
-        with pytest.warns(DeprecationWarning):
-            legacy_layer = ML.QuantumLayer(
-                input_size=2,
-                n_photons=2,
-                builder=builder,
-                measurement_strategy=ML.MeasurementStrategy.PROBABILITIES,
-            )
+        legacy_layer = ML.QuantumLayer(
+            input_size=2,
+            n_photons=2,
+            builder=builder,
+            measurement_strategy=ML.MeasurementStrategy.probs(),
+        )
 
         legacy_output = legacy_layer(x)
         grouping_cases = [
@@ -442,19 +441,6 @@ class TestQuantumLayerMeasurementStrategy:
 
 
 def test_resolve_measurement_strategy():
-    with pytest.warns(DeprecationWarning):
-        assert isinstance(
-            resolve_measurement_strategy(MeasurementStrategy.PROBABILITIES),
-            ProbabilitiesStrategy,
-        )
-        assert isinstance(
-            resolve_measurement_strategy(MeasurementStrategy.MODE_EXPECTATIONS),
-            ModeExpectationsStrategy,
-        )
-        assert isinstance(
-            resolve_measurement_strategy(MeasurementStrategy.AMPLITUDES),
-            AmplitudesStrategy,
-        )
     assert isinstance(
         resolve_measurement_strategy(MeasurementStrategy.probs()),
         ProbabilitiesStrategy,
@@ -938,7 +924,7 @@ class TestComputationSpaceConflictResolution:
         builder.add_entangling_layer(trainable=True, name="U1")
         builder.add_angle_encoding(modes=[0, 1], name="input")
 
-        with pytest.raises(TypeError, match="Cannot specify 'computation_space'"):
+        with pytest.raises(AttributeError, match="Cannot specify 'computation_space'"):
             ML.QuantumLayer(
                 input_size=2,
                 n_photons=1,
@@ -956,7 +942,7 @@ class TestComputationSpaceConflictResolution:
         builder.add_entangling_layer(trainable=True, name="U1")
         builder.add_angle_encoding(modes=[0, 1], name="input")
 
-        with pytest.raises(TypeError, match="Cannot specify 'computation_space'"):
+        with pytest.raises(AttributeError, match="Cannot specify 'computation_space'"):
             ML.QuantumLayer(
                 input_size=2,
                 n_photons=1,
@@ -973,7 +959,7 @@ class TestComputationSpaceConflictResolution:
         builder.add_entangling_layer(trainable=True, name="U1")
         builder.add_angle_encoding(modes=[0, 1], name="input")
 
-        with pytest.raises(TypeError, match="Cannot specify 'computation_space'"):
+        with pytest.raises(AttributeError, match="Cannot specify 'computation_space'"):
             ML.QuantumLayer(
                 input_size=2,
                 n_photons=1,
@@ -1004,36 +990,36 @@ class TestComputationSpaceConflictResolution:
         assert layer.computation_space == ComputationSpace.FOCK
         assert layer.measurement_strategy.type == MeasurementKind.PROBABILITIES
 
-    def test_legacy_enum_with_constructor_computation_space_warns(self):
+    def test_constructor_computation_space_fails(self):
         """Legacy enum (PROBABILITIES) with constructor computation_space should WARN but work."""
         builder = ML.CircuitBuilder(n_modes=3)
         builder.add_entangling_layer(trainable=True, name="U1")
         builder.add_angle_encoding(modes=[0, 1], name="input")
         builder.add_entangling_layer(trainable=True, name="U2")
 
-        with pytest.warns(DeprecationWarning, match="deprecated"):
+        with pytest.raises(
+            AttributeError,
+            match="Cannot specify 'computation_space' in QuantumLayer's constructor. ",
+        ):
             layer = ML.QuantumLayer(
                 input_size=2,
                 n_photons=1,
                 builder=builder,
                 computation_space=ComputationSpace.FOCK,
-                measurement_strategy=MeasurementStrategy.PROBABILITIES,
+                measurement_strategy=MeasurementStrategy.probs(),
             )
-        # Should have used the constructor computation_space
-        assert layer.computation_space == ComputationSpace.FOCK
 
-    def test_legacy_enum_without_constructor_computation_space_defaults(self):
+    def test_new_ms_without_constructor_computation_space_defaults(self):
         """Legacy enum without computation_space should default to UNBUNCHED."""
         builder = ML.CircuitBuilder(n_modes=3)
         builder.add_entangling_layer(trainable=True, name="U1")
         builder.add_angle_encoding(modes=[0, 1], name="input")
 
-        with pytest.warns(DeprecationWarning):
-            layer = ML.QuantumLayer(
-                input_size=2,
-                n_photons=1,
-                builder=builder,
-                measurement_strategy=MeasurementStrategy.PROBABILITIES,
-            )
+        layer = ML.QuantumLayer(
+            input_size=2,
+            n_photons=1,
+            builder=builder,
+            measurement_strategy=MeasurementStrategy.probs(),
+        )
         # Should default to UNBUNCHED
         assert layer.computation_space == ComputationSpace.UNBUNCHED

--- a/tests/measurement/test_photon_loss.py
+++ b/tests/measurement/test_photon_loss.py
@@ -114,7 +114,7 @@ class TestPhotonLossWithQuantumLayer:
 
         with pytest.raises(
             RuntimeError,
-            match="measurement_strategy=MeasurementStrategy.AMPLITUDES cannot be used when the experiment defines a NoiseModel.",
+            match=r"measurement_strategy=MeasurementStrategy\.amplitudes\(\) cannot be used when the experiment defines a NoiseModel.",
         ):
             ML.QuantumLayer(
                 input_size=0,
@@ -447,11 +447,13 @@ class TestPhotonLossWithQuantumLayer:
         layer.train()
         probabilities = layer(x)
         probabilities = probabilities
-        target = torch.tensor([
-            [0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
-            [0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
-            [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
-        ])
+        target = torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+            ]
+        )
 
         cel = torch.nn.CrossEntropyLoss()
         loss = cel(probabilities, target)
@@ -676,7 +678,9 @@ class TestPhotonLossWithFidelityKernel:
         keys_noise = kernel_noise._quantum_layer._detector_transform.output_keys
 
         assert kernel._quantum_layer._detector_transform.output_size == len(keys)
-        assert kernel_noise._quantum_layer._detector_transform.output_size == len(keys_noise)
+        assert kernel_noise._quantum_layer._detector_transform.output_size == len(
+            keys_noise
+        )
         assert len(keys) < len(keys_noise)
         assert all(sum(key) == sum(input_state) for key in keys)
         assert any(sum(key) < sum(input_state) for key in keys_noise)


### PR DESCRIPTION
## Summary
Complete the deprecation of the MeaurementStrategy enum object. Warnings are not errors.

## Related Issue
PML-351

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor / Cleanup
- [ ] Performance improvement
- [ ] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)


## Proposed changes
- Removed the enum type object for MeaurementStrategy.
   - Like it is mentionned in the ticket: Kept the MeasurmentStrategy.None object.
   - Respected in general the guidelines of deprecations at the top of the merlin/measurement/strategies.py file. Diverted from this plan to keep the None strategy
- Previous warnings that were thrown for enum-type measurement stratgies now fail and now public acess to the enum style probs, amplitude and mode expectation is now possible. 
- Cleaned the documentation so that no reference to enum-style measurement strategy is present.

## How to test / How to run
```
pytest -q
```

## Documentation
- [x] User docs updated (Sphinx)
- [x] Examples / notebooks updated
- [x] Docstrings updated
- [ ] Updated the API