### PR TITLE
PML-352 Remove no_bunching flag

### DIFF
--- a/docs/source/api_reference/api/merlin.algorithms.kernels.rst
+++ b/docs/source/api_reference/api/merlin.algorithms.kernels.rst
@@ -29,10 +29,11 @@ Deprecations
    :undoc-members:
    :show-inheritance:
 
-.. warning:: *Deprecated since version 0.3:*
+.. warning:: *Removed in version 0.4:*
    The ``no_bunching`` flag accepted by legacy kernel constructors is removed
-   since version 0.3.0. Use the ``computation_space`` parameter instead.
-   See :doc:`/user_guide/migration_guide`.
+   in version 0.4. Use ``computation_space=ComputationSpace.UNBUNCHED`` or
+   ``computation_space=ComputationSpace.FOCK`` instead. See
+   :doc:`/user_guide/migration_guide`.
 
 .. warning:: *Deprecated since version 0.4:*
    Direct unitary construction through :meth:`FeatureMap.compute_unitary` is a

--- a/docs/source/api_reference/api/merlin.algorithms.layer.rst
+++ b/docs/source/api_reference/api/merlin.algorithms.layer.rst
@@ -414,9 +414,11 @@ For manual truncated backpropagation through time (TBPTT), set ``detach_at_each_
 
 Deprecations
 -------------------------
-.. warning:: *Deprecated since version 0.3:*
-   The use of the ``no_bunching`` flag  is deprecated and is removed since version 0.3.0.
-   Use the ``computation_space`` flag inside ``measurement_strategy`` instead. See :doc:`/user_guide/migration_guide`.
+.. warning:: *Removed in version 0.4:*
+   The ``no_bunching`` flag is removed in version 0.4. Use
+   ``MeasurementStrategy.probs(computation_space=ComputationSpace.UNBUNCHED)``
+   or ``MeasurementStrategy.probs(computation_space=ComputationSpace.FOCK)``
+   instead. See :doc:`/user_guide/migration_guide`.
 
 .. warning::
    *Deprecated since version 0.4:* The use of the ``computation_space`` argument in the QuantumLayer's constructor is no longer supported as 0.4.0.

--- a/docs/source/api_reference/api/merlin.utils.deprecations.rst
+++ b/docs/source/api_reference/api/merlin.utils.deprecations.rst
@@ -8,8 +8,8 @@ merlin.utils.deprecations module
 
 .. autofunction:: sanitize_parameters
 
-.. autofunction:: warn_deprecated_enum_access
+.. autofunction:: error_deprecated_enum_access
 
-.. autofunction:: raise_no_bunching_deprecated
+.. autofunction:: raise_no_bunching_removed
 
 .. autofunction:: normalize_measurement_strategy

--- a/docs/source/reproduced_papers/reproductions/photonic_memristor.rst
+++ b/docs/source/reproduced_papers/reproductions/photonic_memristor.rst
@@ -56,8 +56,9 @@ Memristor ``QuantumLayer`` usage (from the implementation):
        trainable_parameters=["theta"],
        input_parameters=["px"],
        input_state=[0, 1, 0],
-       measurement_strategy=ml.MeasurementStrategy.probs(),
-       no_bunching=True,
+       measurement_strategy=ml.MeasurementStrategy.probs(
+           computation_space=ml.ComputationSpace.UNBUNCHED
+       ),
    )
 
    phi_enc = encode_phase(x)

--- a/docs/source/user_guide/computation_space.rst
+++ b/docs/source/user_guide/computation_space.rst
@@ -67,11 +67,14 @@ We can choose from:
    *Deprecated since version 0.4:* The use of the ``computation_space`` argument in the QuantumLayer's constructor is no longer supported as 0.4.0.
    Use the ``computation_space`` flag inside ``measurement_strategy`` instead. See :doc:`/user_guide/migration_guide`.
 
-It will be the only way to control the computation space as the ``no_bunching`` flag is deprecated.
+This is the supported way to control the computation space. The legacy
+``no_bunching`` flag is removed in version 0.4.
 
-.. warning:: *Deprecated since version 0.3:*
-   The use of the ``no_bunching`` flag  is deprecated and is removed since version 0.3.0.
-   Use the ``computation_space`` flag inside ``measurement_strategy`` instead. See :doc:`/user_guide/migration_guide`.
+.. warning:: *Removed in version 0.4:*
+   The ``no_bunching`` flag is removed in version 0.4. Use
+   ``MeasurementStrategy.probs(computation_space=ComputationSpace.UNBUNCHED)``
+   or ``MeasurementStrategy.probs(computation_space=ComputationSpace.FOCK)``
+   instead. See :doc:`/user_guide/migration_guide`.
 
 
 Another parameter is also relevant.

--- a/docs/source/user_guide/layer.rst
+++ b/docs/source/user_guide/layer.rst
@@ -169,8 +169,11 @@ Notes
   whether photon loss is active and how it alters the output distribution.
 
 .. warning::
-   *Deprecated since version 0.3:* The use of the ``no_bunching`` flag  is deprecated and is removed since version 0.3.0.
-   Use the ``computation_space`` flag inside ``measurement_strategy`` instead. See :doc:`/user_guide/migration_guide`.
+   *Removed in version 0.4:* The ``no_bunching`` flag is removed in
+   version 0.4. Use
+   ``MeasurementStrategy.probs(computation_space=ComputationSpace.UNBUNCHED)``
+   or ``MeasurementStrategy.probs(computation_space=ComputationSpace.FOCK)``
+   instead. See :doc:`/user_guide/migration_guide`.
 
 .. warning::
    *Deprecated since version 0.4:* The use of the ``computation_space`` argument in the QuantumLayer's constructor is no longer supported as 0.4.0.

--- a/docs/source/user_guide/measurement_strategy.rst
+++ b/docs/source/user_guide/measurement_strategy.rst
@@ -132,11 +132,14 @@ The MeasurementStrategy now gets two arguments in input.
 
 * ``computation_space``: A ``ComputationSpace`` object that defines the output computation space.
 
