### PR TITLE
PML-311: torch 2.11 and 2.12 support in Merlin v0.4

### DIFF
--- a/merlin/pcvl_pytorch/slos_torchscript.py
+++ b/merlin/pcvl_pytorch/slos_torchscript.py
@@ -347,7 +347,8 @@ class SLOSComputeGraph:
             Number of photons in the input state given to the model during the
             forward pass.
         output_map_func : Callable[[tuple[int, ...]], tuple[int, ...] | None] | None
-            Function applied to output states before aggregation.
+            Function applied to output states before aggregation. It changes the output keys directly.
+            The output tensor is not changed nor permuted, only the keys are changed.
         computation_space : ComputationSpace
             Computation subspace used to build the graph. Default is
             ``ComputationSpace.UNBUNCHED``.
@@ -1048,7 +1049,9 @@ def build_slos_distribution_computegraph(
     n_photons : int
         Total number of photons injected in the circuit.
     output_map_func : Callable[[tuple[int, ...]], tuple[int, ...] | None] | None
-        Mapping applied to each output Fock state, allowing post-processing.
+        Mapping applied to each output Fock state, allowing post-processing. It changes
+        the output keys directly. The output tensor is not changed nor permuted, only the
+        keys are changed.
     computation_space : ComputationSpace | None
         Logical computation subspace used to build the basis and transitions.
         When omitted, defaults to ``ComputationSpace.UNBUNCHED``.
@@ -1247,7 +1250,8 @@ def compute_slos_distribution(
     input_state : list[int]
         Number of photons in every mode of the circuit.
     output_map_func : Callable[[tuple[int, ...]], tuple[int, ...] | None] | None
-        Function that maps output states.
+        Function that maps output states. It changes the output keys directly.
+        The output tensor is not changed nor permuted, only the keys are changed.
     computation_space : ComputationSpace
         Computation subspace used to build the graph. Default is
         ``ComputationSpace.UNBUNCHED``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers=[
 ]
 
 dependencies = [
-    "torch>=2.0.0,<=2.11.0",
+    "torch>=2.0.0,<=2.12.0",
     "perceval-quandela>=1.2.1",
     "numpy>=2.2.6",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers=[
 ]
 
 dependencies = [
-    "torch>=2.0.0,<=2.10.0",
+    "torch>=2.0.0,<=2.11.0",
     "perceval-quandela>=1.2.1",
     "numpy>=2.2.6",
     "pandas",

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,6 +13,8 @@ filterwarnings =
     ignore:Passing 'computation_space' as a separate argument with legacy.*:DeprecationWarning
     ignore:Passing 'computation_space' without an explicit measurement_strategy is deprecated.*:DeprecationWarning
     ignore:The 'remote_processor' argument is deprecated.*:DeprecationWarning
+    #Sparse verification removal in tests
+    ignore:Sparse invariant checks are implicitly disabled.*:UserWarning
     
     # Allow PML-142 deprecation warnings
     # TODO: Remove these once the tests reflect the new API

--- a/tests/algorithms/test_amplitude_encoding.py
+++ b/tests/algorithms/test_amplitude_encoding.py
@@ -341,17 +341,12 @@ def test_amplitude_encoding_sparse_superposition_matches_dense(make_layer):
     dense = torch.arange(1, num_states + 1, dtype=torch.float32).to(torch.complex64)
     dense = dense / dense.norm(p=2)
     indices = torch.arange(num_states, dtype=torch.long).unsqueeze(0)
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message="Sparse invariant checks are implicitly disabled.*",
-        )
-        sparse = torch.sparse_coo_tensor(
-            indices,
-            dense.clone(),
-            (num_states,),
-            dtype=torch.complex64,
-        ).coalesce()
+    sparse = torch.sparse_coo_tensor(
+        indices,
+        dense.clone(),
+        (num_states,),
+        dtype=torch.complex64,
+    ).coalesce()
 
     dense_output = layer(dense, simultaneous_processes=2)
     sparse_output = layer(sparse, simultaneous_processes=2)

--- a/tests/algorithms/test_amplitude_encoding.py
+++ b/tests/algorithms/test_amplitude_encoding.py
@@ -162,9 +162,9 @@ def test_amplitude_encoding_gradients_follow_computation_space(
     assert amplitude_input.grad.shape == amplitude_input.shape
 
     trainable_params = [p for p in layer.parameters() if p.requires_grad]
-    assert trainable_params, (
-        "Expected at least one trainable parameter for gradient check"
-    )
+    assert (
+        trainable_params
+    ), "Expected at least one trainable parameter for gradient check"
     for param in trainable_params:
         assert param.grad is not None
         assert param.grad.shape == param.shape
@@ -341,12 +341,17 @@ def test_amplitude_encoding_sparse_superposition_matches_dense(make_layer):
     dense = torch.arange(1, num_states + 1, dtype=torch.float32).to(torch.complex64)
     dense = dense / dense.norm(p=2)
     indices = torch.arange(num_states, dtype=torch.long).unsqueeze(0)
-    sparse = torch.sparse_coo_tensor(
-        indices,
-        dense.clone(),
-        (num_states,),
-        dtype=torch.complex64,
-    ).coalesce()
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="Sparse invariant checks are implicitly disabled.*",
+        )
+        sparse = torch.sparse_coo_tensor(
+            indices,
+            dense.clone(),
+            (num_states,),
+            dtype=torch.complex64,
+        ).coalesce()
 
     dense_output = layer(dense, simultaneous_processes=2)
     sparse_output = layer(sparse, simultaneous_processes=2)
@@ -883,9 +888,9 @@ def test_amplitude_encoding_superposition_matches_basis_sum():
     combined_output = layer(amplitude_input)
     expected_output = torch.sum(coefficients[:, None, None] * basis_outputs, dim=0)
     difference = combined_output - expected_output
-    assert torch.allclose(combined_output, expected_output, atol=1e-6, rtol=1e-6), (
-        f"Max deviation {difference.abs().max().item():.2e}"
-    )
+    assert torch.allclose(
+        combined_output, expected_output, atol=1e-6, rtol=1e-6
+    ), f"Max deviation {difference.abs().max().item():.2e}"
 
     with pytest.raises(ValueError, match="Amplitude input expects"):
         layer(torch.ones(layer.input_size + 1, dtype=torch.complex64))
@@ -1024,9 +1029,9 @@ def test_ebs_wrt_quantumlayer(
             single_unitary = single_layer.computation_process.converter.to_tensor(
                 *single_params
             )
-            assert torch.allclose(single_unitary, ebs_unitary, rtol=1e-6, atol=1e-8), (
-                "Expected identical unitaries between EBS and single-state layers."
-            )
+            assert torch.allclose(
+                single_unitary, ebs_unitary, rtol=1e-6, atol=1e-8
+            ), "Expected identical unitaries between EBS and single-state layers."
             assert (
                 single_layer.computation_process.simulation_graph.mapped_keys
                 == ebs_layer.computation_process.simulation_graph.mapped_keys
@@ -1044,6 +1049,6 @@ def test_ebs_wrt_quantumlayer(
         p=2, dim=1, keepdim=True
     ).clamp_min(1e-12)
     # TODO: investigate why this tests failed with rtol=1e-6, atol=1e-8
-    assert torch.allclose(ebs_output, expected_output, rtol=1e-4, atol=1e-6), (
-        "EBS output deviates from the superposed QuantumLayer results."
-    )
+    assert torch.allclose(
+        ebs_output, expected_output, rtol=1e-4, atol=1e-6
+    ), "EBS output deviates from the superposed QuantumLayer results."

--- a/tests/pcvl_pytorch/test_slos_torchscript.py
+++ b/tests/pcvl_pytorch/test_slos_torchscript.py
@@ -157,7 +157,10 @@ def test_slos_compute_slos_distribution_with_output_map_function():
         return state[::-1]
 
     output_map_func = reverse_state
-    with pytest.warns(DeprecationWarning, match=r"torch\.jit\.script.*deprecated"):
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"torch\.jit\.script.*(deprecated|not supported)",
+    ):
         keys, amplitudes = compute_slos_distribution(
             unitary=U_torch,
             input_state=input_state,

--- a/tests/pcvl_pytorch/test_slos_torchscript.py
+++ b/tests/pcvl_pytorch/test_slos_torchscript.py
@@ -104,20 +104,20 @@ def test_slos_save_load_computation_graph(get_tmp_file):
     # Test for vectorized_operations
     assert len(graph.vectorized_operations) == len(
         loaded_graph.vectorized_operations
-    ), sDoesntMatch + "vectorized_operations (length mismatch)"
+    ), (sDoesntMatch + "vectorized_operations (length mismatch)")
 
     for i, (tuple1, tuple2) in enumerate(
         zip(
             graph.vectorized_operations, loaded_graph.vectorized_operations, strict=True
         )
     ):
-        assert len(tuple1) == len(tuple2), (
-            f"{sDoesntMatch}vectorized_operations (tuple {i} length mismatch)"
-        )
+        assert len(tuple1) == len(
+            tuple2
+        ), f"{sDoesntMatch}vectorized_operations (tuple {i} length mismatch)"
         for j, (tensor1, tensor2) in enumerate(zip(tuple1, tuple2, strict=True)):
-            assert torch.equal(tensor1, tensor2), (
-                f"{sDoesntMatch}vectorized_operations (tuple {i}, tensor {j})"
-            )
+            assert torch.equal(
+                tensor1, tensor2
+            ), f"{sDoesntMatch}vectorized_operations (tuple {i}, tensor {j})"
 
     assert graph.final_keys == loaded_graph.final_keys, sDoesntMatch + "final_keys"
     assert graph.mapped_keys == loaded_graph.mapped_keys, sDoesntMatch + "mapped_keys"
@@ -153,18 +153,18 @@ def test_slos_compute_slos_distribution_with_output_map_function():
 
     # Can't output_map_func = reverse_state:
     # Error l.513 '@jit.script' : DeprecationWarning: `torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`
-    # def reverse_state(state):
-    #    return state[::-1]
-    output_map_func = None
+    def reverse_state(state):
+        return state[::-1]
 
-    keys, amplitudes = compute_slos_distribution(
-        unitary=U_torch,
-        input_state=input_state,
-        output_map_func=output_map_func,
-        keep_keys=True,
-        computation_space=ComputationSpace.FOCK,
-    )
-    print(amplitudes)
+    output_map_func = reverse_state
+    with pytest.warns(DeprecationWarning, match=r"torch\.jit\.script.*deprecated"):
+        keys, amplitudes = compute_slos_distribution(
+            unitary=U_torch,
+            input_state=input_state,
+            output_map_func=output_map_func,
+            keep_keys=True,
+            computation_space=ComputationSpace.FOCK,
+        )
 
     expected_keys = [
         (2, 0, 0, 0),
@@ -178,9 +178,10 @@ def test_slos_compute_slos_distribution_with_output_map_function():
         (0, 0, 1, 1),
         (0, 0, 0, 2),
     ]
-    assert keys == expected_keys, (
-        f"Keys do not match : expected {expected_keys}, calculated {keys}"
-    )
+    expected_keys = [i[::-1] for i in expected_keys]
+    assert (
+        keys == expected_keys
+    ), f"Keys do not match : expected {expected_keys}, calculated {keys}"
 
     expected_amplitudes = torch.tensor(
         [


### PR DESCRIPTION
## Summary
Allowing the use of Pytoch 2.11.0 and 2.12.0 in MerLin so users with torchvision 0.26.0 can still use MerLin.

## Related Issue
PML-311

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / Cleanup
- [ ] Performance improvement
- [x] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)


## Proposed changes
- Changed the torch restrictions in the pyproject.
- No evident bug should happen per the relase notes: 
     - 2.11 https://github.com/pytorch/pytorch/releases/tag/v2.11.0.
     - 2.12: https://github.com/pytorch/pytorch/releases/tag/v2.12.0#deprecations
- One warning of sparse tensor in the tests was emitted: 
```
Sparse invariant checks are implicitly disabled. Memory errors (e.g. SEGFAULT) will occur when operating on a sparse tensor which violates the invariants, but checks incur performance overhead. To silence this warning, explicitly opt in or out. See `torch.sparse.check_sparse_tensor_invariants.__doc__` for guidance.
```
The fix was to catch the warning and silence it as the tensor created in the test is good.

- Will check with claude that nothing else should break.

## How to test / How to run
<!-- Describe test plan and steps for reviewers to validate and run your changes locally. Include datasets if relevant. -->

1. Command lines

```
pytest -q
```

## Documentation
- [ ] User docs updated (Sphinx)
- [ ] Examples / notebooks updated
- [ ] Docstrings updated
- [ ] Updated the API

