### PR TITLE
PML-346: MerLinProcessor gradient documentation and tests

### DIFF
--- a/docs/source/api_reference/api/merlin.core.merlin_processor.rst
+++ b/docs/source/api_reference/api/merlin.core.merlin_processor.rst
@@ -47,17 +47,16 @@ Key Capabilities
 
 Key current limitation
 -----------------------
-* No gradient can flow through the MerLin processor. When calling backwards directly on a MerlinProcessor's 
-forward pass, this error will be shown:
-```
-element 0 of tensors does not require grad and does not have a grad_fn
-```
+* No gradient can flow through the MerLin processor. When calling backwards directly on a MerlinProcessor's
+  forward pass, this error will be shown::
+
+      element 0 of tensors does not require grad and does not have a grad_fn
 
 * If a MerLin processor is part of a bigger ``Pytorch`` module, the quantum layer's parameter gradient will be None.
-This also means that every upstream models' (models called before the :class:`~merlin.algorithms.layer.QuantumLayer` in the model's forward) gradient will be None.
+  This also means that every upstream models' (models called before the :class:`~merlin.algorithms.layer.QuantumLayer` in the model's forward) gradient will be None.
 
 * The gradient can not pass through right now as pytorch can not access
-directly the computation on the QPU.
+  directly the computation on the QPU.
 
 * Differentiation through the MerLin processor will be implemented in v0.5.
 

--- a/docs/source/api_reference/api/merlin.core.merlin_processor.rst
+++ b/docs/source/api_reference/api/merlin.core.merlin_processor.rst
@@ -45,6 +45,22 @@ Key Capabilities
    ``"samples"``). Shots are *user-controlled* via ``nsample``; there is no
    hidden auto-shot selection.
 
+Key current limitation
+-----------------------
+* No gradient can flow through the MerLin processor. When calling backwards directly on a MerlinProcessor's 
+forward pass, this error will be shown:
+```
+element 0 of tensors does not require grad and does not have a grad_fn
+```
+
+* If a MerLin processor is part of a bigger ``Pytorch`` module, the quantum layer's parameter gradient will be None.
+This also means that every upstream models' (models called before the :class:`~merlin.algorithms.layer.QuantumLayer` in the model's forward) gradient will be None.
+
+* The gradient can not pass through right now as pytorch can not access
+directly the computation on the QPU.
+
+* Differentiation through the MerLin processor will be implemented in v0.5.
+
 Class Reference
 ===============
 

--- a/docs/source/user_guide/remote_execution.rst
+++ b/docs/source/user_guide/remote_execution.rst
@@ -551,17 +551,16 @@ Scaleway session with context manager
 
 Gradient Propagation
 ---------------------
-* No gradient can flow through the MerLin processor. When calling backwards directly on a MerlinProcessor's 
-forward pass, this error will be shown:
-```
-element 0 of tensors does not require grad and does not have a grad_fn
-```
+* No gradient can flow through the MerLin processor. When calling backwards directly on a MerlinProcessor's
+  forward pass, this error will be shown::
+
+      element 0 of tensors does not require grad and does not have a grad_fn
 
 * If a MerLin processor is part of a bigger ``Pytorch`` module, the quantum layer's parameter gradient will be None.
-This also means that every upstream models' (models called before the :class:`~merlin.algorithms.layer.QuantumLayer` in the model's forward) gradient will be None.
+  This also means that every upstream models' (models called before the :class:`~merlin.algorithms.layer.QuantumLayer` in the model's forward) gradient will be None.
 
 * The gradient can not pass through right now as pytorch can not access
-directly the computation on the QPU.
+  directly the computation on the QPU.
 
 * Differentiation through the MerLin processor will be implemented in v0.5.
 

--- a/docs/source/user_guide/remote_execution.rst
+++ b/docs/source/user_guide/remote_execution.rst
@@ -549,6 +549,22 @@ Scaleway session with context manager
         # MerlinProcessor context manager cancels any stray jobs on exit.
     # Scaleway session is closed on exit.
 
+Gradient Propagation
+---------------------
+* No gradient can flow through the MerLin processor. When calling backwards directly on a MerlinProcessor's 
+forward pass, this error will be shown:
+```
+element 0 of tensors does not require grad and does not have a grad_fn
+```
+
+* If a MerLin processor is part of a bigger ``Pytorch`` module, the quantum layer's parameter gradient will be None.
+This also means that every upstream models' (models called before the :class:`~merlin.algorithms.layer.QuantumLayer` in the model's forward) gradient will be None.
+
+* The gradient can not pass through right now as pytorch can not access
+directly the computation on the QPU.
+
+* Differentiation through the MerLin processor will be implemented in v0.5.
+
 Troubleshooting
 ---------------
 