-  It will be the only way to define the computation space as the ``no_bunching`` flag is deprecated.
+  This is the supported way to define the computation space. The legacy
+  ``no_bunching`` flag is removed in version 0.4.
   
-  .. warning:: *Deprecated since version 0.3:*
-   The use of the ``no_bunching`` flag  is deprecated and is removed since version 0.3.0.
-   Use the ``computation_space`` flag inside ``measurement_strategy`` instead. See :doc:`/user_guide/migration_guide`.
+  .. warning:: *Removed in version 0.4:*
+     The ``no_bunching`` flag is removed in version 0.4. Use
+     ``MeasurementStrategy.probs(computation_space=ComputationSpace.UNBUNCHED)``
+     or ``MeasurementStrategy.probs(computation_space=ComputationSpace.FOCK)``
+     instead. See :doc:`/user_guide/migration_guide`.
 
 
 * ``grouping``: The grouping strategy to use between ``LexGrouping`` and ``ModGrouping``. By default, no grouping is applied.

--- a/docs/source/user_guide/migration_guide.rst
+++ b/docs/source/user_guide/migration_guide.rst
@@ -3,15 +3,14 @@
 Migration guide
 ===============
 
-Migrating from ``no_bunching`` (deprecated)
--------------------------------------------
+Migrating from removed ``no_bunching``
+--------------------------------------
 
-.. warning:: *Deprecated since version 0.3:*
-   ``no_bunching`` is deprecated and is removed since version 0.3.0. Use
-   ``computation_space`` instead inside the chosen ``measurement_strategy``. 
-   See this migration section for the mapping.
+.. warning:: *Removed in version 0.4:*
+   ``no_bunching`` is removed in version 0.4. Use explicit
+   ``computation_space`` configuration instead.
    
-The ``no_bunching`` flag is deprecated. 
+The ``no_bunching`` flag is removed.
 
 If you are using a ``QuantumLayer`` and you need to control how Fock states are
 truncated or encoded, define the ``computation_space`` inside the ``measurement_strategy``

--- a/merlin/algorithms/feed_forward_legacy.py
+++ b/merlin/algorithms/feed_forward_legacy.py
@@ -29,7 +29,7 @@ from perceval.components import BS, PS
 from ..core.computation_space import ComputationSpace
 from ..core.state import StatePattern, generate_state
 from ..measurement.strategies import MeasurementStrategy
-from ..utils.deprecations import raise_no_bunching_deprecated
+from ..utils.deprecations import raise_no_bunching_removed
 from .layer import QuantumLayer
 
 
@@ -667,7 +667,7 @@ class PoolingFeedForwardLegacy(torch.nn.Module):
         Each sublist contains the indices of input modes to pool together
         for one output mode. If None, an even pooling scheme is automatically generated.
     no_bunching : bool | None
-        Deprecated and now removed; use computation_space in MeasurementStrategy instead.
+        Removed legacy flag. Use computation_space in MeasurementStrategy instead.
 
     Attributes
     ----------
@@ -692,17 +692,13 @@ class PoolingFeedForwardLegacy(torch.nn.Module):
     ):
         super().__init__()
         if no_bunching is not None:
-            raise_no_bunching_deprecated(stacklevel=2)
-        if no_bunching is None:
-            no_bunching = True
+            raise_no_bunching_removed()
         keys_in = QuantumLayer(
             0,
             circuit=pcvl.Circuit(n_modes),
             n_photons=n_photons,
             measurement_strategy=MeasurementStrategy.probs(
-                computation_space=ComputationSpace.coerce(
-                    ComputationSpace.UNBUNCHED if no_bunching else ComputationSpace.FOCK
-                )
+                computation_space=ComputationSpace.UNBUNCHED
             ),
         ).computation_process.simulation_graph.mapped_keys
         keys_out = QuantumLayer(
@@ -710,9 +706,7 @@ class PoolingFeedForwardLegacy(torch.nn.Module):
             circuit=pcvl.Circuit(n_output_modes),
             n_photons=n_photons,
             measurement_strategy=MeasurementStrategy.probs(
-                computation_space=ComputationSpace.coerce(
-                    ComputationSpace.UNBUNCHED if no_bunching else ComputationSpace.FOCK
-                )
+                computation_space=ComputationSpace.UNBUNCHED
             ),
         ).computation_process.simulation_graph.mapped_keys
 

--- a/merlin/core/computation_space.py
+++ b/merlin/core/computation_space.py
@@ -33,22 +33,6 @@ class ComputationSpace(str, Enum):
     DUAL_RAIL = "dual_rail"
 
     @classmethod
-    def default(cls, *, no_bunching: bool) -> "ComputationSpace":
-        """Derive the default computation space from the legacy flag.
-
-        Parameters
-        ----------
-        no_bunching : bool
-            Legacy flag indicating whether bunching should be disallowed.
-
-        Returns
-        -------
-        ComputationSpace
-            Default computation space matching the legacy behavior.
-        """
-        return cls.UNBUNCHED if no_bunching else cls.FOCK
-
-    @classmethod
     def coerce(cls, value: "ComputationSpace | str") -> "ComputationSpace":
         """Normalize user-provided values (enum instances or case-insensitive strings).
 

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -32,7 +32,7 @@ import torch
 
 from ..pcvl_pytorch import CircuitConverter, build_slos_distribution_computegraph
 from ..utils.combinadics import Combinadics
-from ..utils.deprecations import raise_no_bunching_deprecated
+from ..utils.deprecations import raise_no_bunching_removed
 from .base import AbstractComputationProcess
 from .computation_space import ComputationSpace
 
@@ -90,7 +90,7 @@ class ComputationProcess(AbstractComputationProcess):
     computation_space : ComputationSpace | None
         Computation space used for basis enumeration.
     no_bunching : bool | None
-        Deprecated legacy parameter.
+        Removed legacy parameter.
     output_map_func : Any
         Optional output mapping function.
     """
