### PR TITLE
PML-383: Memristive layer unusable with batched amplitude input

### DIFF
--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -27,7 +27,7 @@ Main QuantumLayer implementation
 from __future__ import annotations
 
 import warnings
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, MutableMapping, Sequence
 from contextlib import contextmanager
 from typing import Any, cast
 
@@ -1499,7 +1499,7 @@ class QuantumLayer(MerlinModule):
         # Fatal deprecation is handled by the sanitize_parameters decorator via registry.
         return None
 
-    def to(self, *args, **kwargs):
+    def to(self, *args: Any, **kwargs: Any) -> QuantumLayer:
         """Move the layer and auxiliary transforms to a new device or dtype.
 
         Parameters
@@ -2212,7 +2212,12 @@ class QuantumLayer(MerlinModule):
                 else:
                     self.memristive_history[index] = []
 
-    def _save_to_state_dict(self, destination, prefix, keep_vars):
+    def _save_to_state_dict(
+        self,
+        destination: MutableMapping[str, Any],
+        prefix: str,
+        keep_vars: bool,
+    ) -> None:
         """Save module parameters plus memristive runtime state when present."""
         super()._save_to_state_dict(destination, prefix, keep_vars)
 
@@ -2227,14 +2232,14 @@ class QuantumLayer(MerlinModule):
 
     def _load_from_state_dict(
         self,
-        state_dict,
-        prefix,
-        local_metadata,
-        strict,
-        missing_keys,
-        unexpected_keys,
-        error_msgs,
-    ):
+        state_dict: MutableMapping[str, Any],
+        prefix: str,
+        local_metadata: dict[str, Any],
+        strict: bool,
+        missing_keys: list[str],
+        unexpected_keys: list[str],
+        error_msgs: list[str],
+    ) -> None:
         """Load module parameters plus memristive runtime state when present."""
         memristive_state_key = prefix + "_memristive_state"
         memristive_history_key = prefix + "_memristive_history"

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -1854,9 +1854,9 @@ class QuantumLayer(MerlinModule):
                 n_photons=self.n_photons,
                 keys=_normalize_sector_keys(self._raw_output_keys),
             )
-            distribution_to_use: SectoredDistribution = SectoredDistribution(
-                (sector_result,)
-            )
+            distribution_to_use: SectoredDistribution = SectoredDistribution((
+                sector_result,
+            ))
         else:
             distribution_to_use: SectoredDistribution = distribution
 
@@ -1910,9 +1910,9 @@ class QuantumLayer(MerlinModule):
                 n_photons=self.n_photons,
                 keys=_normalize_sector_keys(self._raw_output_keys),
             )
-            distribution_to_use: SectoredDistribution = SectoredDistribution(
-                (sector_result,)
-            )
+            distribution_to_use: SectoredDistribution = SectoredDistribution((
+                sector_result,
+            ))
         else:
             distribution_to_use: SectoredDistribution = distribution
 

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -1125,12 +1125,12 @@ class QuantumLayer(MerlinModule):
                 raise RuntimeError(
                     "Already ran a smaller batch size: call reset(batch_size=N) before using the layer again"
                 )
-            batch_dim=max(parameter_batch_dim,1)
-            if batch_dim==1 and amplitude_input is not None:
-                if amplitude_input.shape==1:
-                    batch_dim=1
+            batch_dim = max(parameter_batch_dim, 1)
+            if batch_dim == 1 and amplitude_input is not None:
+                if len(amplitude_input.shape) == 1:
+                    batch_dim = 1
                 else:
-                    batch_dim=amplitude_input.shape[0]
+                    batch_dim = amplitude_input.shape[0]
 
             state_dimensions = set()
             for state in self.memristive_state:
@@ -1854,9 +1854,9 @@ class QuantumLayer(MerlinModule):
                 n_photons=self.n_photons,
                 keys=_normalize_sector_keys(self._raw_output_keys),
             )
-            distribution_to_use: SectoredDistribution = SectoredDistribution((
-                sector_result,
-            ))
+            distribution_to_use: SectoredDistribution = SectoredDistribution(
+                (sector_result,)
+            )
         else:
             distribution_to_use: SectoredDistribution = distribution
 
@@ -1910,9 +1910,9 @@ class QuantumLayer(MerlinModule):
                 n_photons=self.n_photons,
                 keys=_normalize_sector_keys(self._raw_output_keys),
             )
-            distribution_to_use: SectoredDistribution = SectoredDistribution((
-                sector_result,
-            ))
+            distribution_to_use: SectoredDistribution = SectoredDistribution(
+                (sector_result,)
+            )
         else:
             distribution_to_use: SectoredDistribution = distribution
 

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -1125,8 +1125,12 @@ class QuantumLayer(MerlinModule):
                 raise RuntimeError(
                     "Already ran a smaller batch size: call reset(batch_size=N) before using the layer again"
                 )
-
-            batch_dim = max(parameter_batch_dim, 1)
+            batch_dim=max(parameter_batch_dim,1)
+            if batch_dim==1 and amplitude_input is not None:
+                if amplitude_input.shape==1:
+                    batch_dim=1
+                else:
+                    batch_dim=amplitude_input.shape[0]
 
             state_dimensions = set()
             for state in self.memristive_state:

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -387,6 +387,7 @@ class ComputationProcess(AbstractComputationProcess):
         unitary: torch.Tensor,
         *,
         amplitude_encoding: bool,
+        paired: bool = False,
     ) -> torch.Tensor | SectoredDistribution:
         """Compute source-noise probabilities for one precomputed unitary.
 
@@ -405,6 +406,8 @@ class ComputationProcess(AbstractComputationProcess):
         amplitude_encoding : bool
             Whether tensor ``input_state`` values should be interpreted as a
             superposition over input basis states.
+        paired: bool
+            Whether the output is simply one input state per unitary without the cross combinations.
 
         Returns
         -------
@@ -549,10 +552,7 @@ class ComputationProcess(AbstractComputationProcess):
         return final_amplitudes
 
     def _compute_probabilities_for_unitary(
-        self,
-        unitary: torch.Tensor,
-        *,
-        amplitude_encoding: bool,
+        self, unitary: torch.Tensor, *, amplitude_encoding: bool, paired: bool = False
     ) -> torch.Tensor | SectoredDistribution:
         """Compute output probabilities for one precomputed unitary.
 
@@ -570,6 +570,8 @@ class ComputationProcess(AbstractComputationProcess):
         amplitude_encoding : bool
             Whether tensor ``input_state`` values should be interpreted as a
             coherent superposition for this sample.
+        paired: bool
+            Whether the output is simply one input state per unitary without the cross combinations.
 
         Returns
         -------
@@ -585,16 +587,20 @@ class ComputationProcess(AbstractComputationProcess):
         """
         if self._has_source_noise():
             return self._compute_source_probabilities_for_unitary(
-                unitary, amplitude_encoding=amplitude_encoding
+                unitary, amplitude_encoding=amplitude_encoding, paired=paired
             )
 
         if isinstance(self.input_state, torch.Tensor) and amplitude_encoding:
-            amplitudes = self._compute_superposition_amplitudes_for_unitary(unitary)
+            amplitudes = self._compute_superposition_amplitudes_for_unitary(
+                unitary, paired=paired
+            )
             probabilities = probabilities_from_amplitudes(amplitudes)
             return normalize_probabilities(probabilities, self.computation_space)
 
         input_state = self._fixed_input_state_for_compute()
-        keys, probs = self.simulation_graph.compute_probs(unitary, input_state)
+        keys, probs = self.simulation_graph.compute_probs(
+            unitary, input_state, paired=paired
+        )
         self._validate_probability_keys(keys)
         return probs
 
@@ -849,14 +855,15 @@ class ComputationProcess(AbstractComputationProcess):
         prepared_state = (
             self._prepare_superposition_support() if amplitude_encoding else None
         )
+        memristive_batched = (
+            prepared_state is not None
+            and prepared_state.batch_size > 1
+            and memristive_current_state != []
+        )
 
         for _sample_index in range(self._n_phase_error_samples):
             # If there is memristive PS and batched amplitude encoding
-            if (
-                prepared_state is not None
-                and prepared_state.batch_size > 1
-                and (not (memristive_current_state == []))
-            ):
+            if memristive_batched:
                 unitary = self.converter.to_tensor(
                     *parameters,
                     batch_size=(memristive_current_state[0].shape[0]),
@@ -876,7 +883,9 @@ class ComputationProcess(AbstractComputationProcess):
                 )
             self.unitary = unitary
             probabilities = self._compute_probabilities_for_unitary(
-                unitary, amplitude_encoding=amplitude_encoding
+                unitary,
+                amplitude_encoding=amplitude_encoding,
+                paired=memristive_batched,
             )
 
             if accumulated is None:
@@ -1534,16 +1543,16 @@ class ComputationProcess(AbstractComputationProcess):
             )
 
         keys_out = list(self.simulation_graph.mapped_keys)
+        # In paired mode each unitary is contracted with its own amplitude input
+        # (diagonal contraction), so the output has a single batch axis (N, O)
+        # rather than the outer-product (U, batch, O).
+        final_shape = (
+            (prepared_state.batch_size, len(keys_out))
+            if paired
+            else (unitary.shape[0], prepared_state.batch_size, len(keys_out))
+        )
         if not prepared_state.basis_indices:
-            final = torch.zeros(
-                (
-                    unitary.shape[0],
-                    prepared_state.batch_size,
-                    len(keys_out),
-                ),
-                dtype=unitary.dtype,
-                device=unitary.device,
-            )
+            final = torch.zeros(final_shape, dtype=unitary.dtype, device=unitary.device)
             return keys_out, final
 
         fock_basis_states = self._input_basis_states()
@@ -1552,11 +1561,7 @@ class ComputationProcess(AbstractComputationProcess):
         ]
         chunk_size = self._resolve_superposition_chunk_size(simultaneous_processes)
         final_amplitudes = torch.zeros(
-            (
-                unitary.shape[0],
-                prepared_state.batch_size,
-                len(keys_out),
-            ),
+            final_shape,
             dtype=unitary.dtype,
             device=unitary.device,
         )
@@ -1583,8 +1588,6 @@ class ComputationProcess(AbstractComputationProcess):
                 final_amplitudes += torch.einsum(
                     "se,boe->bso", coeffs, batch_amplitudes
                 )
-
-        print(final_amplitudes)
 
         return keys_out, final_amplitudes
 

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -533,6 +533,8 @@ class ComputationProcess(AbstractComputationProcess):
         simultaneous_processes : int
             Maximum number of active input basis states propagated in one
             ``compute_batch`` call. Default is 1.
+        paired: bool
+            Whether the output is simply one input state per unitary without the cross combinations.
 
         Returns
         -------

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -447,13 +447,19 @@ class ComputationProcess(AbstractComputationProcess):
                         selected_weights = weights[:, weight_index].to(
                             sector.tensor.dtype
                         )
-                        sector.tensor = torch.einsum(
-                            "i,bo->bio", selected_weights, sector.tensor
-                        )
-                        if sector.tensor.shape[0] == 1:
-                            sector.tensor = sector.tensor.squeeze(0)
-                        if sector.tensor.ndim == 3 and sector.tensor.shape[1] == 1:
-                            sector.tensor = sector.tensor.squeeze(1)
+                        if paired:
+                            # b == N: pair weight n with unitary n (no cross product)
+                            sector.tensor = (
+                                selected_weights.unsqueeze(-1) * sector.tensor
+                            )  # (N, O)
+                        else:
+                            sector.tensor = torch.einsum(
+                                "i,bo->bio", selected_weights, sector.tensor
+                            )
+                            if sector.tensor.shape[0] == 1:
+                                sector.tensor = sector.tensor.squeeze(0)
+                            if sector.tensor.ndim == 3 and sector.tensor.shape[1] == 1:
+                                sector.tensor = sector.tensor.squeeze(1)
 
                     if output_distribution is None:
                         output_distribution = probs