--- a/merlin/core/merlin_processor.py
+++ b/merlin/core/merlin_processor.py
@@ -859,8 +859,9 @@ class MerlinProcessor:
 
         if module.training:
             raise RuntimeError(
-                "Backend quantum execution requires `.eval()` mode. "
-                "Call `module.eval()` before forward."
+                "Backend quantum execution requires `.eval()` mode because no gradient"
+                "can flow through the QPU runs. Gradient computation methods in the MerlinProcessor"
+                " will come in v0.5. Call `module.eval()` before forward."
             )
 
         if nsample is not None and nsample > self.max_shots_per_call:

--- a/tests/core/test_merlin_processor_gradient.py
+++ b/tests/core/test_merlin_processor_gradient.py
@@ -1,0 +1,98 @@
+import pytest
+import perceval as pcvl
+import torch
+import torch.nn as nn
+
+from merlin.algorithms import QuantumLayer
+from merlin.builder.circuit_builder import CircuitBuilder
+from merlin.core.computation_space import ComputationSpace
+from merlin.core.merlin_processor import MerlinProcessor
+from merlin.measurement.strategies import MeasurementStrategy
+
+
+def _build_merlin_processor() -> MerlinProcessor:
+    rp = pcvl.Processor("SLOS")
+    return MerlinProcessor(
+        processor=rp,
+        microbatch_size=32,
+        timeout=3600.0,
+        max_shots_per_call=None,
+        chunk_concurrency=1,
+    )
+
+
+def _build_quantum_layer() -> QuantumLayer:
+    builder = CircuitBuilder(n_modes=6)
+    builder.add_rotations(trainable=True, name="theta")
+    builder.add_angle_encoding(modes=[0, 1], name="px")
+    builder.add_entangling_layer()
+
+    return QuantumLayer(
+        input_size=2,
+        builder=builder,
+        n_photons=2,
+        measurement_strategy=MeasurementStrategy.probs(
+            computation_space=ComputationSpace.UNBUNCHED,
+        ),
+        dtype=torch.float32,
+    )
+
+
+def _random_one_hot_targets_like(output: torch.Tensor) -> torch.Tensor:
+    labels = torch.randint(low=0, high=output.shape[1], size=(output.shape[0],))
+    targets = torch.zeros_like(output)
+    targets[torch.arange(output.shape[0]), labels] = 1.0
+    return targets
+
+
+def test_processor_of_hybrid_model_gradient_fail_without_eval():
+    proc = _build_merlin_processor()
+    quantum_layer = _build_quantum_layer()
+
+    model = nn.Sequential(
+        nn.Linear(3, 2, bias=False, dtype=torch.float32),
+        quantum_layer,
+        nn.Linear(15, 4, bias=False, dtype=torch.float32),
+    )
+
+    X = torch.rand(8, 3)
+    model.eval()
+    y = proc.forward(model, X, nsample=5000)
+
+    labels_to_check = _random_one_hot_targets_like(y)
+    loss = torch.nn.MSELoss()(labels_to_check, y)
+
+    with pytest.raises(RuntimeError, match="does not require grad"):
+        loss.backward()
+
+
+def test_hybrid_model_of_processor_gradient_passes():
+    proc = _build_merlin_processor()
+    quantum_layer = _build_quantum_layer()
+
+    class MyModel(nn.Module):
+        def __init__(self, qlayer: QuantumLayer, processor: MerlinProcessor) -> None:
+            super().__init__()
+            self.layer_1 = nn.Linear(3, 2, bias=False, dtype=torch.float32)
+            self.layer_2 = nn.Linear(15, 4, bias=False, dtype=torch.float32)
+            self.qlayer = qlayer.eval()
+            self.processor = processor
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            out_1 = self.layer_1(x)
+            out_2 = self.processor.forward(self.qlayer, out_1, nsample=5000)
+            return self.layer_2(out_2)
+
+    model = MyModel(quantum_layer, proc)
+
+    X = torch.rand(8, 3)
+    y = model(X)
+
+    labels_to_check = _random_one_hot_targets_like(y)
+    loss = torch.nn.MSELoss()(labels_to_check, y)
+
+    loss.backward()
+
+    assert [p.grad for p in model.layer_1.parameters()] == [None]
+    assert [p.grad for p in model.qlayer.parameters()] == [None, None]
+    assert not [p.grad for p in model.layer_2.parameters()] == [None]


### PR DESCRIPTION
## Summary
Tested a backward pass on MerLinProcessor based modules:
- A MerLinProcessor containing a full hybrid module
- A Hybrid model conatining a MerLinProcessor module

Documented the errors and tests that verify those errors.


## Related Issue
PML-346

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [x] Refactor / Cleanup
- [ ] Performance improvement
- [ ] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)


## Proposed changes
- Added tests to verify the errors or output values
- Added a gradient propagtaion section in the API and user guide for the MerLin processor
- Clarified the error message

## How to test / How to run

```
pytest -q
```

## Documentation
- [x] User docs updated (Sphinx)
- [ ] Examples / notebooks updated
- [ ] Docstrings updated
- [ ] Updated the API