@@ -132,7 +132,7 @@ class ComputationProcess(AbstractComputationProcess):
         memristive_metadata: list[dict] | None
             The memristive phase shifter metadata. If None, it will be stored as an empty list.
         no_bunching : bool | None
-            Deprecated legacy parameter.
+            Removed legacy parameter.
         output_map_func : Any
             Optional output mapping function.
         """
@@ -148,7 +148,7 @@ class ComputationProcess(AbstractComputationProcess):
         )
 
         if no_bunching is not None:
-            raise_no_bunching_deprecated(stacklevel=2)
+            raise_no_bunching_removed()
 
         if computation_space is None:
             computation_space = ComputationSpace.UNBUNCHED

--- a/merlin/pcvl_pytorch/slos_torchscript.py
+++ b/merlin/pcvl_pytorch/slos_torchscript.py
@@ -37,7 +37,7 @@ import torch
 import torch.jit as jit
 
 from merlin.core.computation_space import ComputationSpace
-from merlin.utils.deprecations import raise_no_bunching_deprecated
+from merlin.utils.deprecations import raise_no_bunching_removed
 from merlin.utils.dtypes import resolve_float_complex
 from merlin.utils.normalization import (
     normalize_probabilities,
@@ -1056,7 +1056,7 @@ def build_slos_distribution_computegraph(
         Logical computation subspace used to build the basis and transitions.
         When omitted, defaults to ``ComputationSpace.UNBUNCHED``.
     no_bunching : bool | None
-        Deprecated legacy flag. Use ``computation_space`` instead.
+        Removed legacy flag. Use ``computation_space`` instead.
     keep_keys : bool
         Whether to keep the list of mapped Fock states. Default is ``True``.
     device : torch.device | str | None
@@ -1074,7 +1074,7 @@ def build_slos_distribution_computegraph(
     """
 
     if no_bunching is not None:
-        raise_no_bunching_deprecated(stacklevel=2)
+        raise_no_bunching_removed()
 
     if computation_space is None:
         computation_space = ComputationSpace.UNBUNCHED