@@ -484,12 +490,18 @@ class ComputationProcess(AbstractComputationProcess):
 
             probs_stacked = torch.stack(tensor_probs_per_state, dim=0)
             selected_weights = weights.to(probs_stacked.dtype)
-            mixed_probs = torch.einsum("is,sbo->bio", selected_weights, probs_stacked)
-
-            if mixed_probs.shape[0] == 1:
-                mixed_probs = mixed_probs.squeeze(0)
-            if mixed_probs.ndim == 3 and mixed_probs.shape[1] == 1:
-                mixed_probs = mixed_probs.squeeze(1)
+            if paired:
+                mixed_probs = torch.einsum(
+                    "ns,sno->no", selected_weights, probs_stacked
+                )  # (N, O)
+            else:
+                mixed_probs = torch.einsum(
+                    "is,sbo->bio", selected_weights, probs_stacked
+                )
+                if mixed_probs.shape[0] == 1:
+                    mixed_probs = mixed_probs.squeeze(0)
+                if mixed_probs.ndim == 3 and mixed_probs.shape[1] == 1:
+                    mixed_probs = mixed_probs.squeeze(1)
 
             return mixed_probs
 
@@ -504,6 +516,7 @@ class ComputationProcess(AbstractComputationProcess):
         unitary: torch.Tensor,
         *,
         simultaneous_processes: int = 1,
+        paired: bool = False,
     ) -> torch.Tensor:
         """Compute coherent superposition amplitudes for one precomputed unitary.
 
@@ -542,12 +555,13 @@ class ComputationProcess(AbstractComputationProcess):
             prepared_state,
             unitary if unitary.dim() == 3 else unitary.unsqueeze(0),
             simultaneous_processes=simultaneous_processes,
+            paired=paired,
         )
-
-        if final_amplitudes.shape[0] == 1:
-            final_amplitudes = final_amplitudes.squeeze(0)
-        if final_amplitudes.ndim == 3 and final_amplitudes.shape[1] == 1:
-            final_amplitudes = final_amplitudes.squeeze(1)
+        if not paired:
+            if final_amplitudes.shape[0] == 1:
+                final_amplitudes = final_amplitudes.squeeze(0)
+            if final_amplitudes.ndim == 3 and final_amplitudes.shape[1] == 1:
+                final_amplitudes = final_amplitudes.squeeze(1)
 
         return final_amplitudes
 
@@ -598,9 +612,7 @@ class ComputationProcess(AbstractComputationProcess):
             return normalize_probabilities(probabilities, self.computation_space)
 
         input_state = self._fixed_input_state_for_compute()
-        keys, probs = self.simulation_graph.compute_probs(
-            unitary, input_state, paired=paired
-        )
+        keys, probs = self.simulation_graph.compute_probs(unitary, input_state)
         self._validate_probability_keys(keys)
         return probs
 
@@ -945,13 +957,6 @@ class ComputationProcess(AbstractComputationProcess):
             active (a :class:`~merlin.core.sectored_distribution.SectoredDistribution`
             when g2 noise is present) and amplitudes otherwise.
         """
-        if self._has_phase_error():
-            return self._compute_phase_error_probabilities(
-                parameters,
-                amplitude_encoding=amplitude_encoding,
-                memristive_current_state=memristive_current_state,
-            )
-
         # Checking if there is memristive and amplitude encoding
         memristive_current_state = (
             [] if memristive_current_state is None else memristive_current_state
@@ -959,14 +964,22 @@ class ComputationProcess(AbstractComputationProcess):
         prepared_state = (
             self._prepare_superposition_support() if amplitude_encoding else None
         )
-
-        # If there is memristive PS and batched amplitude encoding, create a
-        # unitary per amplitude input
-        if (
+        memristive_batched_amplitudes = (
             prepared_state is not None
             and prepared_state.batch_size > 1
             and (not (memristive_current_state == []))
-        ):
+        )
+
+        if self._has_phase_error():
+            return self._compute_phase_error_probabilities(
+                parameters,
+                amplitude_encoding=amplitude_encoding,
+                memristive_current_state=memristive_current_state,
+            )
+
+        # If there is memristive PS and batched amplitude encoding, create a
+        # unitary per amplitude input
+        if memristive_batched_amplitudes:
             unitary = self.converter.to_tensor(
                 *parameters,
                 batch_size=(memristive_current_state[0].shape[0]),
@@ -983,7 +996,9 @@ class ComputationProcess(AbstractComputationProcess):
 
         if self._has_source_noise():
             return self._compute_source_probabilities_for_unitary(
-                unitary, amplitude_encoding=amplitude_encoding
+                unitary,
+                amplitude_encoding=amplitude_encoding,
+                paired=memristive_batched_amplitudes,
             )
 
         input_state = self._fixed_input_state_for_compute()

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -1042,9 +1042,7 @@ class ComputationProcess(AbstractComputationProcess):
             for i, unitary in enumerate(unitaries):
                 self.input_state = input_states[i]
                 input_state = self._fixed_input_state_for_compute()
-                _keys, amplitudes = self.simulation_graph.compute(
-                    unitary, input_state
-                )
+                _keys, amplitudes = self.simulation_graph.compute(unitary, input_state)
                 # Flattening the tensor
                 amplitudes = amplitudes.squeeze(dim=0)
                 if keys_out is None:

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -996,17 +996,30 @@ class ComputationProcess(AbstractComputationProcess):
                 "Noisy simulations with source noise can only call the `compute` and `compute_with_keys` methods to compute probabilities"
             )
         prepared_state = self._prepare_superposition_support()
-        unitary = self.converter.to_tensor(
-            *parameters,
-            memristive_current_state=(
+        memristive_current_state=(
                 [] if memristive_current_state is None else memristive_current_state
-            ),
-        )
-        _keys_out, final_amplitudes = self._compute_chunked_superposition(
-            prepared_state,
-            unitary if unitary.dim() == 3 else unitary.unsqueeze(0),
-            simultaneous_processes=simultaneous_processes,
-        )
+            )
+        if prepared_state.batch_size>1 and (not (memristive_current_state == [])):
+            unitaries=[self.converter.to_tensor(
+                *parameters,
+                memristive_current_state=[torch.tensor(memristor[index]) for memristor in memristive_current_state],
+            ) for index in range(prepared_state.batch_size)]
+            #TODO COMPLETE
+            _keys_out, final_amplitudes = self._compute_chunked_superposition(
+                prepared_state,
+                unitary if unitary.dim() == 3 else unitary.unsqueeze(0),
+                simultaneous_processes=simultaneous_processes,
+            )
+        else:
+            unitary = self.converter.to_tensor(
+                *parameters,
+                memristive_current_state=memristive_current_state,
+            )
+            _keys_out, final_amplitudes = self._compute_chunked_superposition(
+                prepared_state,
+                unitary if unitary.dim() == 3 else unitary.unsqueeze(0),
+                simultaneous_processes=simultaneous_processes,
+            )
 
         if final_amplitudes.shape[0] == 1:
             final_amplitudes = final_amplitudes.squeeze(0)

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -1048,8 +1048,12 @@ class ComputationProcess(AbstractComputationProcess):
         memristive_current_state = (
             [] if memristive_current_state is None else memristive_current_state
         )
+        memristive_batched = (
+            prepared_state.batch_size > 1 and memristive_current_state != []
+        )
+
         # If there is amplitude encoding and memristors, create a unitary per input state
-        if prepared_state.batch_size > 1 and (not (memristive_current_state == [])):
+        if memristive_batched:
             unitary = self.converter.to_tensor(
                 *parameters,
                 batch_size=(memristive_current_state[0].shape[0]),
@@ -1062,14 +1066,14 @@ class ComputationProcess(AbstractComputationProcess):
                     [] if memristive_current_state is None else memristive_current_state
                 ),
             )
-
         _keys_out, final_amplitudes = self._compute_chunked_superposition(
             prepared_state,
             unitary if unitary.dim() == 3 else unitary.unsqueeze(0),
             simultaneous_processes=simultaneous_processes,
+            paired=memristive_batched,
         )
 
-        if final_amplitudes.shape[0] == 1:
+        if not memristive_batched and final_amplitudes.shape[0] == 1:
             final_amplitudes = final_amplitudes.squeeze(0)
 
         if return_keys:
@@ -1516,11 +1520,17 @@ class ComputationProcess(AbstractComputationProcess):
         unitary: torch.Tensor,
         *,
         simultaneous_processes: int | None,
+        paired: bool = False,
     ) -> tuple[list[tuple[int, ...]], torch.Tensor]:
         """Evaluate a superposition by streaming chunked kernel calls into the final tensor."""
         if unitary.dim() != 3:
             raise ValueError(
                 "Expected batched unitary tensor for chunked superposition evaluation."
+            )
+
+        if paired and unitary.shape[0] != prepared_state.batch_size:
+            raise ValueError(
+                "Paired superposition requires one unitary per amplitude input."
             )
 
         keys_out = list(self.simulation_graph.mapped_keys)
@@ -1564,7 +1574,17 @@ class ComputationProcess(AbstractComputationProcess):
             batch_amplitudes = batch_amplitudes / batch_amplitudes.norm(
                 p=2, dim=1, keepdim=True
             ).clamp_min(1e-12)
-            final_amplitudes += torch.einsum("se,boe->bso", coeffs, batch_amplitudes)
+
+            if paired:
+                final_amplitudes += torch.einsum(
+                    "ne,noe->no", coeffs, batch_amplitudes
+                )  # (N,O)
+            else:
+                final_amplitudes += torch.einsum(
+                    "se,boe->bso", coeffs, batch_amplitudes
+                )
+
+        print(final_amplitudes)
 
         return keys_out, final_amplitudes
 

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -31,7 +31,11 @@ from typing import Any, Literal, overload
 import perceval as pcvl
 import torch
 
