### PR TITLE
PML-374 Add memristor noise tests and TBPTT docs

### DIFF
--- a/docs/source/api_reference/api/merlin.algorithms.layer.rst
+++ b/docs/source/api_reference/api/merlin.algorithms.layer.rst
@@ -331,15 +331,13 @@ The snippet below prepares a basic quantum layer and returns a :class:`~merlin.c
 
 Memristive phase-shifter
 -------------------------
-When using the :class:`~merlin.builder.circuit_builder.CircuitBuilder` that contains memristive phase-shifters (added with the :meth:`~merlin.builder.circuit_builder.CircuitBuilder.add_memristive_ps` method) to create a :class:`~merlin.algorithms.layer.QuantumLayer`, it is important to set the batch size. To do so, call the :meth:`~merlin.algorithms.layer.QuantumLayer.reset` method. This resets the memristors to their initial state while clearing their history.
-It also prepares the memristors to be run with the specified ``batch_size`` parameter of the function, which defaults to 1.
+Memristive phase-shifters carry state across forward passes. When a :class:`~merlin.algorithms.layer.QuantumLayer` is built from a :class:`~merlin.builder.circuit_builder.CircuitBuilder` that contains memristive phase-shifters added with :meth:`~merlin.builder.circuit_builder.CircuitBuilder.add_memristive_ps`, call :meth:`~merlin.algorithms.layer.QuantumLayer.reset` before processing a new sequence or batch.
 
-The :class:`~merlin.algorithms.layer.QuantumLayer` expects all forward passes to use the configured ``batch_size`` unless :meth:`~merlin.algorithms.layer.QuantumLayer.reset` is called again.
-This method resets the memristors to their initial state while clearing the history. It also
-defines the allowed batch size to be ran per forward pass for circuits with memristive phase shifters. Here is an example to run a N dimension batch.
+``reset(batch_size=...)`` restores each memristor to its initial state, clears :attr:`~merlin.algorithms.layer.QuantumLayer.memristive_history`, and sets the batch size expected by later forward passes. Until ``reset`` is called again, all forward passes must use that configured batch size.
 
 .. code-block:: python
 
+    import torch
     import merlin as ML
 
     circ = ML.CircuitBuilder(n_modes=3)
@@ -354,63 +352,78 @@ defines the allowed batch size to be ran per forward pass for circuits with memr
         ),
     )
 
-    input_tensor=torch.rand((5,2))
+    input_tensor = torch.rand((5, 2))
 
-    # Will fail since it expects tensor of batch dimension of 1 not 5.
-    # probs=ql(input_tensor)
+    # This would fail because the default memristive batch size is 1.
+    # probs = ql(input_tensor)
 
-    # Will pass since the layer was reset to accept tensors of batch dimension 5.
-    ql.reset(5)
-    probs=ql(input_tensor)
+    ql.reset(batch_size=5)
+    probs = ql(input_tensor)
 
-The current state of the memristive phase-shifters can be accessed with the :attr:`~merlin.algorithms.layer.QuantumLayer.memristive_state` attribute. The full history of the memristive phase-shifters can be accessed
-with the :attr:`~merlin.algorithms.layer.QuantumLayer.memristive_history` attribute. The order of the states and history is defined by the order in which the memristive phase-shifters were added in the :class:`~merlin.builder.circuit_builder.CircuitBuilder`.
+The current state of each memristive phase-shifter is available through :attr:`~merlin.algorithms.layer.QuantumLayer.memristive_state`. The full state history is available through :attr:`~merlin.algorithms.layer.QuantumLayer.memristive_history`. Both lists follow the order in which the memristive phase-shifters were added to the :class:`~merlin.builder.circuit_builder.CircuitBuilder`.
 
 **Gradient Flow Control**
 
 When defining a memristive phase-shifter using :meth:`~merlin.builder.circuit_builder.CircuitBuilder.add_memristive_ps`, the ``detach_at_each_forward`` parameter controls how gradients flow through the memristive state recurrence.
 
-Since the memristive state at time *t* depends on the previous state and the output at *t-1*, gradients would normally propagate through the entire history during backpropagation. The ``detach_at_each_forward`` parameter controls this behavior:
+At time step ``t``, the layer uses the current memristive state as the phase value. After the forward pass, the memristor's ``update_rule`` receives the current state and the layer output, then returns the state used at time step ``t + 1``. The numerical state is carried forward in every regime below; only the retained PyTorch autograd history changes.
 
-- ``detach_at_each_forward=True`` (default): New states are detached after computation, blocking gradients from flowing back through the state recurrence. Earlier inputs will receive zero gradients from the memristive state chain, but backpropagation remains fast.
-- ``detach_at_each_forward=False``: New states retain gradients, allowing full gradient flow through the entire accumulated state history. This enables learning from all historical states but may be more computationally expensive.
+Use :meth:`~merlin.algorithms.layer.QuantumLayer.detach_memristive_state` at a TBPTT boundary when the next chunk should keep the current numerical state but stop backpropagating through earlier recurrent updates. Use ``reset`` instead when starting a new independent sequence.
 
-The full history of states is always maintained in :attr:`~merlin.algorithms.layer.QuantumLayer.memristive_history` regardless of the ``detach_at_each_forward`` setting.
+The common gradient-history regimes are:
 
-For manual truncated backpropagation through time (TBPTT), set ``detach_at_each_forward=False`` so gradients flow inside each chunk, then call :meth:`~merlin.algorithms.layer.QuantumLayer.detach_memristive_state` at the chunk boundary. This keeps the current numerical memristive state, but cuts the recurrent autograd graph before the next chunk.
+- **No recurrent gradient steps**: use ``detach_at_each_forward=True``, the default. The memristive state still updates after each forward pass, but each new state is detached from the graph. A later loss does not backpropagate through earlier memristive state updates.
+- **All recurrent gradient steps**: use ``detach_at_each_forward=False`` and do not manually detach during the sequence. Backpropagation can traverse the full memristive history since the last ``reset()``. This is full backpropagation through time and uses more memory as the sequence grows.
+- **N recurrent gradient steps**: use ``detach_at_each_forward=False`` and call ``detach_memristive_state(clear_history=True)`` every ``n`` time steps. This is truncated backpropagation through time (TBPTT): gradients flow inside the current chunk, while the current numerical state is preserved for the next chunk.
+
+The full history of states is maintained in :attr:`~merlin.algorithms.layer.QuantumLayer.memristive_history` until :meth:`~merlin.algorithms.layer.QuantumLayer.reset` is called or :meth:`~merlin.algorithms.layer.QuantumLayer.detach_memristive_state` is called with ``clear_history=True``.
+
+The examples below assume ``torch``, ``ql``, ``optimizer``, ``criterion``, ``inputs``, and ``targets`` already exist, and that each ``x_t`` is one time step with the batch size configured by ``ql.reset(batch_size=...)``. Construct the memristive phase-shifter with the ``detach_at_each_forward`` setting named by each case.
+
+No recurrent gradient steps:
 
 .. code-block:: python
-    
-    import torch
-    import merlin as ML
 
-    # Define the memristive layer
-    circ.add_entangling_layer()
-    circ.add_memristive_ps(
-        mode=1, update_rule=update_rule, initial_state=1.2, detach_at_each_forward=False
-    )
-    circ.add_angle_encoding(modes=[0, 2])
-    circ.add_entangling_layer()
+    ql.reset(batch_size=batch_size)
 
-    ql = ML.QuantumLayer(
-        builder=circ,
-        n_photons=3,
-        input_size=2,  # Two input angles for modes [0, 2]
-        measurement_strategy=ML.MeasurementStrategy.probs(
-            computation_space=ML.ComputationSpace.FOCK
-        ),
-    )
+    for x_t, target_t in zip(inputs, targets):
+        optimizer.zero_grad(set_to_none=True)
 
-    ql.reset(batch_size=1)
-    optimizer = torch.optim.Adam(ql.parameters(), lr=1e-3)
+        prediction = ql(x_t)
+        loss = criterion(prediction, target_t)
 
-    k = 3  # Number of timesteps per TBPTT chunk
-    
-    for chunk in sequence_chunks(inputs, targets, k):
-        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+
+All recurrent gradient steps:
+
+.. code-block:: python
+
+    ql.reset(batch_size=batch_size)
+    optimizer.zero_grad(set_to_none=True)
+
+    loss = torch.zeros((), dtype=ql.dtype, device=ql.device)
+    for x_t, target_t in zip(inputs, targets):
+        prediction = ql(x_t)
+        loss = loss + criterion(prediction, target_t)
+
+    loss.backward()
+    optimizer.step()
+
+N recurrent gradient steps with TBPTT:
+
+.. code-block:: python
+
+    ql.reset(batch_size=batch_size)
+
+    for start in range(0, len(inputs), n):
+        input_chunk = inputs[start : start + n]
+        target_chunk = targets[start : start + n]
+
+        optimizer.zero_grad(set_to_none=True)
+
         loss = torch.zeros((), dtype=ql.dtype, device=ql.device)
-
-        for x_t, target_t in chunk:
+        for x_t, target_t in zip(input_chunk, target_chunk):
             prediction = ql(x_t)
             loss = loss + criterion(prediction, target_t)
 

--- a/tests/algorithms/test_noise_contract.py
+++ b/tests/algorithms/test_noise_contract.py
@@ -255,6 +255,31 @@ def _component_phase_error_circuit() -> pcvl.Circuit:
     return circuit
 
 
+def _phase_interferometer_builder(rotation_value: float) -> ml.CircuitBuilder:
+    """Create a fixed phase interferometer matching the memristive test circuit."""
+    builder = ml.CircuitBuilder(n_modes=2)
+    builder.add_superpositions(targets=(0, 1), theta=0.785398)
+    builder.add_rotations(modes=0, value=rotation_value)
+    builder.add_superpositions(targets=(0, 1), theta=0.785398)
+    return builder
+
+
+def _memristive_phase_interferometer_builder(
+    update_rule,
+    initial_state: float,
+) -> ml.CircuitBuilder:
+    """Create the same interferometer with a memristive phase shifter."""
+    builder = ml.CircuitBuilder(n_modes=2)
+    builder.add_superpositions(targets=(0, 1), theta=0.785398)
+    builder.add_memristive_ps(
+        mode=0,
+        update_rule=update_rule,
+        initial_state=initial_state,
+    )
+    builder.add_superpositions(targets=(0, 1), theta=0.785398)
+    return builder
+
+
 def _assert_normalized_distribution(output: torch.Tensor, size: int) -> None:
     assert output.shape[-1] == size
     assert not output.is_complex()
@@ -281,6 +306,47 @@ def test_phase_imprecision_with_probs_constructs_and_forwards():
     assert layer.computation_process.converter._phase_imprecision == pytest.approx(0.5)
 
 
+def test_phase_imprecision_quantizes_memristive_layer_phase():
+    initial_state = 0.74
+
+    def keep_state(state: torch.Tensor, output: torch.Tensor) -> torch.Tensor:
+        return state
+
+    memristive_layer = ml.QuantumLayer(
+        input_size=0,
+        builder=_memristive_phase_interferometer_builder(
+            keep_state,
+            initial_state,
+        ),
+        input_state=[1, 0],
+        n_photons=1,
+        noise=pcvl.NoiseModel(phase_imprecision=0.5),
+        measurement_strategy=ml.MeasurementStrategy.probs(
+            computation_space=ml.ComputationSpace.FOCK
+        ),
+        dtype=torch.float64,
+    )
+    fixed_quantized_layer = ml.QuantumLayer(
+        input_size=0,
+        builder=_phase_interferometer_builder(0.5),
+        input_state=[1, 0],
+        n_photons=1,
+        measurement_strategy=ml.MeasurementStrategy.probs(
+            computation_space=ml.ComputationSpace.FOCK
+        ),
+        dtype=torch.float64,
+    )
+
+    memristive_output = memristive_layer()
+    fixed_quantized_output = fixed_quantized_layer()
+
+    assert torch.allclose(memristive_output, fixed_quantized_output)
+    assert torch.allclose(
+        memristive_layer.memristive_state[0],
+        memristive_output.new_tensor([initial_state]),
+    )
+
+
 def test_phase_error_with_probs_constructs_and_forwards():
     layer = ml.QuantumLayer(
         input_size=0,
@@ -301,6 +367,42 @@ def test_phase_error_with_probs_constructs_and_forwards():
 
     _assert_normalized_distribution(output, 2)
     assert layer.computation_process._n_phase_error_samples == 4
+
+
+def test_phase_error_memristive_layer_updates_from_noisy_probabilities():
+    def update_from_first_probability(
+        state: torch.Tensor,
+        output: torch.Tensor,
+    ) -> torch.Tensor:
+        return output[:, 0]
+
+    builder = _memristive_phase_interferometer_builder(
+        update_from_first_probability,
+        initial_state=0.74,
+    )
+    builder.add_angle_encoding(modes=[1], name="x")
+    layer = ml.QuantumLayer(
+        input_size=1,
+        builder=builder,
+        input_state=[1, 0],
+        n_photons=1,
+        noise=pcvl.NoiseModel(phase_error=0.25),
+        n_phase_error_samples=5,
+        measurement_strategy=ml.MeasurementStrategy.probs(
+            computation_space=ml.ComputationSpace.FOCK
+        ),
+        dtype=torch.float64,
+    )
+    layer.reset(batch_size=2)
+
+    torch.manual_seed(123)
+    output = layer(torch.zeros(2, 1, dtype=torch.float64))
+
+    _assert_normalized_distribution(output, 2)
+    assert layer.computation_process._n_phase_error_samples == 5
+    assert layer.computation_process.converter._phase_error == pytest.approx(0.25)
+    assert torch.allclose(layer.memristive_state[0], output[:, 0])
+    assert torch.allclose(layer.memristive_history[0][-1], output[:, 0])
 
 
 def test_phase_error_with_probs_defaults_to_one_sample():

--- a/tests/pcvl_pytorch/test_phase_noise_converter.py
+++ b/tests/pcvl_pytorch/test_phase_noise_converter.py
@@ -39,6 +39,22 @@ def _single_phase_circuit() -> pcvl.Circuit:
     return pcvl.Circuit(1) // pcvl.PS(pcvl.P("phi"))
 
 
+def _single_memristive_phase_circuit() -> pcvl.Circuit:
+    return pcvl.Circuit(1) // pcvl.PS(pcvl.P("mem1"))
+
+
+def _memristive_metadata() -> list[dict]:
+    return [
+        {
+            "target_mode": 0,
+            "name": "mem1",
+            "update_rule": lambda state, output: state,
+            "initial_state": 0.0,
+            "detach_at_each_forward": True,
+        }
+    ]
+
+
 def _expected_phase_unitary(
     phase: torch.Tensor | float, dtype: torch.dtype
 ) -> torch.Tensor:
@@ -76,6 +92,23 @@ def test_phase_imprecision_quantizes_forward_phase_values():
 
     phase = torch.tensor([0.74], dtype=torch.float64)
     unitary = converter.to_tensor(phase)
+
+    expected = _expected_phase_unitary(0.5, torch.float64)
+    assert torch.allclose(unitary, expected)
+
+
+def test_phase_imprecision_quantizes_memristive_phase_values():
+    circuit = _single_memristive_phase_circuit()
+    converter = CircuitConverter(
+        circuit,
+        input_specs=[],
+        memristive_metadata=_memristive_metadata(),
+        dtype=torch.float64,
+        phase_imprecision=0.5,
+    )
+    memristive_state = torch.tensor([0.74], dtype=torch.float64)
+
+    unitary = converter.to_tensor(memristive_current_state=[memristive_state])
 
     expected = _expected_phase_unitary(0.5, torch.float64)
     assert torch.allclose(unitary, expected)
@@ -157,6 +190,37 @@ def test_different_torch_seeds_produce_different_phase_error_samples():
     second = converter.to_tensor(phase, apply_phase_error=True)
 
     assert not torch.allclose(first, second)
+
+
+def test_active_phase_error_perturbs_memristive_phase_values():
+    circuit = _single_memristive_phase_circuit()
+    phase_error = 0.25
+    converter = CircuitConverter(
+        circuit,
+        input_specs=[],
+        memristive_metadata=_memristive_metadata(),
+        dtype=torch.float64,
+        phase_error=phase_error,
+    )
+    memristive_state = torch.tensor([0.74], dtype=torch.float64)
+
+    torch.manual_seed(1234)
+    phase_error_sample = torch.empty_like(memristive_state).uniform_(
+        -phase_error,
+        phase_error,
+    )
+    expected = _expected_phase_unitary(
+        memristive_state + phase_error_sample,
+        torch.float64,
+    )
+
+    torch.manual_seed(1234)
+    unitary = converter.to_tensor(
+        memristive_current_state=[memristive_state],
+        apply_phase_error=True,
+    )
+
+    assert torch.allclose(unitary, expected)
 
 
 def test_phase_error_is_inactive_without_apply_phase_error_flag():


### PR DESCRIPTION
Adds regression coverage for memristive phase-shifters under circuit phase noise and clarifies the memristive TBPTT documentation.

The tests assert that memristive phase values participate in the existing phase-noise contract:

- `phase_imprecision` quantizes memristive phase values.
- active `phase_error` perturbs memristive phase values.
- memristive state updates receive outputs produced by noisy phase evaluation.

The docs now describe the three memristive gradient-history regimes directly: no recurrent gradient steps, all recurrent gradient steps, and N-step TBPTT.

## Related Issue

Related Jira: PML-374

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / Cleanup
- [ ] Performance improvement
- [ ] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)

## Proposed changes

- Add low-level phase-noise converter tests for memristive phase-shifters.
- Add `QuantumLayer` noise-contract tests covering memristive `phase_imprecision` and active `phase_error`.
- Update the memristive phase-shifter docs to explain:
  - `reset(batch_size=...)` versus `detach_memristive_state(clear_history=True)`;
  - default detached recurrence behavior;
  - full backpropagation through memristive history;
  - N-step TBPTT with inline chunk slicing.
- Remove the unclear undefined `sequence_chunks` example from the TBPTT docs.

## How to test / How to run

1. Run the focused new tests:

```powershell
.\.venv\Scripts\python.exe -m pytest tests/pcvl_pytorch/test_phase_noise_converter.py::test_phase_imprecision_quantizes_memristive_phase_values tests/pcvl_pytorch/test_phase_noise_converter.py::test_active_phase_error_perturbs_memristive_phase_values tests/algorithms/test_noise_contract.py::test_phase_imprecision_quantizes_memristive_layer_phase tests/algorithms/test_noise_contract.py::test_phase_error_memristive_layer_updates_from_noisy_probabilities
```

2. Run the touched test files:

```powershell
.\.venv\Scripts\python.exe -m pytest tests/pcvl_pytorch/test_phase_noise_converter.py tests/algorithms/test_noise_contract.py
```

3. Run lint for the touched test files:

```powershell
.\.venv\Scripts\ruff.exe check tests\pcvl_pytorch\test_phase_noise_converter.py tests\algorithms\test_noise_contract.py
```

4. Build docs with Sphinx warnings as errors:

```powershell
.\.venv\Scripts\sphinx-build.exe -M html docs\source docs\build -W --keep-going -n
```

## Screenshots / Logs (optional)

Focused new tests: `4 passed`

Touched test files: `77 passed, 1 skipped`

Ruff: `All checks passed!`

Docs: `build succeeded`

## Performance considerations (optional)

No expected runtime impact. This PR adds tests and documentation only.

## Documentation

- [x] User docs updated (Sphinx)
- [ ] Examples / notebooks updated
- [ ] Docstrings updated
- [x] Updated the API

## Checklist

- [x] PR title includes Jira issue key (e.g., PML-126)
- [x] "Related Jira ticket" section includes the Jira issue key (no URL)
- [ ] Code formatted (ruff format)
- [x] Lint passes (ruff)
- [ ] Static typing passes (mypy) if applicable
- [x] Unit tests added/updated (pytest)
- [x] Tests pass locally (pytest)
- [ ] Tests pass on GPU (pytest)
- [x] Test coverage not decreased significantly
- [x] Docs build locally if affected (sphinx)
- [ ] With this command:

        > SPHINXOPTS="-W --keep-going -n" make -C docs clean html

    the docs are built without any warning or errors.

  Note: `make` is not available in this Windows environment. The equivalent direct Sphinx command passed:

        > .\.venv\Scripts\sphinx-build.exe -M html docs\source docs\build -W --keep-going -n

- [ ] New public classes/methods/packages are added in the API following the methodology presented in other files.
- [ ] Dependencies updated (if needed) and pinned appropriately
- [x] PR description explains what changed and how to validate it
