### PR TITLE
Claude workflow for PR review

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,119 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read         # Read-only access to code
+      pull-requests: write   # Can post comments/reviews on PRs
+      id-token: write        # Required for authentication
+      actions: read          # Required for Claude to read CI results on PRs
+    steps:
+      - name: Check Claude trigger authorization
+        id: authorize
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const trustedPermissions = new Set(['admin', 'maintain', 'write']);
+            const eventName = context.eventName;
+            const payload = context.payload;
+
+            let body = '';
+            let authorAssociation = '';
+            let isPullRequestEvent = false;
+            let repositoryPermission = 'unknown';
+
+            if (eventName === 'issue_comment') {
+              body = payload.comment?.body ?? '';
+              authorAssociation = payload.comment?.author_association ?? '';
+              isPullRequestEvent = Boolean(payload.issue?.pull_request);
+            } else if (eventName === 'pull_request_review_comment') {
+              body = payload.comment?.body ?? '';
+              authorAssociation = payload.comment?.author_association ?? '';
+              isPullRequestEvent = true;
+            } else if (eventName === 'pull_request_review') {
+              body = payload.review?.body ?? '';
+              authorAssociation = payload.review?.author_association ?? '';
+              isPullRequestEvent = true;
+
+              const reviewComments = await github.paginate(
+                'GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments',
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: payload.pull_request.number,
+                  review_id: payload.review.id,
+                  per_page: 100,
+                }
+              );
+              body = [body, ...reviewComments.map((comment) => comment.body ?? '')].join('\n');
+            }
+
+            try {
+              const response = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: context.actor,
+              });
+              repositoryPermission = response.data.permission;
+            } catch (error) {
+              core.info(`repository_permission_lookup_failed=${error.status ?? error.message}`);
+            }
+
+            const hasTriggerPhrase = body.toLowerCase().includes('@claude');
+            const isTrustedActor = trustedPermissions.has(repositoryPermission);
+            const isAuthorized = isPullRequestEvent && hasTriggerPhrase && isTrustedActor;
+
+            core.info(`event_name=${eventName}`);
+            core.info(`actor=${context.actor}`);
+            core.info(`author_association=${authorAssociation || 'unknown'}`);
+            core.info(`repository_permission=${repositoryPermission}`);
+            core.info(`is_pull_request_event=${isPullRequestEvent}`);
+            core.info(`has_trigger_phrase=${hasTriggerPhrase}`);
+            core.info(`is_trusted_actor=${isTrustedActor}`);
+
+            core.setOutput('authorized', String(isAuthorized));
+
+      - name: Checkout repository
+        if: steps.authorize.outputs.authorized == 'true'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        if: steps.authorize.outputs.authorized == 'true'
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          additional_permissions: |
+            actions: read
+
+          # Optional: Customize the trigger phrase (default: @claude)
+          # trigger_phrase: "/claude"
+
+          # Optional: Trigger when specific user is assigned to an issue
+          # assignee_trigger: "claude-bot"
+
+          # Optional: Configure Claude's behavior with CLI arguments
+          # claude_args: |
+          #   --model claude-opus-4-1-20250805
+          #   --max-turns 10
+          #   --allowedTools "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+          #   --system-prompt "Follow our coding standards. Ensure all new code has tests. Use TypeScript for new files."
+
+          # Optional: Advanced settings configuration
+          # settings: |
+          #   {
+          #     "env": {
+          #       "NODE_ENV": "test"
+          #     }
+          #   }

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,18 +44,6 @@ jobs:
               body = payload.review?.body ?? '';
               authorAssociation = payload.review?.author_association ?? '';
               isPullRequestEvent = true;
-
-              const reviewComments = await github.paginate(
-                'GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments',
-                {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: payload.pull_request.number,
-                  review_id: payload.review.id,
-                  per_page: 100,
-                }
-              );
-              body = [body, ...reviewComments.map((comment) => comment.body ?? '')].join('\n');
             }
 
             try {

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: read         # Read-only access to code
       pull-requests: write   # Can post comments/reviews on PRs
+      issues: write          # Can reply to PR conversation comments
       id-token: write        # Required for authentication
       actions: read          # Required for Claude to read CI results on PRs
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers=[
 
 dependencies = [
     "torch>=2.0.0,<=2.10.0",
-    "perceval-quandela>=0.13.1",
+    "perceval-quandela>=0.13.1,<=1.1",
     "numpy>=2.2.6",
     "pandas",
     "scikit-learn>=1.7.2",


### PR DESCRIPTION
## Summary
Adds a Claude Code GitHub Actions workflow that can be triggered from PR comments/reviews with `@claude`, restricted to trusted repository collaborators only. 
Also caps `perceval-quandela` to avoid incompatible versions on main. 1.2 version will be supported in 0.4 release


## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / Cleanup
- [ ] Performance improvement
- [x] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)

## Proposed changes
- Add `.github/workflows/claude.yml`.
- Enable Claude Code on:
  - PR issue comments
  - PR review comments
  - submitted PR reviews
- Require the trigger text `@claude`.
- Restrict execution to actors with effective repository permission `write`, `maintain`, or `admin`.
- Keep workflow permissions scoped to read repository contents, read actions, write PR comments/reviews, and OIDC auth.
- Add a `perceval-quandela<=1.1` upper bound in `pyproject.toml`.

## To test
You can comment @claude review and observe the Actions
No review should run because my dev branch is not the default branch so the workflow does not run. It should run once it is merged on main