@@ -1277,7 +1277,6 @@ def compute_slos_distribution(
         sum(input_state),
         output_map_func,
         computation_space,
-        no_bunching=None,
         keep_keys=keep_keys,
         device=device,
         dtype=dtype,

--- a/merlin/utils/deprecations.py
+++ b/merlin/utils/deprecations.py
@@ -5,7 +5,7 @@ import warnings
 from collections.abc import Callable, Sequence
 from contextvars import ContextVar
 from functools import wraps
-from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, NoReturn, TypeVar, cast, overload
 
 from ..core.computation_space import ComputationSpace
 
@@ -35,7 +35,7 @@ _NO_BUNCHING_REMOVED_MESSAGE = (
 )
 
 
-def raise_no_bunching_removed() -> None:
+def raise_no_bunching_removed() -> NoReturn:
     """
     Raise when the removed ``no_bunching`` flag is used.
 

--- a/merlin/utils/deprecations.py
+++ b/merlin/utils/deprecations.py
@@ -28,41 +28,28 @@ _ACTIVE_DEPRECATION_MESSAGES: ContextVar[frozenset[str]] = ContextVar(
 
 _NO_BUNCHING_REMOVED_MESSAGE = (
     "The 'no_bunching' parameter is removed. "
-    "Use measurement_strategy=MeasurementStrategy.probs(computation_space=ComputationSpace.UNBUNCHED) "
-    "for no_bunching=True or computation_space=ComputationSpace.FOCK for no_bunching=False."
+    "Use MeasurementStrategy.probs(computation_space=ComputationSpace.UNBUNCHED) "
+    "or MeasurementStrategy.probs(computation_space=ComputationSpace.FOCK) "
+    "for QuantumLayer measurements. Use computation_space=ComputationSpace.UNBUNCHED "
+    "or computation_space=ComputationSpace.FOCK for kernels."
 )
 
 
-def raise_no_bunching_deprecated(*, stacklevel: int = 2) -> None:
+def raise_no_bunching_removed() -> None:
     """
-    Warn and raise when deprecated ``no_bunching`` is used.
+    Raise when the removed ``no_bunching`` flag is used.
 
-    Parameters
-    ----------
-    stacklevel : int
-        Warning stack level used for the emitted deprecation warning. Default is ``2``.
+    Returns
+    -------
+    None
+        This function never returns normally.
 
     Raises
     ------
     ValueError
-        Always raised after emitting the deprecation warning.
+        Always raised with the 0.4 migration guidance.
     """
-    warnings.warn(
-        _NO_BUNCHING_REMOVED_MESSAGE,
-        DeprecationWarning,
-        stacklevel=stacklevel,
-    )
     raise ValueError(_NO_BUNCHING_REMOVED_MESSAGE)
-
-
-def _reject_no_bunching_init(
-    method_qualname: str, kwargs: dict[str, Any]
-) -> dict[str, Any]:
-    """Reject deprecated `no_bunching` usage (hard-fail with warning)."""
-    _ = method_qualname
-    if "no_bunching" in kwargs:
-        raise_no_bunching_deprecated(stacklevel=3)
-    return kwargs
 
 
 # ---------------------------------------------------------------------------
@@ -152,9 +139,9 @@ DEPRECATION_REGISTRY: dict[
         None,
     ),
     "QuantumLayer.__init__.no_bunching": (
+        _NO_BUNCHING_REMOVED_MESSAGE,
+        True,
         None,
-        None,
-        _reject_no_bunching_init,
     ),
     "QuantumLayer.__init__.computation_space": (
         None,
@@ -163,9 +150,9 @@ DEPRECATION_REGISTRY: dict[
     ),
     # QuantumLayer.simple deprecations
     "QuantumLayer.simple.no_bunching": (
+        _NO_BUNCHING_REMOVED_MESSAGE,
+        True,
         None,
-        None,
-        _reject_no_bunching_init,
     ),
     "QuantumLayer.simple.computation_space": (
         "The 'computation_space' keyword is deprecated; move it into MeasurementStrategy.probs(computation_space).",
@@ -241,9 +228,9 @@ DEPRECATION_REGISTRY: dict[
         _remove_FidelityKernel_simple_n_photons,
     ),
     "FidelityKernel.simple.no_bunching": (
+        _NO_BUNCHING_REMOVED_MESSAGE,
+        True,
         None,
-        None,
-        _reject_no_bunching_init,
     ),
     "FidelityKernel.simple.trainable": (
         "Since merlin >= 0.3, input parameter allocation is automatically inferred from input dimensionality, following Gan et al. (2022) on Fock-space expressivity. Manual control of input/trainable parameters is deprecated.",
@@ -257,9 +244,9 @@ DEPRECATION_REGISTRY: dict[
     ),
     # FidelityKernel.__init__ deprecations
     "FidelityKernel.__init__.no_bunching": (
+        _NO_BUNCHING_REMOVED_MESSAGE,
+        True,
         None,
-        None,
-        _reject_no_bunching_init,
     ),
     # KernelCircuitBuilder deprecations
     # TODO: In release 0.5.x, remove these entries along with KernelCircuitBuilder.
@@ -285,9 +272,9 @@ DEPRECATION_REGISTRY: dict[
     ),
     # KernelCircuitBuilder.build_fidelity_kernel parameter-level deprecations
     "KernelCircuitBuilder.build_fidelity_kernel.no_bunching": (
+        _NO_BUNCHING_REMOVED_MESSAGE,
+        True,
         None,
-        None,
-        _reject_no_bunching_init,
     ),
 }
 
@@ -329,7 +316,10 @@ def _collect_deprecations_and_converters(
         if full_name in DEPRECATION_REGISTRY:
             msg, severity, converter = DEPRECATION_REGISTRY[full_name]
             if msg is not None and severity is not None:
-                base = f"Parameter '{key}' is deprecated. {msg}"
+                if msg == _NO_BUNCHING_REMOVED_MESSAGE:
+                    base = msg
+                else:
+                    base = f"Parameter '{key}' is deprecated. {msg}"
                 if severity is True:
                     raise_msgs.append(base)
                 elif severity is False:

--- a/tests/algorithms/test_amplitude_encoding.py
+++ b/tests/algorithms/test_amplitude_encoding.py
@@ -158,9 +158,9 @@ def test_amplitude_encoding_gradients_follow_computation_space(
     assert amplitude_input.grad.shape == amplitude_input.shape
 
     trainable_params = [p for p in layer.parameters() if p.requires_grad]
-    assert (
-        trainable_params
-    ), "Expected at least one trainable parameter for gradient check"
+    assert trainable_params, (
+        "Expected at least one trainable parameter for gradient check"
+    )
     for param in trainable_params:
         assert param.grad is not None
         assert param.grad.shape == param.shape
@@ -873,9 +873,9 @@ def test_amplitude_encoding_superposition_matches_basis_sum():
     combined_output = layer(amplitude_input)
     expected_output = torch.sum(coefficients[:, None, None] * basis_outputs, dim=0)
     difference = combined_output - expected_output
-    assert torch.allclose(
-        combined_output, expected_output, atol=1e-6, rtol=1e-6
-    ), f"Max deviation {difference.abs().max().item():.2e}"
+    assert torch.allclose(combined_output, expected_output, atol=1e-6, rtol=1e-6), (
+        f"Max deviation {difference.abs().max().item():.2e}"
+    )
 
     with pytest.raises(ValueError, match="Amplitude input expects"):
         layer(torch.ones(basis_size + 1, dtype=torch.complex64))
@@ -1012,9 +1012,9 @@ def test_ebs_wrt_quantumlayer(
             single_unitary = single_layer.computation_process.converter.to_tensor(
                 *single_params
             )
-            assert torch.allclose(
-                single_unitary, ebs_unitary, rtol=1e-6, atol=1e-8
-            ), "Expected identical unitaries between EBS and single-state layers."
+            assert torch.allclose(single_unitary, ebs_unitary, rtol=1e-6, atol=1e-8), (
+                "Expected identical unitaries between EBS and single-state layers."
+            )
             assert (
                 single_layer.computation_process.simulation_graph.mapped_keys
                 == ebs_layer.computation_process.simulation_graph.mapped_keys
@@ -1032,6 +1032,6 @@ def test_ebs_wrt_quantumlayer(
         p=2, dim=1, keepdim=True
     ).clamp_min(1e-12)
     # TODO: investigate why this tests failed with rtol=1e-6, atol=1e-8
-    assert torch.allclose(
-        ebs_output, expected_output, rtol=1e-4, atol=1e-6
-    ), "EBS output deviates from the superposed QuantumLayer results."
+    assert torch.allclose(ebs_output, expected_output, rtol=1e-4, atol=1e-6), (
+        "EBS output deviates from the superposed QuantumLayer results."
+    )

--- a/tests/algorithms/test_dtype_propagation.py
+++ b/tests/algorithms/test_dtype_propagation.py
@@ -120,9 +120,9 @@ class TestQuantumLayerDtypePropagation:
         )
 
         mask = qlayer.measurement_mapping.mask
-        assert (
-            mask.dtype == torch.float64
-        ), f"Expected mask dtype=torch.float64, got {mask.dtype}"
+        assert mask.dtype == torch.float64, (
+            f"Expected mask dtype=torch.float64, got {mask.dtype}"
+        )
 
     def test_mode_expectations_float32_mask_dtype(self, circuit_2mode):
         """Verify float32 still works (backward compatibility)."""
@@ -310,9 +310,9 @@ class TestQuantumLayerDtypePropagation:
 
         psi_out = layer(psi_in)
 
-        assert (
-            psi_out.dtype == torch.cfloat
-        ), f"Expected AMPLITUDES output dtype=torch.cfloat, got {psi_out.dtype}"
+        assert psi_out.dtype == torch.cfloat, (
+            f"Expected AMPLITUDES output dtype=torch.cfloat, got {psi_out.dtype}"
+        )
         assert psi_out.shape in {(num_states,), (1, num_states)}
 
     def test_amplitudes_complex_forward_float64_outputs_cdouble(
@@ -335,9 +335,9 @@ class TestQuantumLayerDtypePropagation:
 
         psi_out = layer(psi_in)
 
-        assert (
-            psi_out.dtype == torch.cdouble
-        ), f"Expected AMPLITUDES output dtype=torch.cdouble, got {psi_out.dtype}"
+        assert psi_out.dtype == torch.cdouble, (
+            f"Expected AMPLITUDES output dtype=torch.cdouble, got {psi_out.dtype}"
+        )
         assert psi_out.shape in {(num_states,), (1, num_states)}
 
 
@@ -384,9 +384,9 @@ class TestOriginalBugReproduction:
 
         # Verify mask dtype is now correct
         mask = qlayer.measurement_mapping.mask
-        assert (
-            mask.dtype == torch.float64
-        ), f"BUG NOT FIXED: mask dtype is {mask.dtype}, expected torch.float64"
+        assert mask.dtype == torch.float64, (
+            f"BUG NOT FIXED: mask dtype is {mask.dtype}, expected torch.float64"
+        )
 
         # Verify forward pass succeeds (this was the crash point)
         x = torch.zeros(1, 1, dtype=torch_dtype)

--- a/tests/algorithms/test_kernels_deprecation.py
+++ b/tests/algorithms/test_kernels_deprecation.py
@@ -268,11 +268,11 @@ class TestLegacyFeatureMapUnitaryPath:
 
 
 # ---------------------------------------------------------------------------
-# Deprecated no_bunching parameter
+# Removed no_bunching parameter
 # ---------------------------------------------------------------------------
 
 
-class TestDeprecatedNoBunchingParam:
+class TestRemovedNoBunchingParam:
     """Tests for the removed ``no_bunching`` parameter across kernel APIs."""
 
     def setup_method(self):
@@ -286,26 +286,46 @@ class TestDeprecatedNoBunchingParam:
             input_parameters="x",
         )
 
-    def test_kernel_rejects_no_bunching(self):
-        with pytest.warns(DeprecationWarning):
+    def _assert_removed_message(self, message: str) -> None:
+        assert "no_bunching" in message
+        assert "ComputationSpace.UNBUNCHED" in message
+        assert "ComputationSpace.FOCK" in message
+
+    def _assert_no_deprecation_warning(self, warning_list) -> None:
+        assert not any(
+            issubclass(warning.category, DeprecationWarning)
+            for warning in warning_list
+        )
+
+    @pytest.mark.parametrize("no_bunching", [True, False])
+    def test_kernel_rejects_no_bunching(self, no_bunching: bool):
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
             with pytest.raises(ValueError) as exc_info:
                 FidelityKernel(
                     feature_map=self.feature_map,
                     input_state=[2, 0],
-                    no_bunching=True,
+                    no_bunching=no_bunching,
                 )
-        assert "no_bunching" in str(exc_info.value)
+        self._assert_no_deprecation_warning(warning_list)
+        self._assert_removed_message(str(exc_info.value))
 
-        with pytest.warns(DeprecationWarning):
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
             with pytest.raises(ValueError) as exc_info:
-                FidelityKernel.simple(input_size=2, no_bunching=True)
-        assert "no_bunching" in str(exc_info.value)
+                FidelityKernel.simple(input_size=2, no_bunching=no_bunching)
+        self._assert_no_deprecation_warning(warning_list)
+        self._assert_removed_message(str(exc_info.value))
 
-        builder = KernelCircuitBuilder().input_size(2).n_modes(4)
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning, match="KernelCircuitBuilder"):
+            builder = KernelCircuitBuilder()
+        builder = builder.input_size(2).n_modes(4)
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
             with pytest.raises(ValueError) as exc_info:
-                builder.build_fidelity_kernel(no_bunching=True)
-        assert "no_bunching" in str(exc_info.value)
+                builder.build_fidelity_kernel(no_bunching=no_bunching)
+        self._assert_no_deprecation_warning(warning_list)
+        self._assert_removed_message(str(exc_info.value))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/algorithms/test_kernels_deprecation.py
+++ b/tests/algorithms/test_kernels_deprecation.py
@@ -293,8 +293,7 @@ class TestRemovedNoBunchingParam:
 
     def _assert_no_deprecation_warning(self, warning_list) -> None:
         assert not any(
-            issubclass(warning.category, DeprecationWarning)
-            for warning in warning_list
+            issubclass(warning.category, DeprecationWarning) for warning in warning_list
         )
 
     @pytest.mark.parametrize("no_bunching", [True, False])

--- a/tests/bridge/test_quantum_bridge.py
+++ b/tests/bridge/test_quantum_bridge.py
@@ -9,7 +9,10 @@ from merlin.bridge.quantum_bridge import QuantumBridge
 
 
 def make_identity_layer(
-    m: int, n_photons: int, *, no_bunching: bool = True
+    m: int,
+    n_photons: int,
+    *,
+    computation_space: ComputationSpace = ComputationSpace.UNBUNCHED,
 ) -> QuantumLayer:
     c = pcvl.Circuit(m)  # identity unitary
     layer = QuantumLayer(
@@ -18,7 +21,7 @@ def make_identity_layer(
         device=torch.device("cpu"),
         dtype=torch.float32,
         measurement_strategy=MeasurementStrategy.probs(
-            computation_space=ComputationSpace.default(no_bunching=no_bunching)
+            computation_space=computation_space
         ),
     )
     return layer
@@ -264,7 +267,11 @@ def test_bridge_properties_exposed():
 def test_bridge_fock_space_matches_layer_keys():
     groups = [1, 1]
     m = sum(2**g for g in groups)
-    layer = make_identity_layer(m, n_photons=len(groups), no_bunching=False)
+    layer = make_identity_layer(
+        m,
+        n_photons=len(groups),
+        computation_space=ComputationSpace.FOCK,
+    )
     bridge = QuantumBridge(
         qubit_groups=groups,
         n_modes=m,

--- a/tests/core/test_unbunched.py
+++ b/tests/core/test_unbunched.py
@@ -530,8 +530,7 @@ class TestNoBunchingFunctionality:
                 )
 
         assert not any(
-            issubclass(warning.category, DeprecationWarning)
-            for warning in warning_list
+            issubclass(warning.category, DeprecationWarning) for warning in warning_list
         )
         message = str(exc_info.value)
         assert "MeasurementStrategy.probs" in message

--- a/tests/core/test_unbunched.py
+++ b/tests/core/test_unbunched.py
@@ -25,6 +25,7 @@ Tests for UNBUNCHED vs FOCK computation-space behavior in quantum computation.
 """
 
 import math
+import warnings
 
 import pytest
 import torch
@@ -512,13 +513,14 @@ class TestNoBunchingFunctionality:
                 "Conversion from distribution_full_fock_space to distribution_unbunched completed successfully"
             )
 
