### PR TITLE
Fix on CI to avoid OSError with no space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,6 @@ jobs:
         df -h
         pip install -e ".[dev]"
         df -h
-        python -m pip cache purge
     
     - name: Run code quality checks
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      PIP_NO_CACHE_DIR: "1"
+      PIP_NO_COMPILE: "1"
+      PYTHONDONTWRITEBYTECODE: "1"
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -21,14 +25,32 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Free unused runner disk space
+      run: |
+        df -h
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo rm -rf /usr/share/swift
+        sudo rm -rf /usr/local/.ghcup
+        sudo apt-get clean
+        df -h
     
     - name: Install dependencies
       run: |
+        df -h
         python -m pip install --upgrade pip
+        df -h
+        pip install --index-url https://download.pytorch.org/whl/cpu "torch>=2.0.0,<=2.10.0"
+        df -h
         pip install -e ".[dev]"
+        df -h
+        python -m pip cache purge
     
     - name: Run code quality checks
       run: |
@@ -38,4 +60,10 @@ jobs:
     
     - name: Run tests with coverage
       run: |
-        pytest tests/ -v
+        pytest -o addopts="--cov=merlin --cov-report=term-missing" tests/ -v
+
+    - name: Clean test artifacts
+      if: always()
+      run: |
+        rm -rf .pytest_cache .mypy_cache .ruff_cache htmlcov coverage.xml build dist *.egg-info
+        find . -type d -name __pycache__ -prune -exec rm -rf {} +

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,6 @@ jobs:
           df -h
           pip install -e ".[docs]"
           df -h
-          python -m pip cache purge
 
       - name: Build documentation
         working-directory: docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,10 @@ on:
 jobs:
   build-docs:
     runs-on: ubuntu-latest
+    env:
+      PIP_NO_CACHE_DIR: "1"
+      PIP_NO_COMPILE: "1"
+      PYTHONDONTWRITEBYTECODE: "1"
 
     steps:
       - uses: actions/checkout@v4
@@ -26,11 +30,19 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y pandoc
+          sudo apt-get clean
+          sudo rm -rf /var/lib/apt/lists/*
 
       - name: Install documentation dependencies
         run: |
+          df -h
           python -m pip install --upgrade pip
+          df -h
+          pip install --index-url https://download.pytorch.org/whl/cpu "torch>=2.0.0,<=2.10.0"
+          df -h
           pip install -e ".[docs]"
+          df -h
+          python -m pip cache purge
 
       - name: Build documentation
         working-directory: docs


### PR DESCRIPTION
## Summary
We are currently facing OSError with no space on device on CI.
This PR reduces GitHub Actions disk usage during dependency installation.

The CI failure appears to come from the default PyPI `torch` wheel resolving CUDA/NVIDIA dependencies on `ubuntu-latest`. The failing install log shows `pip install -e ".[dev]"` downloading large packages such as:

- `torch-2.10.0` (~915 MB)
- `nvidia-cublas-cu12` (~594 MB)
- `nvidia-cudnn-cu12` (~707 MB)
- `nvidia-cusolver-cu12`, `nvidia-cusparse-cu12`, `nvidia-nccl-cu12`, `triton`, and other CUDA-related wheels

These are not needed for CPU-only GitHub hosted runners and can exhaust runner disk during installation. This could solve our problem

## Changes

- Preinstall CPU-only Torch from the PyTorch CPU wheel index before installing project extras
- Disable pip cache and bytecode generation in CI
- Free unused preinstalled runner tooling before dependency installation
- Add temporary `df -h` probes around install steps to confirm where disk space is consumed
- Avoid generating HTML coverage output in the test workflow
- Clean pip/apt caches and generated test artifacts

## Notes

The key expected CI log difference is that dependency installation should no longer collect `nvidia-*`, `cuda-*`, or CUDA `triton` packages when installing Merlin on Ubuntu CPU runners.