### PR TITLE
Claude Review (from upstream branch)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,7 +1,6 @@
 name: Claude Code
 
 on:
-  workflow_dispatch:
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -12,8 +11,7 @@ on:
 jobs:
   check-membership:
     if: |
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
     runs-on: ubuntu-latest
@@ -80,6 +78,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          additional_permissions: |
+            actions: read
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,10 +22,15 @@ jobs:
     outputs:
       is-member: ${{ steps.check.outputs.is-member }}
     steps:
-      - name: Validate GitHub App private key
+      - name: Validate GitHub App credentials
         env:
+          CLAUDE_APP_CLIENT_ID: ${{ vars.CLAUDE_APP_CLIENT_ID }}
           CLAUDE_APP_PRIVATE_KEY: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
         run: |
+          if [ -z "$CLAUDE_APP_CLIENT_ID" ]; then
+            echo "::error::Repository variable CLAUDE_APP_CLIENT_ID is empty or missing."
+            exit 1
+          fi
           if [ -z "$CLAUDE_APP_PRIVATE_KEY" ]; then
             echo "::error::Repository secret CLAUDE_APP_PRIVATE_KEY is empty or missing."
             exit 1
@@ -35,9 +40,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: 4019885
+          client-id: ${{ vars.CLAUDE_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
 
       - name: Check if user is organization member
         id: check

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,8 +28,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          appId: 4019885
-          privateKey: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+          app-id: 4019885
+          private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
 
       - name: Check if user is organization member
         id: check

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,23 +10,6 @@ on:
 
 jobs:
   claude:
-    if: |
-      (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        contains(github.event.comment.body, '@claude') &&
-        contains(fromJSON('["OWNER","MEMBER"]'), github.event.comment.author_association)
-      ) ||
-      (
-        github.event_name == 'pull_request_review_comment' &&
-        contains(github.event.comment.body, '@claude') &&
-        contains(fromJSON('["OWNER","MEMBER"]'), github.event.comment.author_association)
-      ) ||
-      (
-        github.event_name == 'pull_request_review' &&
-        contains(github.event.review.body, '@claude') &&
-        contains(fromJSON('["OWNER","MEMBER"]'), github.event.review.author_association)
-      )
     runs-on: ubuntu-latest
     permissions:
       contents: read         # Read-only access to code
@@ -34,12 +17,54 @@ jobs:
       id-token: write        # Required for authentication
       actions: read          # Required for Claude to read CI results on PRs
     steps:
+      - name: Check Claude trigger authorization
+        id: authorize
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const trustedAssociations = new Set(['OWNER', 'MEMBER']);
+            const eventName = context.eventName;
+            const payload = context.payload;
+
+            let body = '';
+            let authorAssociation = '';
+            let isPullRequestEvent = false;
+
+            if (eventName === 'issue_comment') {
+              body = payload.comment?.body ?? '';
+              authorAssociation = payload.comment?.author_association ?? '';
+              isPullRequestEvent = Boolean(payload.issue?.pull_request);
+            } else if (eventName === 'pull_request_review_comment') {
+              body = payload.comment?.body ?? '';
+              authorAssociation = payload.comment?.author_association ?? '';
+              isPullRequestEvent = true;
+            } else if (eventName === 'pull_request_review') {
+              body = payload.review?.body ?? '';
+              authorAssociation = payload.review?.author_association ?? '';
+              isPullRequestEvent = true;
+            }
+
+            const hasTriggerPhrase = body.toLowerCase().includes('@claude');
+            const isTrustedActor = trustedAssociations.has(authorAssociation);
+            const isAuthorized = isPullRequestEvent && hasTriggerPhrase && isTrustedActor;
+
+            core.info(`event_name=${eventName}`);
+            core.info(`actor=${context.actor}`);
+            core.info(`author_association=${authorAssociation || 'unknown'}`);
+            core.info(`is_pull_request_event=${isPullRequestEvent}`);
+            core.info(`has_trigger_phrase=${hasTriggerPhrase}`);
+            core.info(`is_trusted_actor=${isTrustedActor}`);
+
+            core.setOutput('authorized', String(isAuthorized));
+
       - name: Checkout repository
+        if: steps.authorize.outputs.authorized == 'true'
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
+        if: steps.authorize.outputs.authorized == 'true'
         id: claude
         uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,23 +17,31 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:
       contents: read
     outputs:
       is-member: ${{ steps.check.outputs.is-member }}
     steps:
+      - name: Validate GitHub App private key
+        env:
+          CLAUDE_APP_PRIVATE_KEY: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+        run: |
+          if [ -z "$CLAUDE_APP_PRIVATE_KEY" ]; then
+            echo "::error::Repository secret CLAUDE_APP_PRIVATE_KEY is empty or missing."
+            exit 1
+          fi
+
       - name: Create GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: 4019885
           private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Check if user is organization member
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -59,7 +67,7 @@ jobs:
       actions: read          # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,10 +20,18 @@ jobs:
     outputs:
       is-member: ${{ steps.check.outputs.is-member }}
     steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 4019885
+          private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+
       - name: Check if user is organization member
         id: check
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             try {
               await github.rest.orgs.checkMembershipForUser({

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -23,12 +23,14 @@ jobs:
         with:
           script: |
             const trustedAssociations = new Set(['OWNER', 'MEMBER']);
+            const trustedPermissions = new Set(['admin', 'maintain', 'write']);
             const eventName = context.eventName;
             const payload = context.payload;
 
             let body = '';
             let authorAssociation = '';
             let isPullRequestEvent = false;
+            let repositoryPermission = 'unknown';
 
             if (eventName === 'issue_comment') {
               body = payload.comment?.body ?? '';
@@ -42,15 +44,41 @@ jobs:
               body = payload.review?.body ?? '';
               authorAssociation = payload.review?.author_association ?? '';
               isPullRequestEvent = true;
+
+              const reviewComments = await github.paginate(
+                'GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments',
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: payload.pull_request.number,
+                  review_id: payload.review.id,
+                  per_page: 100,
+                }
+              );
+              body = [body, ...reviewComments.map((comment) => comment.body ?? '')].join('\n');
+            }
+
+            try {
+              const response = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: context.actor,
+              });
+              repositoryPermission = response.data.permission;
+            } catch (error) {
+              core.info(`repository_permission_lookup_failed=${error.status ?? error.message}`);
             }
 
             const hasTriggerPhrase = body.toLowerCase().includes('@claude');
-            const isTrustedActor = trustedAssociations.has(authorAssociation);
+            const isTrustedActor =
+              trustedAssociations.has(authorAssociation) ||
+              trustedPermissions.has(repositoryPermission);
             const isAuthorized = isPullRequestEvent && hasTriggerPhrase && isTrustedActor;
 
             core.info(`event_name=${eventName}`);
             core.info(`actor=${context.actor}`);
             core.info(`author_association=${authorAssociation || 'unknown'}`);
+            core.info(`repository_permission=${repositoryPermission}`);
             core.info(`is_pull_request_event=${isPullRequestEvent}`);
             core.info(`has_trigger_phrase=${hasTriggerPhrase}`);
             core.info(`is_trusted_actor=${isTrustedActor}`);

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Create GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: 4019885
           private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
@@ -57,7 +57,7 @@ jobs:
       actions: read          # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,8 +26,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: 4019885
-          private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+          app_id: 4019885
+          private_key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
 
       - name: Check if user is organization member
         id: check

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,81 @@
+name: Claude Code
+
+on:
+  workflow_dispatch:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  check-membership:
+    if: |
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      is-member: ${{ steps.check.outputs.is-member }}
+    steps:
+      - name: Check if user is organization member
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.orgs.checkMembershipForUser({
+                org: context.repo.owner,
+                username: context.actor
+              });
+              core.setOutput('is-member', 'true');
+            } catch (error) {
+              core.setOutput('is-member', 'false');
+              core.setFailed(`User ${context.actor} is not a member of ${context.repo.owner}`);
+            }
+
+  claude:
+    needs: check-membership
+    if: needs.check-membership.outputs.is-member == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read         # Read-only access to code
+      pull-requests: write   # Can post comments/reviews on PRs
+      id-token: write        # Required for authentication
+      actions: read          # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Optional: Customize the trigger phrase (default: @claude)
+          # trigger_phrase: "/claude"
+
+          # Optional: Trigger when specific user is assigned to an issue
+          # assignee_trigger: "claude-bot"
+
+          # Optional: Configure Claude's behavior with CLI arguments
+          # claude_args: |
+          #   --model claude-opus-4-1-20250805
+          #   --max-turns 10
+          #   --allowedTools "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+          #   --system-prompt "Follow our coding standards. Ensure all new code has tests. Use TypeScript for new files."
+
+          # Optional: Advanced settings configuration
+          # settings: |
+          #   {
+          #     "env": {
+          #       "NODE_ENV": "test"
+          #     }
+          #   }

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -2,6 +2,8 @@ name: Claude Code
 
 on:
   workflow_dispatch:
+  issue_comment:
+    types: [created]
   pull_request_review_comment:
     types: [created]
   pull_request_review:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,58 +9,24 @@ on:
     types: [submitted]
 
 jobs:
-  check-membership:
-    if: |
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      is-member: ${{ steps.check.outputs.is-member }}
-    steps:
-      - name: Validate GitHub App credentials
-        env:
-          CLAUDE_APP_CLIENT_ID: ${{ vars.CLAUDE_APP_CLIENT_ID }}
-          CLAUDE_APP_PRIVATE_KEY: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
-        run: |
-          if [ -z "$CLAUDE_APP_CLIENT_ID" ]; then
-            echo "::error::Repository variable CLAUDE_APP_CLIENT_ID is empty or missing."
-            exit 1
-          fi
-          if [ -z "$CLAUDE_APP_PRIVATE_KEY" ]; then
-            echo "::error::Repository secret CLAUDE_APP_PRIVATE_KEY is empty or missing."
-            exit 1
-          fi
-
-      - name: Create GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ vars.CLAUDE_APP_CLIENT_ID }}
-          private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
-
-      - name: Check if user is organization member
-        id: check
-        uses: actions/github-script@v9
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-            try {
-              await github.rest.orgs.checkMembershipForUser({
-                org: context.repo.owner,
-                username: context.actor
-              });
-              core.setOutput('is-member', 'true');
-            } catch (error) {
-              core.setOutput('is-member', 'false');
-              core.setFailed(`User ${context.actor} is not a member of ${context.repo.owner}`);
-            }
-
   claude:
-    needs: check-membership
-    if: needs.check-membership.outputs.is-member == 'true'
+    if: |
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER"]'), github.event.review.author_association)
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read         # Read-only access to code

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -2,8 +2,6 @@ name: Claude Code
 
 on:
   workflow_dispatch:
-  issue_comment:
-    types: [created]
   pull_request_review_comment:
     types: [created]
   pull_request_review:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,6 +17,8 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:
       contents: read
     outputs:
@@ -26,8 +28,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app_id: 4019885
-          private_key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+          appId: 4019885
+          privateKey: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
 
       - name: Check if user is organization member
         id: check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers=[
 
 dependencies = [
     "torch>=2.0.0,<=2.10.0",
-    "perceval-quandela>=0.13.1",
+    "perceval-quandela>=0.13.1,<=1.1",
     "numpy>=2.2.6",
     "pandas",
     "scikit-learn>=1.7.2",


### PR DESCRIPTION
<!--
Thank you for contributing to MerLin!
Please fill out the sections below to help us review your PR efficiently.

NOTE: this repo is a public repository, therefore, do NOT paste Jira URLs. Use the Jira issue key only (e.g., PML-126).
The Jira–GitHub integration will link PRs/commits automatically when the key is present.
-->

<!-- Add the Jira issue key in the title -->
<!-- e.g., PML-126 Updating PR template -->

## Summary
<!-- What does this PR do? A clear, concise description. -->
This PR introduces a new GitHub Actions workflow that enables Claude to provide automated code reviews on pull requests, with security controls to restrict access to organization members.
Features

- On-demand code reviews: Members can request Claude reviews by commenting @claude on PRs, issues, or review comments
- Manual trigger option: Alternatively, trigger reviews manually via GitHub Actions > Claude Code > Run workflow
- Organization member verification: Workflow automatically verifies that the requesting user is an organization member before running
- Comments-only access: Claude has read-only access to code and can post review comments but cannot make direct modifications
- CI-aware reviews: Claude can read CI results to provide context-aware feedback

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / Cleanup
- [ ] Performance improvement
- [x] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)


## Proposed changes
<!-- Bulleted list of key changes. If API changes, list them explicitly. -->
How to Use
Automatic trigger: simply comment @claude anywhere on a PR, and the workflow will automatically trigger.

Manual trigger:
- Go to Actions → Claude Code
- Click Run workflow
- Claude will review the current PR

Permissions

- contents: read — Read-only access to code and tests
- pull-requests: write — Can post comments and reviews
- id-token: write — Authentication with Anthropic API
- actions: read — Access to CI results

Security

- Membership check ensures only organization members can trigger reviews
- No write access to code (comments only)
- Supports ANTHROPIC_API_KEY secret for API authentication