-    def test_no_bunching_deprecation_warning_and_error(self):
-        """Passing no_bunching should warn and raise a ValueError."""
+    def test_no_bunching_removed_error_without_warning(self):
+        """Passing no_bunching should raise a removal error without a warning."""
         circuit = _build_parallel_columns(2, 1).to_pcvl_circuit()
         input_state = list(generate_state(2, 1, StatePattern.SEQUENTIAL))
 
-        with pytest.warns(DeprecationWarning):
-            with pytest.raises(ValueError):
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
+            with pytest.raises(ValueError) as exc_info:
                 ComputationProcessFactory.create(
                     circuit=circuit,
                     input_state=input_state,
@@ -527,13 +529,23 @@ class TestNoBunchingFunctionality:
                     no_bunching=True,
                 )
 
+        assert not any(
+            issubclass(warning.category, DeprecationWarning)
+            for warning in warning_list
+        )
+        message = str(exc_info.value)
+        assert "MeasurementStrategy.probs" in message
+        assert "ComputationSpace.UNBUNCHED" in message
+        assert "ComputationSpace.FOCK" in message
+
 
 @pytest.mark.parametrize("no_bunching", [True, False])
 def test_quantum_layer_rejects_no_bunching(no_bunching: bool):
     circuit = _build_series(4, 2).to_pcvl_circuit()
     input_state = list(generate_state(4, 2, StatePattern.PERIODIC))
 