-from merlin.core.sectored_distribution import SectoredDistribution, SectorResult
+from merlin.core.sectored_distribution import (
+    SectoredDistribution,
+    SectorResult,
+    stack_sectored_distributions,
+)
 from merlin.pcvl_pytorch.noisy_slos import (
     NoisyG2SLOSComputeGraph,
     NoisySLOSComputeGraph,
@@ -838,18 +842,71 @@ class ComputationProcess(AbstractComputationProcess):
         """
         accumulated: torch.Tensor | SectoredDistribution | None = None
 
+        # Checking if there is memristive and amplitude encoding
+        memristive_current_state = (
+            [] if memristive_current_state is None else memristive_current_state
+        )
+        prepared_state = (
+            self._prepare_superposition_support() if amplitude_encoding else None
+        )
+
         for _sample_index in range(self._n_phase_error_samples):
-            unitary = self.converter.to_tensor(
-                *parameters,
-                apply_phase_error=True,
-                memristive_current_state=(
-                    [] if memristive_current_state is None else memristive_current_state
-                ),
-            )
-            self.unitary = unitary
-            probabilities = self._compute_probabilities_for_unitary(
-                unitary, amplitude_encoding=amplitude_encoding
-            )
+            # If there is memristive PS and batched amplitude encoding
+            if (
+                prepared_state is not None
+                and prepared_state.batch_size > 1
+                and (not (memristive_current_state == []))
+            ):
+                unitaries = [
+                    self.converter.to_tensor(
+                        *parameters,
+                        memristive_current_state=[
+                            memristor[index] for memristor in memristive_current_state
+                        ],
+                    )
+                    for index in range(prepared_state.batch_size)
+                ]
+                self.unitary = unitaries
+                input_states = self.input_state
+                output_probs = []
+
+                for i, unitary in enumerate(unitaries):
+                    self.input_state = input_states[i]
+                    probabilities = self._compute_probabilities_for_unitary(
+                        unitary, amplitude_encoding=amplitude_encoding
+                    )
+
+                    if isinstance(probabilities, SectoredDistribution):
+                        for i in range(len(probabilities.sectors)):
+                            probabilities.sectors[i].tensor = probabilities.sectors[
+                                i
+                            ].tensor.squeeze(dim=0)
+                    else:
+                        probabilities = probabilities.squeeze(dim=0)
+
+                    output_probs.append(probabilities)
+
+                self.input_state = input_states
+                if isinstance(probabilities, SectoredDistribution):
+                    probabilities = stack_sectored_distributions(output_probs)
+                else:
+                    probabilities = torch.stack(output_probs, dim=0)
+
+            # Otherwise
+            else:
+                unitary = self.converter.to_tensor(
+                    *parameters,
+                    apply_phase_error=True,
+                    memristive_current_state=(
+                        []
+                        if memristive_current_state is None
+                        else memristive_current_state
+                    ),
+                )
+                self.unitary = unitary
+                probabilities = self._compute_probabilities_for_unitary(
+                    unitary, amplitude_encoding=amplitude_encoding
+                )
 
             if accumulated is None:
                 accumulated = probabilities
@@ -915,22 +972,100 @@ class ComputationProcess(AbstractComputationProcess):
                 memristive_current_state=memristive_current_state,
             )
 
-        unitary = self.converter.to_tensor(
-            *parameters,
-            memristive_current_state=(
-                [] if memristive_current_state is None else memristive_current_state
-            ),
+        # Checking if there is memristive and amplitude encoding
+        memristive_current_state = (
+            [] if memristive_current_state is None else memristive_current_state
         )
-        self.unitary = unitary
+        prepared_state = (
+            self._prepare_superposition_support() if amplitude_encoding else None
+        )
 
-        if self._has_source_noise():
-            return self._compute_source_probabilities_for_unitary(
-                unitary, amplitude_encoding=amplitude_encoding
+        # If there is memristive PS and batched amplitude encoding, create a
+        # unitary per amplitude input
+        if (
+            prepared_state is not None
+            and prepared_state.batch_size > 1
+            and (not (memristive_current_state == []))
+        ):
+            unitaries = [
+                self.converter.to_tensor(
+                    *parameters,
+                    memristive_current_state=[
+                        memristor[index] for memristor in memristive_current_state
+                    ],
+                )
+                for index in range(prepared_state.batch_size)
+            ]
+            self.unitary = unitaries
+            input_states = self.input_state
+            keys_out, final_amplitudes = None, []
+
+            for i, unitary in enumerate(unitaries):
+                self.input_state = input_states[i]
+                if self._has_source_noise():
+                    probs = self._compute_source_probabilities_for_unitary(
+                        unitary, amplitude_encoding=amplitude_encoding
+                    )
+                    if isinstance(probs, SectoredDistribution):
+                        for i in range(len(probs.sectors)):
+                            probs.sectors[i].tensor = probs.sectors[i].tensor.squeeze(
+                                dim=0
+                            )
+                    else:
+                        probs = probs.squeeze(dim=0)
+
+                    final_amplitudes.append(probs)
+                else:
+                    input_state = self._fixed_input_state_for_compute()
+                    _keys, amplitudes = self.simulation_graph.compute(
+                        unitary, input_state
+                    )
+                    # Flattening the tensor
+                    if isinstance(amplitudes, SectoredDistribution):
+                        for i in range(len(amplitudes.sectors)):
+                            amplitudes.sectors[i].tensor = amplitudes.sectors[
+                                i
+                            ].tensor.squeeze(dim=0)
+                    else:
+                        amplitudes = amplitudes.squeeze(dim=0)
+                    if keys_out is None:
+                        keys_out = _keys
+                        final_amplitudes.append(amplitudes)
+                    else:
+                        # Reorder amplitudes to match the reference ordering
+                        key_to_index = {key: j for j, key in enumerate(_keys)}
+
+                        reordered = torch.empty_like(final_amplitudes[0])
+
+                        for target_idx, key in enumerate(keys_out):
+                            reordered[target_idx] = amplitudes[key_to_index[key]]
+
+                        final_amplitudes.append(reordered)
+
+            self.input_state = input_states
+            if isinstance(final_amplitudes[0], SectoredDistribution):
+                return stack_sectored_distributions(final_amplitudes)
+            else:
+                return torch.stack(final_amplitudes, dim=0)
+
+        # Otherwise
+        else:
+            unitary = self.converter.to_tensor(
+                *parameters,
+                memristive_current_state=(
+                    [] if memristive_current_state is None else memristive_current_state
+                ),
             )
+            self.unitary = unitary
 
-        input_state = self._fixed_input_state_for_compute()
-        _keys, amplitudes = self.simulation_graph.compute(unitary, input_state)
-        return amplitudes
+            if self._has_source_noise():
+                return self._compute_source_probabilities_for_unitary(
+                    unitary, amplitude_encoding=amplitude_encoding
+                )
+
+            input_state = self._fixed_input_state_for_compute()
+            _keys, amplitudes = self.simulation_graph.compute(unitary, input_state)
+            return amplitudes
 
     @overload
     def compute_superposition_state(
@@ -996,28 +1131,38 @@ class ComputationProcess(AbstractComputationProcess):
                 "Noisy simulations with source noise can only call the `compute` and `compute_with_keys` methods to compute probabilities"
             )
         prepared_state = self._prepare_superposition_support()
-        memristive_current_state=(
-                [] if memristive_current_state is None else memristive_current_state
-            )
-        if prepared_state.batch_size>1 and (not (memristive_current_state == [])):
-            unitaries=[self.converter.to_tensor(
-                *parameters,
-                memristive_current_state=[memristor[index] for memristor in memristive_current_state],
-            ) for index in range(prepared_state.batch_size)]
-            keys_out,final_amplitudes=None,[]
-            for i,unitary in enumerate(unitaries):
+        memristive_current_state = (
+            [] if memristive_current_state is None else memristive_current_state
+        )
+        # If there is amplitude encoding and memristors, create a unitary per input state
+        if prepared_state.batch_size > 1 and (not (memristive_current_state == [])):
+            unitaries = [
+                self.converter.to_tensor(
+                    *parameters,
+                    memristive_current_state=[
+                        memristor[index] for memristor in memristive_current_state
+                    ],
+                )
+                for index in range(prepared_state.batch_size)
+            ]
+            keys_out, final_amplitudes = None, []
+            for i, unitary in enumerate(unitaries):
                 _keys, amplitudes = self._compute_chunked_superposition(
-                    _SuperpositionSupport(prepared_state.basis_indices,coefficients=prepared_state.coefficients[i].unsqueeze(0),basis_size=prepared_state.basis_size),
+                    _SuperpositionSupport(
+                        prepared_state.basis_indices,
+                        coefficients=prepared_state.coefficients[i].unsqueeze(0),
+                        basis_size=prepared_state.basis_size,
+                    ),
                     unitary if unitary.dim() == 3 else unitary.unsqueeze(0),
                     simultaneous_processes=simultaneous_processes,
                 )
-                amplitudes=amplitudes.squeeze()
+                amplitudes = amplitudes.squeeze()
                 if keys_out is None:
                     keys_out = _keys
                     final_amplitudes.append(amplitudes)
                 else:
                     # Reorder amplitudes to match the reference ordering
-                    key_to_index = {key: i for i, key in enumerate(_keys)}
+                    key_to_index = {key: j for j, key in enumerate(_keys)}
 
                     reordered = torch.empty_like(final_amplitudes[0])
 
@@ -1025,7 +1170,7 @@ class ComputationProcess(AbstractComputationProcess):
                         reordered[target_idx] = amplitudes[key_to_index[key]]
 
                     final_amplitudes.append(reordered)
-            
+
             final_amplitudes = torch.stack(final_amplitudes, dim=0)
         else:
             unitary = self.converter.to_tensor(

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -869,7 +869,7 @@ class ComputationProcess(AbstractComputationProcess):
                 ]
                 self.unitary = unitaries
                 input_states = self.input_state
-                output_probs = []
+                output_probs: list[SectoredDistribution] | list[torch.Tensor] = []
 
                 for i, unitary in enumerate(unitaries):
                     self.input_state = input_states[i]
@@ -999,7 +999,8 @@ class ComputationProcess(AbstractComputationProcess):
             ]
             self.unitary = unitaries
             input_states = self.input_state
-            keys_out, final_amplitudes = None, []
+            keys_out: list[tuple[int, ...]] | None = None
+            final_amplitudes: list[SectoredDistribution] | list[torch.Tensor] = []
 
             for i, unitary in enumerate(unitaries):
                 self.input_state = input_states[i]

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -857,49 +857,12 @@ class ComputationProcess(AbstractComputationProcess):
                 and prepared_state.batch_size > 1
                 and (not (memristive_current_state == []))
             ):
-                unitaries = [
-                    self.converter.to_tensor(
-                        *parameters,
-                        memristive_current_state=[
-                            memristor[index] for memristor in memristive_current_state
-                        ],
-                        apply_phase_error=True,
-                    )
-                    for index in range(prepared_state.batch_size)
-                ]
-                self.unitary = unitaries
-                input_states = self.input_state
-                if not isinstance(input_states, torch.Tensor):
-                    raise TypeError("Input state should be a tensor")
-                output_distributions: list[SectoredDistribution] = []
-                output_tensors: list[torch.Tensor] = []
-
-                for i, unitary in enumerate(unitaries):
-                    self.input_state = input_states[i]
-                    probabilities = self._compute_probabilities_for_unitary(
-                        unitary, amplitude_encoding=amplitude_encoding
-                    )
-
-                    if isinstance(probabilities, SectoredDistribution):
-                        for k in range(len(probabilities.sectors)):
-                            probabilities.sectors[k].tensor = probabilities.sectors[
-                                k
-                            ].tensor.squeeze(dim=0)
-                        output_distributions.append(probabilities)
-                    else:
-                        probabilities = probabilities.squeeze(dim=0)
-                        output_tensors.append(probabilities)
-
-                self.input_state = input_states
-                if output_distributions:
-                    if output_tensors:
-                        raise ValueError(
-                            "Phase-error sample type mismatch while averaging probabilities."
-                        )
-                    probabilities = stack_sectored_distributions(output_distributions)
-                else:
-                    probabilities = torch.stack(output_tensors, dim=0)
-
+                unitary = self.converter.to_tensor(
+                    *parameters,
+                    batch_size=(memristive_current_state[0].shape[0]),
+                    apply_phase_error=True,
+                    memristive_current_state=memristive_current_state,
+                )
             # Otherwise
             else:
                 unitary = self.converter.to_tensor(
@@ -911,10 +874,10 @@ class ComputationProcess(AbstractComputationProcess):
                         else memristive_current_state
                     ),
                 )
-                self.unitary = unitary
-                probabilities = self._compute_probabilities_for_unitary(
-                    unitary, amplitude_encoding=amplitude_encoding
-                )
+            self.unitary = unitary
+            probabilities = self._compute_probabilities_for_unitary(
+                unitary, amplitude_encoding=amplitude_encoding
+            )
 
             if accumulated is None:
                 accumulated = probabilities
@@ -995,74 +958,11 @@ class ComputationProcess(AbstractComputationProcess):
             and prepared_state.batch_size > 1
             and (not (memristive_current_state == []))
         ):
-            unitaries = [
-                self.converter.to_tensor(
-                    *parameters,
-                    memristive_current_state=[
-                        memristor[index] for memristor in memristive_current_state
-                    ],
-                )
-                for index in range(prepared_state.batch_size)
-            ]
-            self.unitary = unitaries
-            input_states = self.input_state
-            if not isinstance(input_states, torch.Tensor):
-                raise TypeError("Input state should be a tensor")
-
-            if self._has_source_noise():
-                final_distributions: list[SectoredDistribution] = []
-                final_probabilities: list[torch.Tensor] = []
-                for i, unitary in enumerate(unitaries):
-                    self.input_state = input_states[i]
-                    probs = self._compute_source_probabilities_for_unitary(
-                        unitary, amplitude_encoding=amplitude_encoding
-                    )
-                    if isinstance(probs, SectoredDistribution):
-                        for k in range(len(probs.sectors)):
-                            probs.sectors[k].tensor = probs.sectors[k].tensor.squeeze(
-                                dim=0
-                            )
-                        final_distributions.append(probs)
-                    else:
-                        probs = probs.squeeze(dim=0)
-                        final_probabilities.append(probs)
-
-                self.input_state = input_states
-                if final_distributions:
-                    if final_probabilities:
-                        raise ValueError(
-                            "Source-noise result type mismatch while batching probabilities."
-                        )
-                    return stack_sectored_distributions(final_distributions)
-                return torch.stack(final_probabilities, dim=0)
-
-            keys_out: list[tuple[int, ...]] | None = None
-            final_amplitudes: list[torch.Tensor] = []
-
-            for i, unitary in enumerate(unitaries):
-                self.input_state = input_states[i]
-                input_state = self._fixed_input_state_for_compute()
-                _keys, amplitudes = self.simulation_graph.compute(unitary, input_state)
-                # Flattening the tensor
-                amplitudes = amplitudes.squeeze(dim=0)
-                if keys_out is None:
-                    keys_out = _keys
-                    final_amplitudes.append(amplitudes)
-                else:
-                    # Reorder amplitudes to match the reference ordering
-                    key_to_index = {key: j for j, key in enumerate(_keys)}
-
-                    reordered = torch.empty_like(final_amplitudes[0])
-
-                    for target_idx, key in enumerate(keys_out):
-                        reordered[target_idx] = amplitudes[key_to_index[key]]
-
-                    final_amplitudes.append(reordered)
-
-            self.input_state = input_states
-            return torch.stack(final_amplitudes, dim=0)
-
-        # Otherwise
+            unitary = self.converter.to_tensor(
+                *parameters,
+                batch_size=(memristive_current_state[0].shape[0]),
+                memristive_current_state=memristive_current_state,
+            )
         else:
             unitary = self.converter.to_tensor(
                 *parameters,
@@ -1070,16 +970,16 @@ class ComputationProcess(AbstractComputationProcess):
                     [] if memristive_current_state is None else memristive_current_state
                 ),
             )
-            self.unitary = unitary
+        self.unitary = unitary
 
-            if self._has_source_noise():
-                return self._compute_source_probabilities_for_unitary(
-                    unitary, amplitude_encoding=amplitude_encoding
-                )
+        if self._has_source_noise():
+            return self._compute_source_probabilities_for_unitary(
+                unitary, amplitude_encoding=amplitude_encoding
+            )
 
-            input_state = self._fixed_input_state_for_compute()
-            _keys, amplitudes = self.simulation_graph.compute(unitary, input_state)
-            return amplitudes
+        input_state = self._fixed_input_state_for_compute()
+        _keys, amplitudes = self.simulation_graph.compute(unitary, input_state)
+        return amplitudes
 
     @overload
     def compute_superposition_state(
@@ -1150,58 +1050,24 @@ class ComputationProcess(AbstractComputationProcess):
         )
         # If there is amplitude encoding and memristors, create a unitary per input state
         if prepared_state.batch_size > 1 and (not (memristive_current_state == [])):
-            unitaries = [
-                self.converter.to_tensor(
-                    *parameters,
-                    memristive_current_state=[
-                        memristor[index] for memristor in memristive_current_state
-                    ],
-                )
-                for index in range(prepared_state.batch_size)
-            ]
-            keys_out: list[tuple[int, ...]] | None = None
-            amplitude_batches: list[torch.Tensor] = []
-            for i, unitary in enumerate(unitaries):
-                _keys, amplitudes = self._compute_chunked_superposition(
-                    _SuperpositionSupport(
-                        prepared_state.basis_indices,
-                        coefficients=prepared_state.coefficients[i].unsqueeze(0),
-                        basis_size=prepared_state.basis_size,
-                    ),
-                    unitary if unitary.dim() == 3 else unitary.unsqueeze(0),
-                    simultaneous_processes=simultaneous_processes,
-                )
-
-                amplitudes = torch.atleast_1d(amplitudes.squeeze())
-
-                if keys_out is None:
-                    keys_out = _keys
-                    amplitude_batches.append(amplitudes)
-                else:
-                    # Reorder amplitudes to match the reference ordering
-                    key_to_index = {key: j for j, key in enumerate(_keys)}
-
-                    reordered = torch.empty_like(amplitude_batches[0])
-
-                    for target_idx, key in enumerate(keys_out):
-                        reordered[target_idx] = amplitudes[key_to_index[key]]
-
-                    amplitude_batches.append(reordered)
-
-            if keys_out is None:
-                raise RuntimeError("No batched superposition amplitudes were computed.")
-            _keys_out = keys_out
-            final_amplitudes = torch.stack(amplitude_batches, dim=0)
+            unitary = self.converter.to_tensor(
+                *parameters,
+                batch_size=(memristive_current_state[0].shape[0]),
+                memristive_current_state=memristive_current_state,
+            )
         else:
             unitary = self.converter.to_tensor(
                 *parameters,
-                memristive_current_state=memristive_current_state,
+                memristive_current_state=(
+                    [] if memristive_current_state is None else memristive_current_state
+                ),
             )
-            _keys_out, final_amplitudes = self._compute_chunked_superposition(
-                prepared_state,
-                unitary if unitary.dim() == 3 else unitary.unsqueeze(0),
-                simultaneous_processes=simultaneous_processes,
-            )
+
+        _keys_out, final_amplitudes = self._compute_chunked_superposition(
+            prepared_state,
+            unitary if unitary.dim() == 3 else unitary.unsqueeze(0),
+            simultaneous_processes=simultaneous_processes,
+        )
 
         if final_amplitudes.shape[0] == 1:
             final_amplitudes = final_amplitudes.squeeze(0)

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -863,6 +863,7 @@ class ComputationProcess(AbstractComputationProcess):
                         memristive_current_state=[
                             memristor[index] for memristor in memristive_current_state
                         ],
+                        apply_phase_error=True,
                     )
                     for index in range(prepared_state.batch_size)
                 ]
@@ -877,9 +878,9 @@ class ComputationProcess(AbstractComputationProcess):
                     )
 
                     if isinstance(probabilities, SectoredDistribution):
-                        for i in range(len(probabilities.sectors)):
-                            probabilities.sectors[i].tensor = probabilities.sectors[
-                                i
+                        for k in range(len(probabilities.sectors)):
+                            probabilities.sectors[k].tensor = probabilities.sectors[
+                                k
                             ].tensor.squeeze(dim=0)
                     else:
                         probabilities = probabilities.squeeze(dim=0)
@@ -1007,8 +1008,8 @@ class ComputationProcess(AbstractComputationProcess):
                         unitary, amplitude_encoding=amplitude_encoding
                     )
                     if isinstance(probs, SectoredDistribution):
-                        for i in range(len(probs.sectors)):
-                            probs.sectors[i].tensor = probs.sectors[i].tensor.squeeze(
+                        for k in range(len(probs.sectors)):
+                            probs.sectors[k].tensor = probs.sectors[k].tensor.squeeze(
                                 dim=0
                             )
                     else:
@@ -1022,9 +1023,9 @@ class ComputationProcess(AbstractComputationProcess):
                     )
                     # Flattening the tensor
                     if isinstance(amplitudes, SectoredDistribution):
-                        for i in range(len(amplitudes.sectors)):
-                            amplitudes.sectors[i].tensor = amplitudes.sectors[
-                                i
+                        for k in range(len(amplitudes.sectors)):
+                            amplitudes.sectors[k].tensor = amplitudes.sectors[
+                                k
                             ].tensor.squeeze(dim=0)
                     else:
                         amplitudes = amplitudes.squeeze(dim=0)
@@ -1156,7 +1157,9 @@ class ComputationProcess(AbstractComputationProcess):
                     unitary if unitary.dim() == 3 else unitary.unsqueeze(0),
                     simultaneous_processes=simultaneous_processes,
                 )
-                amplitudes = amplitudes.squeeze()
+
+                amplitudes = torch.atleast_1d(amplitudes.squeeze())
+
                 if keys_out is None:
                     keys_out = _keys
                     final_amplitudes.append(amplitudes)

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -1002,14 +1002,31 @@ class ComputationProcess(AbstractComputationProcess):
         if prepared_state.batch_size>1 and (not (memristive_current_state == [])):
             unitaries=[self.converter.to_tensor(
                 *parameters,
-                memristive_current_state=[torch.tensor(memristor[index]) for memristor in memristive_current_state],
+                memristive_current_state=[memristor[index] for memristor in memristive_current_state],
             ) for index in range(prepared_state.batch_size)]
-            #TODO COMPLETE
-            _keys_out, final_amplitudes = self._compute_chunked_superposition(
-                prepared_state,
-                unitary if unitary.dim() == 3 else unitary.unsqueeze(0),
-                simultaneous_processes=simultaneous_processes,
-            )
+            keys_out,final_amplitudes=None,[]
+            for i,unitary in enumerate(unitaries):
+                _keys, amplitudes = self._compute_chunked_superposition(
+                    _SuperpositionSupport(prepared_state.basis_indices,coefficients=prepared_state.coefficients[i].unsqueeze(0),basis_size=prepared_state.basis_size),
+                    unitary if unitary.dim() == 3 else unitary.unsqueeze(0),
+                    simultaneous_processes=simultaneous_processes,
+                )
+                amplitudes=amplitudes.squeeze()
+                if keys_out is None:
+                    keys_out = _keys
+                    final_amplitudes.append(amplitudes)
+                else:
+                    # Reorder amplitudes to match the reference ordering
+                    key_to_index = {key: i for i, key in enumerate(_keys)}
+
+                    reordered = torch.empty_like(final_amplitudes[0])
+
+                    for target_idx, key in enumerate(keys_out):
+                        reordered[target_idx] = amplitudes[key_to_index[key]]
+
+                    final_amplitudes.append(reordered)
+            
+            final_amplitudes = torch.stack(final_amplitudes, dim=0)
         else:
             unitary = self.converter.to_tensor(
                 *parameters,

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -34,7 +34,6 @@ import torch
 from merlin.core.sectored_distribution import (
     SectoredDistribution,
     SectorResult,
-    stack_sectored_distributions,
 )
 from merlin.pcvl_pytorch.noisy_slos import (
     NoisyG2SLOSComputeGraph,

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -428,6 +428,10 @@ class ComputationProcess(AbstractComputationProcess):
             # over Fock basis states and produce a weighted mixture of noisy output
             # probabilities. The mixture weight for each basis state is |c_i|^2.
             prepared_state = self._prepare_superposition_support()
+            if paired and unitary.shape[0] != prepared_state.batch_size:
+                raise ValueError(
+                    "Paired superposition requires one unitary per amplitude input."
+                )
             weights = prepared_state.coefficients.abs().pow(2)
 
             active_indices = prepared_state.basis_indices
@@ -968,7 +972,7 @@ class ComputationProcess(AbstractComputationProcess):
         memristive_batched_amplitudes = (
             prepared_state is not None
             and prepared_state.batch_size > 1
-            and (not (memristive_current_state == []))
+            and (memristive_current_state != [])
         )
 
         if self._has_phase_error():

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -869,7 +869,10 @@ class ComputationProcess(AbstractComputationProcess):
                 ]
                 self.unitary = unitaries
                 input_states = self.input_state
-                output_probs: list[SectoredDistribution] | list[torch.Tensor] = []
+                if not isinstance(input_states, torch.Tensor):
+                    raise TypeError("Input state should be a tensor")
+                output_distributions: list[SectoredDistribution] = []
+                output_tensors: list[torch.Tensor] = []
 
                 for i, unitary in enumerate(unitaries):
                     self.input_state = input_states[i]
@@ -882,16 +885,20 @@ class ComputationProcess(AbstractComputationProcess):
                             probabilities.sectors[k].tensor = probabilities.sectors[
                                 k
                             ].tensor.squeeze(dim=0)
+                        output_distributions.append(probabilities)
                     else:
                         probabilities = probabilities.squeeze(dim=0)
-
-                    output_probs.append(probabilities)
+                        output_tensors.append(probabilities)
 
                 self.input_state = input_states
-                if isinstance(probabilities, SectoredDistribution):
-                    probabilities = stack_sectored_distributions(output_probs)
+                if output_distributions:
+                    if output_tensors:
+                        raise ValueError(
+                            "Phase-error sample type mismatch while averaging probabilities."
+                        )
+                    probabilities = stack_sectored_distributions(output_distributions)
                 else:
-                    probabilities = torch.stack(output_probs, dim=0)
+                    probabilities = torch.stack(output_tensors, dim=0)
 
             # Otherwise
             else:
@@ -999,12 +1006,14 @@ class ComputationProcess(AbstractComputationProcess):
             ]
             self.unitary = unitaries
             input_states = self.input_state
-            keys_out: list[tuple[int, ...]] | None = None
-            final_amplitudes: list[SectoredDistribution] | list[torch.Tensor] = []
+            if not isinstance(input_states, torch.Tensor):
+                raise TypeError("Input state should be a tensor")
 
-            for i, unitary in enumerate(unitaries):
-                self.input_state = input_states[i]
-                if self._has_source_noise():
+            if self._has_source_noise():
+                final_distributions: list[SectoredDistribution] = []
+                final_probabilities: list[torch.Tensor] = []
+                for i, unitary in enumerate(unitaries):
+                    self.input_state = input_states[i]
                     probs = self._compute_source_probabilities_for_unitary(
                         unitary, amplitude_encoding=amplitude_encoding
                     )
@@ -1013,42 +1022,47 @@ class ComputationProcess(AbstractComputationProcess):
                             probs.sectors[k].tensor = probs.sectors[k].tensor.squeeze(
                                 dim=0
                             )
+                        final_distributions.append(probs)
                     else:
                         probs = probs.squeeze(dim=0)
+                        final_probabilities.append(probs)
 
-                    final_amplitudes.append(probs)
+                self.input_state = input_states
+                if final_distributions:
+                    if final_probabilities:
+                        raise ValueError(
+                            "Source-noise result type mismatch while batching probabilities."
+                        )
+                    return stack_sectored_distributions(final_distributions)
+                return torch.stack(final_probabilities, dim=0)
+
+            keys_out: list[tuple[int, ...]] | None = None
+            final_amplitudes: list[torch.Tensor] = []
+
+            for i, unitary in enumerate(unitaries):
+                self.input_state = input_states[i]
+                input_state = self._fixed_input_state_for_compute()
+                _keys, amplitudes = self.simulation_graph.compute(
+                    unitary, input_state
+                )
+                # Flattening the tensor
+                amplitudes = amplitudes.squeeze(dim=0)
+                if keys_out is None:
+                    keys_out = _keys
+                    final_amplitudes.append(amplitudes)
                 else:
-                    input_state = self._fixed_input_state_for_compute()
-                    _keys, amplitudes = self.simulation_graph.compute(
-                        unitary, input_state
-                    )
-                    # Flattening the tensor
-                    if isinstance(amplitudes, SectoredDistribution):
-                        for k in range(len(amplitudes.sectors)):
-                            amplitudes.sectors[k].tensor = amplitudes.sectors[
-                                k
-                            ].tensor.squeeze(dim=0)
-                    else:
-                        amplitudes = amplitudes.squeeze(dim=0)
-                    if keys_out is None:
-                        keys_out = _keys
-                        final_amplitudes.append(amplitudes)
-                    else:
-                        # Reorder amplitudes to match the reference ordering
-                        key_to_index = {key: j for j, key in enumerate(_keys)}
+                    # Reorder amplitudes to match the reference ordering
+                    key_to_index = {key: j for j, key in enumerate(_keys)}
 
-                        reordered = torch.empty_like(final_amplitudes[0])
+                    reordered = torch.empty_like(final_amplitudes[0])
 
-                        for target_idx, key in enumerate(keys_out):
-                            reordered[target_idx] = amplitudes[key_to_index[key]]
+                    for target_idx, key in enumerate(keys_out):
+                        reordered[target_idx] = amplitudes[key_to_index[key]]
 
-                        final_amplitudes.append(reordered)
+                    final_amplitudes.append(reordered)
 
             self.input_state = input_states
-            if isinstance(final_amplitudes[0], SectoredDistribution):
-                return stack_sectored_distributions(final_amplitudes)
-            else:
-                return torch.stack(final_amplitudes, dim=0)
+            return torch.stack(final_amplitudes, dim=0)
 
         # Otherwise
         else:
@@ -1147,7 +1161,8 @@ class ComputationProcess(AbstractComputationProcess):
                 )
                 for index in range(prepared_state.batch_size)
             ]
-            keys_out, final_amplitudes = None, []
+            keys_out: list[tuple[int, ...]] | None = None
+            amplitude_batches: list[torch.Tensor] = []
             for i, unitary in enumerate(unitaries):
                 _keys, amplitudes = self._compute_chunked_superposition(
                     _SuperpositionSupport(
@@ -1163,19 +1178,22 @@ class ComputationProcess(AbstractComputationProcess):
 
                 if keys_out is None:
                     keys_out = _keys
-                    final_amplitudes.append(amplitudes)
+                    amplitude_batches.append(amplitudes)
                 else:
                     # Reorder amplitudes to match the reference ordering
                     key_to_index = {key: j for j, key in enumerate(_keys)}
 
-                    reordered = torch.empty_like(final_amplitudes[0])
+                    reordered = torch.empty_like(amplitude_batches[0])
 
                     for target_idx, key in enumerate(keys_out):
                         reordered[target_idx] = amplitudes[key_to_index[key]]
 
-                    final_amplitudes.append(reordered)
+                    amplitude_batches.append(reordered)
 
-            final_amplitudes = torch.stack(final_amplitudes, dim=0)
+            if keys_out is None:
+                raise RuntimeError("No batched superposition amplitudes were computed.")
+            _keys_out = keys_out
+            final_amplitudes = torch.stack(amplitude_batches, dim=0)
         else:
             unitary = self.converter.to_tensor(
                 *parameters,

--- a/merlin/core/sectored_distribution.py
+++ b/merlin/core/sectored_distribution.py
@@ -409,9 +409,10 @@ def clean_sectored_distribution(dist: SectoredDistribution) -> SectoredDistribut
                     number_of_photons_in_state
                 ].index(key)
 
-                sectors[number_of_photons_in_state][..., column_in_new_tensor] = (
-                    sectors[number_of_photons_in_state][..., column_in_new_tensor]
-                    + (sector_to_fix.tensor[..., col_index_in_previous_sector])
+                sectors[number_of_photons_in_state][
+                    ..., column_in_new_tensor
+                ] = sectors[number_of_photons_in_state][..., column_in_new_tensor] + (
+                    sector_to_fix.tensor[..., col_index_in_previous_sector]
                 )
 
         else:
@@ -461,3 +462,35 @@ def clean_sectored_distribution(dist: SectoredDistribution) -> SectoredDistribut
     )
 
     return SectoredDistribution(sectors=sectors_to_return)
+
+
+def stack_sectored_distributions(
+    dists: list[SectoredDistribution],
+) -> SectoredDistribution:
+    if not dists:
+        raise ValueError("Empty list")
+
+    # Use first distribution as reference
+    photon_numbers = sorted(dists[0]._photon_map.keys())
+
+    sectors = []
+
+    for n_photons in photon_numbers:
+        ref_sector = dists[0].get_sector(n_photons)
+
+        stacked_tensor = torch.stack(
+            [dist.get_sector(n_photons).tensor for dist in dists],
+            dim=0,
+        )
+
+        sectors.append(
+            SectorResult(
+                tensor=stacked_tensor,
+                n_modes=ref_sector.n_modes,
+                n_photons=ref_sector.n_photons,
+                computation_space=ref_sector.computation_space,
+                keys=ref_sector.keys,
+            )
+        )
+
+    return SectoredDistribution(tuple(sectors))

--- a/merlin/core/sectored_distribution.py
+++ b/merlin/core/sectored_distribution.py
@@ -470,16 +470,28 @@ def stack_sectored_distributions(
     if not dists:
         raise ValueError("Empty list")
 
-    # Use first distribution as reference
-    photon_numbers = sorted(dists[0]._photon_map.keys())
+    all_photon_numbers = sorted(
+        set().union(*(dist._photon_map.keys() for dist in dists))
+    )
 
     sectors = []
 
-    for n_photons in photon_numbers:
-        ref_sector = dists[0].get_sector(n_photons)
+    for n_photons in all_photon_numbers:
+        ref_sector = next(
+            dist.get_sector(n_photons)
+            for dist in dists
+            if n_photons in dist._photon_map
+        )
 
         stacked_tensor = torch.stack(
-            [dist.get_sector(n_photons).tensor for dist in dists],
+            [
+                (
+                    dist.get_sector(n_photons).tensor
+                    if n_photons in dist._photon_map
+                    else torch.zeros_like(ref_sector.tensor)
+                )
+                for dist in dists
+            ],
             dim=0,
         )
 
@@ -487,7 +499,7 @@ def stack_sectored_distributions(
             SectorResult(
                 tensor=stacked_tensor,
                 n_modes=ref_sector.n_modes,
-                n_photons=ref_sector.n_photons,
+                n_photons=n_photons,
                 computation_space=ref_sector.computation_space,
                 keys=ref_sector.keys,
             )

--- a/merlin/core/sectored_distribution.py
+++ b/merlin/core/sectored_distribution.py
@@ -409,9 +409,10 @@ def clean_sectored_distribution(dist: SectoredDistribution) -> SectoredDistribut
                     number_of_photons_in_state
                 ].index(key)
 
-                sectors[number_of_photons_in_state][..., column_in_new_tensor] = (
-                    sectors[number_of_photons_in_state][..., column_in_new_tensor]
-                    + (sector_to_fix.tensor[..., col_index_in_previous_sector])
+                sectors[number_of_photons_in_state][
+                    ..., column_in_new_tensor
+                ] = sectors[number_of_photons_in_state][..., column_in_new_tensor] + (
+                    sector_to_fix.tensor[..., col_index_in_previous_sector]
                 )
 
         else:
@@ -461,47 +462,3 @@ def clean_sectored_distribution(dist: SectoredDistribution) -> SectoredDistribut
     )
 
     return SectoredDistribution(sectors=sectors_to_return)
-
-
-def stack_sectored_distributions(
-    dists: list[SectoredDistribution],
-) -> SectoredDistribution:
-    if not dists:
-        raise ValueError("Empty list")
-
-    all_photon_numbers = sorted(
-        set().union(*(dist._photon_map.keys() for dist in dists))
-    )
-
-    sectors = []
-
-    for n_photons in all_photon_numbers:
-        ref_sector = next(
-            dist.get_sector(n_photons)
-            for dist in dists
-            if n_photons in dist._photon_map
-        )
-
-        stacked_tensor = torch.stack(
-            [
-                (
-                    dist.get_sector(n_photons).tensor
-                    if n_photons in dist._photon_map
-                    else torch.zeros_like(ref_sector.tensor)
-                )
-                for dist in dists
-            ],
-            dim=0,
-        )
-
-        sectors.append(
-            SectorResult(
-                tensor=stacked_tensor,
-                n_modes=ref_sector.n_modes,
-                n_photons=n_photons,
-                computation_space=ref_sector.computation_space,
-                keys=ref_sector.keys,
-            )
-        )
-
-    return SectoredDistribution(tuple(sectors))

--- a/merlin/core/sectored_distribution.py
+++ b/merlin/core/sectored_distribution.py
@@ -409,10 +409,9 @@ def clean_sectored_distribution(dist: SectoredDistribution) -> SectoredDistribut
                     number_of_photons_in_state
                 ].index(key)
 
-                sectors[number_of_photons_in_state][
-                    ..., column_in_new_tensor
-                ] = sectors[number_of_photons_in_state][..., column_in_new_tensor] + (
-                    sector_to_fix.tensor[..., col_index_in_previous_sector]
+                sectors[number_of_photons_in_state][..., column_in_new_tensor] = (
+                    sectors[number_of_photons_in_state][..., column_in_new_tensor]
+                    + (sector_to_fix.tensor[..., col_index_in_previous_sector])
                 )
 
         else:

--- a/tests/algorithms/test_amplitude_encoding.py
+++ b/tests/algorithms/test_amplitude_encoding.py
@@ -166,9 +166,9 @@ def test_amplitude_encoding_gradients_follow_computation_space(
     assert amplitude_input.grad.shape == amplitude_input.shape
 
     trainable_params = [p for p in layer.parameters() if p.requires_grad]
-    assert trainable_params, (
-        "Expected at least one trainable parameter for gradient check"
-    )
+    assert (
+        trainable_params
+    ), "Expected at least one trainable parameter for gradient check"
     for param in trainable_params:
         assert param.grad is not None
         assert param.grad.shape == param.shape
@@ -377,7 +377,9 @@ def test_amplitude_encoding_dense_tensor_forward_uses_sparse_support(
     seen = {"sparse": False, "nnz": 0, "shape": None}
     original_chunked = process._compute_chunked_superposition
 
-    def tracked_chunked(self, prepared_state, unitary, *, simultaneous_processes):
+    def tracked_chunked(
+        self, prepared_state, unitary, *, simultaneous_processes, paired=False
+    ):
         seen["sparse"] = prepared_state.is_sparse
         seen["nnz"] = prepared_state.nnz
         seen["shape"] = prepared_state.shape
@@ -411,7 +413,9 @@ def test_amplitude_encoding_dense_statevector_forward_uses_sparse_support(
     seen = {"sparse": False, "nnz": 0, "shape": None}
     original_chunked = process._compute_chunked_superposition
 
-    def tracked_chunked(self, prepared_state, unitary, *, simultaneous_processes):
+    def tracked_chunked(
+        self, prepared_state, unitary, *, simultaneous_processes, paired=False
+    ):
         seen["sparse"] = prepared_state.is_sparse
         seen["nnz"] = prepared_state.nnz
         seen["shape"] = prepared_state.shape
@@ -456,7 +460,9 @@ def test_amplitude_encoding_sparse_statevector_forward_stays_sparse(
     seen = {"sparse": False}
     original_chunked = process._compute_chunked_superposition
 
-    def tracked_chunked(self, prepared_state, unitary, *, simultaneous_processes):
+    def tracked_chunked(
+        self, prepared_state, unitary, *, simultaneous_processes, paired=False
+    ):
         seen["sparse"] = prepared_state.is_sparse
         return original_chunked(
             prepared_state,
@@ -496,7 +502,9 @@ def test_constructor_dense_statevector_input_uses_sparse_support():
     seen = {"sparse": False, "nnz": 0, "shape": None}
     original_chunked = layer.computation_process._compute_chunked_superposition
 
-    def tracked_chunked(self, prepared_state, unitary, *, simultaneous_processes):
+    def tracked_chunked(
+        self, prepared_state, unitary, *, simultaneous_processes, paired=False
+    ):
         seen["sparse"] = prepared_state.is_sparse
         seen["nnz"] = prepared_state.nnz
         seen["shape"] = prepared_state.shape
@@ -551,7 +559,9 @@ def test_constructor_sparse_statevector_input_stays_sparse(monkeypatch):
     seen = {"sparse": False}
     original_chunked = layer.computation_process._compute_chunked_superposition
 
-    def tracked_chunked(self, prepared_state, unitary, *, simultaneous_processes):
+    def tracked_chunked(
+        self, prepared_state, unitary, *, simultaneous_processes, paired=False
+    ):
         seen["sparse"] = prepared_state.is_sparse
         return original_chunked(
             prepared_state,
@@ -924,9 +934,9 @@ def test_amplitude_encoding_superposition_matches_basis_sum():
     combined_output = layer(amplitude_input)
     expected_output = torch.sum(coefficients[:, None, None] * basis_outputs, dim=0)
     difference = combined_output - expected_output
-    assert torch.allclose(combined_output, expected_output, atol=1e-6, rtol=1e-6), (
-        f"Max deviation {difference.abs().max().item():.2e}"
-    )
+    assert torch.allclose(
+        combined_output, expected_output, atol=1e-6, rtol=1e-6
+    ), f"Max deviation {difference.abs().max().item():.2e}"
 
     with pytest.raises(ValueError, match="Amplitude input expects"):
         layer(torch.ones(basis_size + 1, dtype=torch.complex64))
@@ -1063,9 +1073,9 @@ def test_ebs_wrt_quantumlayer(
             single_unitary = single_layer.computation_process.converter.to_tensor(
                 *single_params
             )
-            assert torch.allclose(single_unitary, ebs_unitary, rtol=1e-6, atol=1e-8), (
-                "Expected identical unitaries between EBS and single-state layers."
-            )
+            assert torch.allclose(
+                single_unitary, ebs_unitary, rtol=1e-6, atol=1e-8
+            ), "Expected identical unitaries between EBS and single-state layers."
             assert (
                 single_layer.computation_process.simulation_graph.mapped_keys
                 == ebs_layer.computation_process.simulation_graph.mapped_keys
@@ -1083,6 +1093,6 @@ def test_ebs_wrt_quantumlayer(
         p=2, dim=1, keepdim=True
     ).clamp_min(1e-12)
     # TODO: investigate why this tests failed with rtol=1e-6, atol=1e-8
-    assert torch.allclose(ebs_output, expected_output, rtol=1e-4, atol=1e-6), (
-        "EBS output deviates from the superposed QuantumLayer results."
-    )
+    assert torch.allclose(
+        ebs_output, expected_output, rtol=1e-4, atol=1e-6
+    ), "EBS output deviates from the superposed QuantumLayer results."

--- a/tests/algorithms/test_layer.py
+++ b/tests/algorithms/test_layer.py
@@ -46,6 +46,7 @@ from merlin.algorithms.layer import QuantumLayer
 from merlin.core import StateVector, EncodingSpace
 from merlin import CircuitBuilder, QuantumLayer, MeasurementStrategy, ComputationSpace
 
+
 class TestQuantumLayer:
     """Test suite for QuantumLayer."""
 
@@ -382,10 +383,12 @@ class TestQuantumLayer:
             measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
-        params, batch_dim = layer._prepare_classical_parameters([
-            torch.rand(2, 2),
-            torch.rand(2, 2),
-        ])
+        params, batch_dim = layer._prepare_classical_parameters(
+            [
+                torch.rand(2, 2),
+                torch.rand(2, 2),
+            ]
+        )
 
         assert batch_dim == 2
         assert len(params) >= 2
@@ -1040,9 +1043,9 @@ class TestQuantumLayer:
         assert model[1].out_features == 3
         # Check that it has trainable parameters (only in Linear layer)
         trainable_params_layer = [p for p in layer.parameters() if p.requires_grad]
-        assert len(trainable_params_layer) == 0, (
-            "Layer should have no trainable parameters"
-        )
+        assert (
+            len(trainable_params_layer) == 0
+        ), "Layer should have no trainable parameters"
         trainable_params = [p for p in model.parameters() if p.requires_grad]
         assert len(trainable_params) > 0, "Model should have trainable parameters"
 
@@ -2361,12 +2364,12 @@ def test_memristive_state_dict_round_trip_preserves_state_and_history():
     restored = _layer(_builder_with_memristor(with_inputs=True), input_size=2)
     restored.load_state_dict(torch.load(buffer, weights_only=True))
 
-    assert torch.allclose(restored.memristive_state[0], state_before), (
-        "memristive_state was not preserved across a state_dict round-trip"
-    )
-    assert len(restored.memristive_history[0]) == history_len_before, (
-        "memristive_history length was not preserved across a state_dict round-trip"
-    )
+    assert torch.allclose(
+        restored.memristive_state[0], state_before
+    ), "memristive_state was not preserved across a state_dict round-trip"
+    assert (
+        len(restored.memristive_history[0]) == history_len_before
+    ), "memristive_history length was not preserved across a state_dict round-trip"
 
 
 def test_memristive_state_dict_round_trip_as_submodule():
@@ -2629,9 +2632,9 @@ def test_memristive_works_with_typed_objects_and_cloning_protects_gradients():
     loss_sv = output_sv_typed.tensor.abs().sum()
     loss_sv.backward()
     assert input_data.grad is not None
-    assert torch.any(input_data.grad != 0), (
-        "Gradients should flow through StateVector output"
-    )
+    assert torch.any(
+        input_data.grad != 0
+    ), "Gradients should flow through StateVector output"
 
     # Verify memristive history accumulated (one forward pass = one state)
     assert len(layer_statevector_typed.memristive_history[0]) >= 1
@@ -2646,9 +2649,7 @@ def test_memristive_works_with_typed_objects_and_cloning_protects_gradients():
     # Verify output is NOT modified by the update rule (cloning protected it)
     assert not torch.allclose(
         output_pd_typed.tensor, torch.full_like(output_pd_typed.tensor, 999.0)
-    ), (
-        "ProbabilityDistribution output was incorrectly modified by memristive update rule"
-    )
+    ), "ProbabilityDistribution output was incorrectly modified by memristive update rule"
     assert output_pd_typed.tensor.requires_grad
 
     # Compute loss and backward for ProbabilityDistribution
@@ -2782,9 +2783,9 @@ def test_detach_at_each_forward_false_allows_full_gradient_history():
     outputs = [layer(input_batch) for input_batch in inputs]
 
     # Verify memristive history accumulated
-    assert len(layer.memristive_history[0]) == 6, (
-        f"Expected 6 history entries, got {len(layer.memristive_history[0])}"
-    )
+    assert (
+        len(layer.memristive_history[0]) == 6
+    ), f"Expected 6 history entries, got {len(layer.memristive_history[0])}"
 
     # Compute loss from the last output and backpropagate
     loss = outputs[-1][:, 0].sum()
@@ -2799,9 +2800,9 @@ def test_detach_at_each_forward_false_allows_full_gradient_history():
 
     # All inputs should have non-zero gradients (full history retained)
     for i, grad_norm in enumerate(grad_norms):
-        assert grad_norm > 1e-8, (
-            f"Input {i} should have non-zero gradient with full history, got {grad_norm}"
-        )
+        assert (
+            grad_norm > 1e-8
+        ), f"Input {i} should have non-zero gradient with full history, got {grad_norm}"
 
 
 def test_detach_at_each_forward_is_boolean_flag():
@@ -2899,9 +2900,9 @@ def test_mixed_memristors_with_different_detach_settings():
         assert state.grad_fn is None, "Detached memristor states should have no grad_fn"
 
     # Second memristor (full grad) should retain gradients
-    assert layer.memristive_history[1][-1].grad_fn is not None, (
-        "Non-detached memristor should retain gradients"
-    )
+    assert (
+        layer.memristive_history[1][-1].grad_fn is not None
+    ), "Non-detached memristor should retain gradients"
 
 
 def test_detach_at_each_forward_false_has_larger_gradients_than_true():
@@ -2946,9 +2947,9 @@ def test_detach_at_each_forward_false_has_larger_gradients_than_true():
 
     # Earlier inputs should have larger or equal gradients with full history
     for i in range(N - 1):  # All except last
-        assert grads_full[i] >= grads_detached[i] * 0.9, (
-            "Full gradient flow should have larger or equal gradients for earlier inputs"
-        )
+        assert (
+            grads_full[i] >= grads_detached[i] * 0.9
+        ), "Full gradient flow should have larger or equal gradients for earlier inputs"
 
 
 def test_reset_properly_detaches_or_keeps_initial_state():
@@ -2962,12 +2963,12 @@ def test_reset_properly_detaches_or_keeps_initial_state():
     # Test with detach=True
     layer_detached = _make_memristive_layer(detach_at_each_forward=True)
     layer_detached.reset(batch_size=1)
-    assert layer_detached.memristive_state[0].grad_fn is None, (
-        "Initial state should be detached with detach_at_each_forward=True"
-    )
-    assert layer_detached.memristive_history[0][0].grad_fn is None, (
-        "Initial history state should be detached with detach_at_each_forward=True"
-    )
+    assert (
+        layer_detached.memristive_state[0].grad_fn is None
+    ), "Initial state should be detached with detach_at_each_forward=True"
+    assert (
+        layer_detached.memristive_history[0][0].grad_fn is None
+    ), "Initial history state should be detached with detach_at_each_forward=True"
 
     # Test with detach=False
     layer_full = _make_memristive_layer(detach_at_each_forward=False)
@@ -2976,9 +2977,9 @@ def test_reset_properly_detaches_or_keeps_initial_state():
     # But after first forward it should retain gradients
     inp = torch.randn(1, 2, requires_grad=True)
     layer_full(inp)
-    assert layer_full.memristive_state[0].grad_fn is not None, (
-        "State should retain gradients after forward with detach_at_each_forward=False"
-    )
+    assert (
+        layer_full.memristive_state[0].grad_fn is not None
+    ), "State should retain gradients after forward with detach_at_each_forward=False"
 
 
 def test_detach_at_each_forward_with_batch_dimension():
@@ -3075,90 +3076,132 @@ def test_long_sequence_with_manual_sliding_window_detach():
 
 
 def test_quantum_layer_photon_count_mismatch_list():
-    with pytest.raises(ValueError, match="Inconsistent number of photons between input_state and n_photons."):
+    with pytest.raises(
+        ValueError,
+        match="Inconsistent number of photons between input_state and n_photons.",
+    ):
         QuantumLayer(
             input_size=0,
             circuit=pcvl.Circuit(3),
-            input_state=[1, 1, 1], 
+            input_state=[1, 1, 1],
             n_photons=1,
-            measurement_strategy=ML.MeasurementStrategy.probs(),)
+            measurement_strategy=ML.MeasurementStrategy.probs(),
+        )
+
+
 def test_quantum_layer_photon_count_mismatch_tuple():
-    with pytest.raises(ValueError, match="Inconsistent number of photons between input_state and n_photons."):
+    with pytest.raises(
+        ValueError,
+        match="Inconsistent number of photons between input_state and n_photons.",
+    ):
         QuantumLayer(
             input_size=0,
             circuit=pcvl.Circuit(3),
-            input_state=(1, 1, 1), 
+            input_state=(1, 1, 1),
             n_photons=1,
-            measurement_strategy=ML.MeasurementStrategy.probs(),)
+            measurement_strategy=ML.MeasurementStrategy.probs(),
+        )
+
+
 def test_quantum_layer_photon_count_mismatch_list_is_float_compatible_working():
-    with pytest.raises(ValueError, match="Inconsistent number of photons between input_state and n_photons."):
+    with pytest.raises(
+        ValueError,
+        match="Inconsistent number of photons between input_state and n_photons.",
+    ):
         QuantumLayer(
             input_size=0,
             circuit=pcvl.Circuit(3),
-            input_state=[1, 1, 1], 
+            input_state=[1, 1, 1],
             n_photons=1,
-            measurement_strategy=ML.MeasurementStrategy.probs(),)
+            measurement_strategy=ML.MeasurementStrategy.probs(),
+        )
+
+
 def test_quantum_layer_photon_count_match_list_is_float_compatible_working():
-        layer = QuantumLayer(
-            input_size=0,
-            circuit=pcvl.Circuit(3),
-            input_state=[1, 1, 1], 
-            n_photons=3,
-            measurement_strategy=ML.MeasurementStrategy.probs(),)
-        assert layer is not None
-        assert isinstance(layer, QuantumLayer)
+    layer = QuantumLayer(
+        input_size=0,
+        circuit=pcvl.Circuit(3),
+        input_state=[1, 1, 1],
+        n_photons=3,
+        measurement_strategy=ML.MeasurementStrategy.probs(),
+    )
+    assert layer is not None
+    assert isinstance(layer, QuantumLayer)
+
+
 def test_quantum_layer_photon_count_mismatch_StateVector():
-    with pytest.raises(ValueError, match="Inconsistent number of photons between input_state and n_photons."):
+    with pytest.raises(
+        ValueError,
+        match="Inconsistent number of photons between input_state and n_photons.",
+    ):
         QuantumLayer(
             input_size=0,
             circuit=pcvl.Circuit(3),
-            input_state=pcvl.StateVector("|1,0,1>"), 
+            input_state=pcvl.StateVector("|1,0,1>"),
             n_photons=1,
-            measurement_strategy=ML.MeasurementStrategy.probs(),)
+            measurement_strategy=ML.MeasurementStrategy.probs(),
+        )
+
 
 def test_quantum_layer_photon_count_mismatch_BasicState():
-    with pytest.raises(ValueError, match="Inconsistent number of photons between input_state and n_photons."):
+    with pytest.raises(
+        ValueError,
+        match="Inconsistent number of photons between input_state and n_photons.",
+    ):
         QuantumLayer(
             input_size=0,
             circuit=pcvl.Circuit(3),
-            input_state=pcvl.BasicState("|1,0,1>"), 
+            input_state=pcvl.BasicState("|1,0,1>"),
             n_photons=1,
-            measurement_strategy=ML.MeasurementStrategy.probs(),)
-        
+            measurement_strategy=ML.MeasurementStrategy.probs(),
+        )
+
+
 def test_quantum_layer_photon_count_mismatch_StateVector_superposition():
-    with pytest.raises(ValueError, match="Inconsistent number of photons between input_state and n_photons."):
+    with pytest.raises(
+        ValueError,
+        match="Inconsistent number of photons between input_state and n_photons.",
+    ):
         QuantumLayer(
             input_size=0,
             circuit=pcvl.Circuit(3),
-            input_state=pcvl.StateVector("|1,0,1>")+pcvl.StateVector("|0,1,1>"), 
+            input_state=pcvl.StateVector("|1,0,1>") + pcvl.StateVector("|0,1,1>"),
             n_photons=1,
-            measurement_strategy=ML.MeasurementStrategy.probs(),)
+            measurement_strategy=ML.MeasurementStrategy.probs(),
+        )
+
 
 def test_quantum_layer_photon_count_match_StateVector():
-        layer = QuantumLayer(
-            input_size=0,
-            circuit=pcvl.Circuit(3),
-            input_state=pcvl.StateVector("|1,0,1>"), 
-            n_photons=2,
-            measurement_strategy=ML.MeasurementStrategy.probs(),)
-        assert layer is not None
-        assert isinstance(layer, QuantumLayer)
+    layer = QuantumLayer(
+        input_size=0,
+        circuit=pcvl.Circuit(3),
+        input_state=pcvl.StateVector("|1,0,1>"),
+        n_photons=2,
+        measurement_strategy=ML.MeasurementStrategy.probs(),
+    )
+    assert layer is not None
+    assert isinstance(layer, QuantumLayer)
+
+
 def test_quantum_layer_photon_count_match_List():
-        layer = QuantumLayer(
-            input_size=0,
-            circuit=pcvl.Circuit(3),
-            input_state=[1,0,1], 
-            n_photons=2,
-            measurement_strategy=ML.MeasurementStrategy.probs(),)
-        assert layer is not None
-        assert isinstance(layer, QuantumLayer)
+    layer = QuantumLayer(
+        input_size=0,
+        circuit=pcvl.Circuit(3),
+        input_state=[1, 0, 1],
+        n_photons=2,
+        measurement_strategy=ML.MeasurementStrategy.probs(),
+    )
+    assert layer is not None
+    assert isinstance(layer, QuantumLayer)
+
+
 def test_quantum_layer_photon_count_match_amplitude():
     layer = QuantumLayer(
         circuit=pcvl.Circuit(3),
         n_photons=2,
         measurement_strategy=ML.MeasurementStrategy.probs(),
         input_state=None,
-        amplitude_encoding=True,   
+        amplitude_encoding=True,
     )
     assert layer is not None
     assert isinstance(layer, QuantumLayer)
@@ -3167,14 +3210,14 @@ def test_quantum_layer_photon_count_match_amplitude():
 def test_quantum_layer_photon_count_match_amplitude():
     builder = CircuitBuilder(n_modes=4)
     builder.add_entangling_layer()
-    
+
     input_state = StateVector(
-        tensor=torch.rand(1, 10), 
+        tensor=torch.rand(1, 10),
         n_modes=4,
         n_photons=2,
         encoding=ML.EncodingSpace.FOCK,
     )
-    
+
     QuantumLayer(
         input_size=0,
         builder=builder,
@@ -3185,61 +3228,65 @@ def test_quantum_layer_photon_count_match_amplitude():
         input_state=input_state,
     )
 
+
 def test_quantum_layer_list_not_contain_integers():
     """see if an input state reject list of float."""
-    expected_msg =("List/tuple input_state must contain non-negative integer "
-                   "occupations; use a StateVector for superposed inputs.")
-    
+    expected_msg = (
+        "List/tuple input_state must contain non-negative integer "
+        "occupations; use a StateVector for superposed inputs."
+    )
+
     with pytest.raises(ValueError, match=re.escape(expected_msg)):
         QuantumLayer(
             input_size=0,
             circuit=pcvl.Circuit(3),
-            input_state=[0.3, 0, 1], #invalide input for list.
+            input_state=[0.3, 0, 1],  # invalide input for list.
             measurement_strategy=ML.MeasurementStrategy.probs(),
         )
 
+
 def test_quantum_layer_tuple_not_contain_integers():
     """see if an input state reject list of float."""
-    expected_msg =("List/tuple input_state must contain non-negative integer "
-                   "occupations; use a StateVector for superposed inputs.")
-    
+    expected_msg = (
+        "List/tuple input_state must contain non-negative integer "
+        "occupations; use a StateVector for superposed inputs."
+    )
+
     with pytest.raises(ValueError, match=re.escape(expected_msg)):
         QuantumLayer(
             input_size=0,
             circuit=pcvl.Circuit(3),
-            input_state=(0.3, 0, 1), #invalide input for list.
+            input_state=(0.3, 0, 1),  # invalide input for list.
             measurement_strategy=ML.MeasurementStrategy.probs(),
         )
+
 
 def test_quantum_layer_experiment_input_state_overrides_without_error():
     circuit = pcvl.Circuit(2)
     experiment = pcvl.Experiment(circuit)
     experiment.with_input(pcvl.BasicState([1, 0]))
     expected_warning = "Both 'experiment.input_state' and 'input_state' are provided. 'experiment.input_state' will be used."
-    
+
     with pytest.raises(UserWarning, match=re.escape(expected_warning)):
         layer = QuantumLayer(
             input_size=0,
             experiment=experiment,
-            input_state=[1, 1],   # ignored, replaced by experiment.input_state
+            input_state=[1, 1],  # ignored, replaced by experiment.input_state
             n_photons=1,
             measurement_strategy=ML.MeasurementStrategy.probs(),
         )
         assert layer.n_photons == 1
 
 
-
-def test_memrsistive_statevector_input_batched():
+def test_memrsistive_amplitude_input_batched():
     def update_rule(state: torch.Tensor, output: torch.Tensor):
-        return state + torch.vstack([output[0, 0]] * state.size(0)).squeeze(
-            dim=0
-        )
+        x = state + output[:, 0]
+        return x
 
     circ = ML.CircuitBuilder(n_modes=3)
     circ.add_entangling_layer()
     circ.add_memristive_ps(mode=0, update_rule=update_rule, initial_state=0)
     circ.add_entangling_layer()
-    #circ.add_angle_encoding(modes=[0, 1])
 
     ql = ML.QuantumLayer(
         builder=circ,
@@ -3250,12 +3297,45 @@ def test_memrsistive_statevector_input_batched():
     )
     ql.reset(batch_size=2)
 
-    input = torch.tensor([[1, 0,0],[0,1, 0]],dtype=torch.complex64)
+    input = torch.tensor([[1, 0, 0], [0, 1, 0]], dtype=torch.complex64)
 
-    output=ql(input)
+    output = ql(input)
 
-    print(output)
+    assert output.shape == (2, 3)
+    assert not ql.memristive_state[0][0] == ql.memristive_state[0][1]
+    assert ql.memristive_history[0][0][0] == ql.memristive_history[0][0][1]
 
-    print(ql.memristive_state)
-    print(ql.memristive_history)
-    assert False
+
+def test_memrsistive_amplitude_input_batched_with_noise():
+    def update_rule(state: torch.Tensor, output: torch.Tensor):
+        x = state + output[:, 0]
+        return x
+
+    circ = ML.CircuitBuilder(n_modes=3)
+    circ.add_entangling_layer()
+    circ.add_memristive_ps(mode=0, update_rule=update_rule, initial_state=0)
+    circ.add_entangling_layer()
+
+    ql = ML.QuantumLayer(
+        builder=circ,
+        n_photons=1,
+        measurement_strategy=ML.MeasurementStrategy.probs(
+            computation_space=ML.ComputationSpace.FOCK
+        ),
+        noise=pcvl.NoiseModel(
+            brightness=0.9,
+            indistinguishability=0.7,
+            g2=0.1,
+            phase_error=0.1,
+            phase_imprecision=0.1,
+        ),
+    )
+    ql.reset(batch_size=2)
+
+    input = torch.tensor([[1, 0, 0], [0, 1, 0]], dtype=torch.complex64)
+
+    output = ql(input)
+
+    assert output.shape == (2, 3)
+    assert not ql.memristive_state[0][0] == ql.memristive_state[0][1]
+    assert ql.memristive_history[0][0][0] == ql.memristive_history[0][0][1]

--- a/tests/algorithms/test_layer.py
+++ b/tests/algorithms/test_layer.py
@@ -3305,6 +3305,12 @@ def test_memrsistive_amplitude_input_batched():
     assert not ql.memristive_state[0][0] == ql.memristive_state[0][1]
     assert ql.memristive_history[0][0][0] == ql.memristive_history[0][0][1]
 
+    input = torch.tensor([[1, 0, 0], [1, 0, 0]], dtype=torch.complex64)
+
+    output = ql(input)
+
+    assert not torch.allclose(output[0], output[1])
+
 
 def test_memrsistive_amplitude_input_batched_with_noise():
     def update_rule(state: torch.Tensor, output: torch.Tensor):
@@ -3327,9 +3333,10 @@ def test_memrsistive_amplitude_input_batched_with_noise():
             brightness=0.9,
             indistinguishability=0.7,
             g2=0.1,
-            phase_error=0.1,
-            phase_imprecision=0.1,
+            phase_error=0.01,
+            phase_imprecision=0.01,
         ),
+        n_phase_error_samples=1,
     )
     ql.reset(batch_size=2)
 
@@ -3383,9 +3390,10 @@ def test_memrsistive_amplitude_input_batched_with_noise():
             computation_space=ML.ComputationSpace.FOCK
         ),
         noise=pcvl.NoiseModel(
-            phase_error=0.1,
-            phase_imprecision=0.1,
+            phase_error=0.01,
+            phase_imprecision=0.01,
         ),
+        n_phase_error_samples=1,
     )
     ql.reset(batch_size=2)
 

--- a/tests/algorithms/test_layer.py
+++ b/tests/algorithms/test_layer.py
@@ -3278,10 +3278,8 @@ def test_quantum_layer_experiment_input_state_overrides_without_error():
         assert layer.n_photons == 1
 
 
-def test_memrsistive_amplitude_input_batched():
+def test_memristive_amplitude_input_batched():
     def update_rule(state: torch.Tensor, output: torch.Tensor):
-        print(state)
-        print(output)
         x = state + output[:, 0]
         return x
 
@@ -3314,10 +3312,8 @@ def test_memrsistive_amplitude_input_batched():
     assert not torch.allclose(output[0], output[1])
 
 
-def test_memrsistive_amplitude_input_batched_with_noise():
+def test_memristive_amplitude_input_batched_with_noise():
     def update_rule(state: torch.Tensor, output: torch.Tensor):
-        print(state)
-        print(output)
         x = state + output[:, 0]
         return x
 

--- a/tests/algorithms/test_layer.py
+++ b/tests/algorithms/test_layer.py
@@ -3226,3 +3226,36 @@ def test_quantum_layer_experiment_input_state_overrides_without_error():
             measurement_strategy=ML.MeasurementStrategy.probs(),
         )
         assert layer.n_photons == 1
+
+
+
+def test_memrsistive_statevector_input_batched():
+    def update_rule(state: torch.Tensor, output: torch.Tensor):
+        return state + torch.vstack([output[0, 0]] * state.size(0)).squeeze(
+            dim=0
+        )
+
+    circ = ML.CircuitBuilder(n_modes=3)
+    circ.add_entangling_layer()
+    circ.add_memristive_ps(mode=0, update_rule=update_rule, initial_state=0)
+    circ.add_entangling_layer()
+    #circ.add_angle_encoding(modes=[0, 1])
+
+    ql = ML.QuantumLayer(
+        builder=circ,
+        n_photons=1,
+        measurement_strategy=ML.MeasurementStrategy.probs(
+            computation_space=ML.ComputationSpace.FOCK
+        ),
+    )
+    ql.reset(batch_size=2)
+
+    input = torch.tensor([[1, 0,0],[0,1, 0]],dtype=torch.complex64)
+
+    output=ql(input)
+
+    print(output)
+
+    print(ql.memristive_state)
+    print(ql.memristive_history)
+    assert False

--- a/tests/algorithms/test_layer.py
+++ b/tests/algorithms/test_layer.py
@@ -3316,6 +3316,7 @@ def test_memrsistive_amplitude_input_batched_with_noise():
     circ.add_memristive_ps(mode=0, update_rule=update_rule, initial_state=0)
     circ.add_entangling_layer()
 
+    # Both source and phase
     ql = ML.QuantumLayer(
         builder=circ,
         n_photons=1,
@@ -3336,6 +3337,68 @@ def test_memrsistive_amplitude_input_batched_with_noise():
 
     output = ql(input)
 
+    assert output.shape == (2, 10)
+    assert not ql.memristive_state[0][0] == ql.memristive_state[0][1]
+    assert ql.memristive_history[0][0][0] == ql.memristive_history[0][0][1]
+
+    input = torch.tensor([[1, 0, 0], [1, 0, 0]], dtype=torch.complex64)
+
+    output = ql(input)
+
+    assert not torch.allclose(output[0], output[1])
+
+    # Source noise only
+    ql = ML.QuantumLayer(
+        builder=circ,
+        n_photons=1,
+        measurement_strategy=ML.MeasurementStrategy.probs(
+            computation_space=ML.ComputationSpace.FOCK
+        ),
+        noise=pcvl.NoiseModel(
+            indistinguishability=0.7,
+            g2=0.1,
+        ),
+    )
+    ql.reset(batch_size=2)
+
+    input = torch.tensor([[1, 0, 0], [0, 1, 0]], dtype=torch.complex64)
+
+    output = ql(input)
+
+    assert output.shape == (2, 9)
+    assert not ql.memristive_state[0][0] == ql.memristive_state[0][1]
+    assert ql.memristive_history[0][0][0] == ql.memristive_history[0][0][1]
+
+    input = torch.tensor([[1, 0, 0], [1, 0, 0]], dtype=torch.complex64)
+
+    output = ql(input)
+
+    assert not torch.allclose(output[0], output[1])
+
+    # Phase noise only
+    ql = ML.QuantumLayer(
+        builder=circ,
+        n_photons=1,
+        measurement_strategy=ML.MeasurementStrategy.probs(
+            computation_space=ML.ComputationSpace.FOCK
+        ),
+        noise=pcvl.NoiseModel(
+            phase_error=0.1,
+            phase_imprecision=0.1,
+        ),
+    )
+    ql.reset(batch_size=2)
+
+    input = torch.tensor([[1, 0, 0], [0, 1, 0]], dtype=torch.complex64)
+
+    output = ql(input)
+
     assert output.shape == (2, 3)
     assert not ql.memristive_state[0][0] == ql.memristive_state[0][1]
     assert ql.memristive_history[0][0][0] == ql.memristive_history[0][0][1]
+
+    input = torch.tensor([[1, 0, 0], [1, 0, 0]], dtype=torch.complex64)
+
+    output = ql(input)
+
+    assert not torch.allclose(output[0], output[1])

--- a/tests/algorithms/test_layer.py
+++ b/tests/algorithms/test_layer.py
@@ -3280,6 +3280,8 @@ def test_quantum_layer_experiment_input_state_overrides_without_error():
 
 def test_memrsistive_amplitude_input_batched():
     def update_rule(state: torch.Tensor, output: torch.Tensor):
+        print(state)
+        print(output)
         x = state + output[:, 0]
         return x
 
@@ -3314,6 +3316,8 @@ def test_memrsistive_amplitude_input_batched():
 
 def test_memrsistive_amplitude_input_batched_with_noise():
     def update_rule(state: torch.Tensor, output: torch.Tensor):
+        print(state)
+        print(output)
         x = state + output[:, 0]
         return x
 


### PR DESCRIPTION
## Summary
- The memristive phase shifters did not work with batched amplitude encoding

## Related Issue
PML-383

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / Cleanup
- [ ] Performance improvement
- [ ] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)


## Proposed changes
- For every compute method that uses memristove phase shifters and amplitude encoding
   - Computing one unitary per memristove state in the batch
   - Combine every output into the batched output

## How to test / How to run
```
pytest -q
```

## Documentation
- [ ] User docs updated (Sphinx)
- [ ] Examples / notebooks updated
- [ ] Docstrings updated
- [ ] Updated the API