-    with pytest.warns(DeprecationWarning):
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
         with pytest.raises(ValueError) as exc_info:
             QuantumLayer(
                 input_size=3,
@@ -544,6 +556,9 @@ def test_quantum_layer_rejects_no_bunching(no_bunching: bool):
                 no_bunching=no_bunching,
             )
 
+    assert not any(
+        issubclass(warning.category, DeprecationWarning) for warning in warning_list
+    )
     message = str(exc_info.value)
     assert "MeasurementStrategy.probs" in message
     assert "ComputationSpace.UNBUNCHED" in message
@@ -552,10 +567,14 @@ def test_quantum_layer_rejects_no_bunching(no_bunching: bool):
 
 @pytest.mark.parametrize("no_bunching", [True, False])
 def test_quantum_layer_simple_rejects_no_bunching(no_bunching: bool):
-    with pytest.warns(DeprecationWarning):
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
         with pytest.raises(ValueError) as exc_info:
             QuantumLayer.simple(input_size=2, no_bunching=no_bunching)
 
+    assert not any(
+        issubclass(warning.category, DeprecationWarning) for warning in warning_list
+    )
     message = str(exc_info.value)
     assert "MeasurementStrategy.probs" in message
     assert "ComputationSpace.UNBUNCHED" in message

--- a/tests/measurement/test_detectors.py
+++ b/tests/measurement/test_detectors.py
@@ -984,6 +984,6 @@ def test_detector_transform_row():
     transform = DetectorTransform(simulation_keys, detectors, partial_measurement=False)
     row = transform.row(index=0)
     expected = torch.tensor([1.0])
-    assert torch.allclose(
-        row, expected
-    ), f"Unexpected value for row: got {row}, expected: {expected}"
+    assert torch.allclose(row, expected), (
+        f"Unexpected value for row: got {row}, expected: {expected}"
+    )

--- a/tests/measurement/test_measurement_deprecations.py
+++ b/tests/measurement/test_measurement_deprecations.py
@@ -65,7 +65,7 @@ class TestMeasurementStrategyDeprecations:
             AttributeError,
             match="Use MeasurementStrategy.probs",
         ):
-            layer = QuantumLayer(
+            QuantumLayer(
                 input_size=0,
                 circuit=circuit,
                 input_state=[1, 0],
@@ -77,7 +77,7 @@ class TestMeasurementStrategyDeprecations:
             AttributeError,
             match="Use MeasurementStrategy.amplitudes",
         ):
-            layer = QuantumLayer(
+            QuantumLayer(
                 input_size=0,
                 circuit=circuit,
                 input_state=[1, 0],
@@ -89,7 +89,7 @@ class TestMeasurementStrategyDeprecations:
             AttributeError,
             match="Use MeasurementStrategy.mode_expectations",
         ):
-            layer = QuantumLayer(
+            QuantumLayer(
                 input_size=0,
                 circuit=circuit,
                 input_state=[1, 0],
@@ -99,7 +99,7 @@ class TestMeasurementStrategyDeprecations:
 
     def test_deprecated_enum_none_sill_passes_in_quantum_layer(self):
         circuit = pcvl.Circuit(2)
-        layer = QuantumLayer(
+        QuantumLayer(
             input_size=0,
             circuit=circuit,
             input_state=[1, 0],
@@ -112,7 +112,7 @@ class TestMeasurementStrategyDeprecations:
             TypeError,
             match="Passing measurement_strategy as a string is no longer supported as of v0.4.",
         ):
-            layer = QuantumLayer(
+            QuantumLayer(
                 input_size=0,
                 circuit=circuit,
                 input_state=[1, 0],
@@ -125,7 +125,7 @@ class TestMeasurementStrategyDeprecations:
             TypeError,
             match="Passing measurement_strategy as a string is no longer supported as of v0.4.",
         ):
-            layer = QuantumLayer(
+            QuantumLayer(
                 input_size=0,
                 circuit=circuit,
                 input_state=[1, 0],
@@ -138,7 +138,7 @@ class TestMeasurementStrategyDeprecations:
             TypeError,
             match="Passing measurement_strategy as a string is no longer supported as of v0.4.",
         ):
-            layer = QuantumLayer(
+            QuantumLayer(
                 input_size=0,
                 circuit=circuit,
                 input_state=[1, 0],
@@ -151,7 +151,7 @@ class TestMeasurementStrategyDeprecations:
             AttributeError,
             match="Cannot specify 'computation_space' in QuantumLayer's constructor. Move",
         ):
-            layer = QuantumLayer(
+            QuantumLayer(
                 input_size=0,
                 circuit=circuit,
                 input_state=[1, 0],
@@ -161,7 +161,7 @@ class TestMeasurementStrategyDeprecations:
             AttributeError,
             match="Cannot specify 'computation_space' in QuantumLayer's constructor.",
         ):
-            layer = QuantumLayer(
+            QuantumLayer(
                 input_size=0,
                 circuit=circuit,
                 input_state=[1, 0],
@@ -172,7 +172,7 @@ class TestMeasurementStrategyDeprecations:
             AttributeError,
             match="Cannot specify 'computation_space' in QuantumLayer's constructor.",
         ):
-            layer = QuantumLayer(
+            QuantumLayer(
                 input_size=0,
                 circuit=circuit,
                 input_state=[1, 0],
@@ -184,7 +184,7 @@ class TestMeasurementStrategyDeprecations:
             AttributeError,
             match="Cannot specify 'computation_space' in QuantumLayer's constructor.",
         ):
-            layer = QuantumLayer(
+            QuantumLayer(
                 input_size=0,
                 circuit=circuit,
                 input_state=[1, 0],
@@ -196,7 +196,7 @@ class TestMeasurementStrategyDeprecations:
             AttributeError,
             match="Cannot specify 'computation_space' in QuantumLayer's constructor.",
         ):
-            layer = QuantumLayer(
+            QuantumLayer(
                 input_size=0,
                 circuit=circuit,
                 input_state=[1, 0],
@@ -208,7 +208,7 @@ class TestMeasurementStrategyDeprecations:
             AttributeError,
             match="Cannot specify 'computation_space' in QuantumLayer's constructor.",
         ):
-            layer = QuantumLayer(
+            QuantumLayer(
                 input_size=0,
                 circuit=circuit,
                 input_state=[1, 0],
@@ -219,13 +219,13 @@ class TestMeasurementStrategyDeprecations:
     def modern_factory_raises_no_error():
         circuit = pcvl.Circuit(2)
 
-        layer = QuantumLayer(
+        QuantumLayer(
             input_size=0,
             circuit=circuit,
             input_state=[1, 0],
         )
 
-        layer = QuantumLayer(
+        QuantumLayer(
             input_size=0,
             circuit=circuit,
             input_state=[1, 0],
@@ -233,14 +233,14 @@ class TestMeasurementStrategyDeprecations:
         )
 
         # probs
-        layer = QuantumLayer(
+        QuantumLayer(
             input_size=0,
             circuit=circuit,
             input_state=[1, 0],
             measurement_strategy=MeasurementStrategy.probs(),
         )
 
-        layer = QuantumLayer(
+        QuantumLayer(
             input_size=0,
             circuit=circuit,
             input_state=[1, 0],
@@ -250,14 +250,14 @@ class TestMeasurementStrategyDeprecations:
         )
 
         # amplitudes
-        layer = QuantumLayer(
+        QuantumLayer(
             input_size=0,
             circuit=circuit,
             input_state=[1, 0],
             measurement_strategy=MeasurementStrategy.amplitudes(),
         )
 
-        layer = QuantumLayer(
+        QuantumLayer(
             input_size=0,
             circuit=circuit,
             input_state=[1, 0],
@@ -267,14 +267,14 @@ class TestMeasurementStrategyDeprecations:
         )
 
         # mode expectation
-        layer = QuantumLayer(
+        QuantumLayer(
             input_size=0,
             circuit=circuit,
             input_state=[1, 0],
             measurement_strategy=MeasurementStrategy.mode_expectations(),
         )
 
-        layer = QuantumLayer(
+        QuantumLayer(
             input_size=0,
             circuit=circuit,
             input_state=[1, 0],
@@ -284,14 +284,14 @@ class TestMeasurementStrategyDeprecations:
         )
 
         # Partial
-        layer = QuantumLayer(
+        QuantumLayer(
             input_size=0,
             circuit=circuit,
             input_state=[1, 0],
             measurement_strategy=MeasurementStrategy.partial(modes=[0]),
         )
 
-        layer = QuantumLayer(
+        QuantumLayer(
             input_size=0,
             circuit=circuit,
             input_state=[1, 0],

--- a/tests/measurement/test_measurement_strategy.py
+++ b/tests/measurement/test_measurement_strategy.py
@@ -999,7 +999,7 @@ class TestComputationSpaceConflictResolution:
             AttributeError,
             match="Cannot specify 'computation_space' in QuantumLayer's constructor. ",
         ):
-            layer = ML.QuantumLayer(
+            ML.QuantumLayer(
                 input_size=2,
                 n_photons=1,
                 builder=builder,

--- a/tests/measurement/test_photon_loss.py
+++ b/tests/measurement/test_photon_loss.py
@@ -447,13 +447,11 @@ class TestPhotonLossWithQuantumLayer:
         layer.train()
         probabilities = layer(x)
         probabilities = probabilities
-        target = torch.tensor(
-            [
-                [0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
-                [0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
-                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
-            ]
-        )
+        target = torch.tensor([
+            [0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+        ])
 
         cel = torch.nn.CrossEntropyLoss()
         loss = cel(probabilities, target)

--- a/tests/pcvl_pytorch/test_slos_torchscript.py
+++ b/tests/pcvl_pytorch/test_slos_torchscript.py
@@ -104,20 +104,20 @@ def test_slos_save_load_computation_graph(get_tmp_file):
     # Test for vectorized_operations
     assert len(graph.vectorized_operations) == len(
         loaded_graph.vectorized_operations
-    ), (sDoesntMatch + "vectorized_operations (length mismatch)")
+    ), sDoesntMatch + "vectorized_operations (length mismatch)"
 
     for i, (tuple1, tuple2) in enumerate(
         zip(
             graph.vectorized_operations, loaded_graph.vectorized_operations, strict=True
         )
     ):
-        assert len(tuple1) == len(
-            tuple2
-        ), f"{sDoesntMatch}vectorized_operations (tuple {i} length mismatch)"
+        assert len(tuple1) == len(tuple2), (
+            f"{sDoesntMatch}vectorized_operations (tuple {i} length mismatch)"
+        )
         for j, (tensor1, tensor2) in enumerate(zip(tuple1, tuple2, strict=True)):
-            assert torch.equal(
-                tensor1, tensor2
-            ), f"{sDoesntMatch}vectorized_operations (tuple {i}, tensor {j})"
+            assert torch.equal(tensor1, tensor2), (
+                f"{sDoesntMatch}vectorized_operations (tuple {i}, tensor {j})"
+            )
 
     assert graph.final_keys == loaded_graph.final_keys, sDoesntMatch + "final_keys"
     assert graph.mapped_keys == loaded_graph.mapped_keys, sDoesntMatch + "mapped_keys"
@@ -182,9 +182,9 @@ def test_slos_compute_slos_distribution_with_output_map_function():
         (0, 0, 0, 2),
     ]
     expected_keys = [i[::-1] for i in expected_keys]
-    assert (
-        keys == expected_keys
-    ), f"Keys do not match : expected {expected_keys}, calculated {keys}"
+    assert keys == expected_keys, (
+        f"Keys do not match : expected {expected_keys}, calculated {keys}"
+    )
 
     expected_amplitudes = torch.tensor(
         [


### PR DESCRIPTION
## Summary
Remove the deprecated `no_bunching` compatibility path for 0.4 and require explicit `ComputationSpace` configuration instead.

## Related Issue
Related Jira: PML-352

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [x] Refactor / Cleanup
- [ ] Performance improvement
- [ ] CI / Build / Tooling
- [x] Breaking change (requires migration notes)

## Proposed changes
- Hard-reject `no_bunching` for `QuantumLayer`, `QuantumLayer.simple`, `FidelityKernel`, `FidelityKernel.simple`, and `KernelCircuitBuilder.build_fidelity_kernel`.
- Replace the warning-backed `raise_no_bunching_deprecated` path with a no-warning `raise_no_bunching_removed` error.
- Remove `ComputationSpace.default(no_bunching=...)` and update internal test helpers to use explicit `ComputationSpace`.
- Update removal tests so `no_bunching` raises clearly without emitting `DeprecationWarning`.
- Update user/API docs and one reproduced-paper snippet to show explicit `ComputationSpace.UNBUNCHED` and `ComputationSpace.FOCK` usage.

## How to test / How to run
1. Focused removal and affected-path tests

```powershell
.\.venv\Scripts\python.exe -m pytest -p no:cacheprovider tests\core\test_unbunched.py tests\algorithms\test_kernels_deprecation.py tests\bridge\test_quantum_bridge.py tests\measurement\test_measurement_deprecations.py tests\measurement\test_measurement_strategy.py
```

2. Full tracked test suite

```powershell
$tests = git ls-files -- 'tests/**/test_*.py'
.\.venv\Scripts\python.exe -m pytest -p no:cacheprovider $tests
```

3. Pre-commit

```powershell
.\.venv\Scripts\python.exe -m pre_commit run --all-files
```

4. Docs

```powershell
$env:SPHINXOPTS='-W --keep-going -n'
$env:SPHINXBUILD='..\.venv\Scripts\sphinx-build.exe'
cd docs
.\make.bat clean
.\make.bat html
```

## Screenshots / Logs (optional)
Focused tests: `104 passed, 4 skipped`.

Full tracked test suite: `961 passed, 106 skipped`.

Pre-commit: ruff, ruff format, and mypy passed.

Docs: Sphinx clean/html passed with `-W --keep-going -n`.

## Performance considerations (optional)
No expected runtime performance impact. The change removes legacy argument handling and updates tests/docs.

## Documentation
- [x] User docs updated (Sphinx)
- [x] Examples / notebooks updated
- [x] Docstrings updated
- [x] Updated the API

## Checklist
- [x] PR title includes Jira issue key (e.g., PML-126)
- [x] "Related Jira ticket" section includes the Jira issue key (no URL)
- [x] Code formatted (ruff format)
- [x] Lint passes (ruff)
- [x] Static typing passes (mypy) if applicable
- [x] Unit tests added/updated (pytest)
- [x] Tests pass locally (pytest)
- [ ] Tests pass on GPU (pytest)
- [ ] Test coverage not decreased significantly
- [x] Docs build locally if affected (sphinx)
- [x] With this command:

        > SPHINXOPTS="-W --keep-going -n" make -C docs clean html

    the docs are built without any warning or errors.
- [x] New public classes/methods/packages are added in the API following the methodology presented in other files.
- [ ] Dependencies updated (if needed) and pinned appropriately
- [x] PR description explains what changed and how to validate it
