### PR TITLE
PML-378

### DIFF
--- a/merlin/algorithms/module.py
+++ b/merlin/algorithms/module.py
@@ -54,7 +54,7 @@ class MerlinModule(nn.Module):
     """
 
     # -------------------- Execution policy & helpers --------------------
-    uid = uuid.uuid4()
+    uid: uuid.UUID
 
     @property
     def force_local(self) -> bool:
@@ -87,6 +87,8 @@ class MerlinModule(nn.Module):
     def __init__(self) -> None:
         """Initialize the shared Merlin module state."""
         super().__init__()
+
+        self.uid = uuid.uuid4()
 
         # execution policy: when True, always simulate locally (do not offload)
         self._force_simulation: bool = False

--- a/tests/core/test_merlin_processor_unit.py
+++ b/tests/core/test_merlin_processor_unit.py
@@ -21,8 +21,10 @@ from perceval.runtime import AProcessor, Processor, RemoteProcessor
 from perceval.runtime.session import ISession
 
 import merlin.core.merlin_processor as merlin_processor_module
+from merlin.algorithms import QuantumLayer
 from merlin.algorithms.module import MerlinModule
 from merlin.core.circuit import Circuit
+from merlin.core.computation_space import ComputationSpace
 from merlin.core.merlin_processor import (
     BackendCapabilities,
     MerlinProcessor,
@@ -30,6 +32,7 @@ from merlin.core.merlin_processor import (
     ValidatedLayerConfig,
 )
 from merlin.core.state_vector import StateVector
+from merlin.measurement.strategies import MeasurementStrategy
 
 
 class FakeCommand:
@@ -1511,6 +1514,84 @@ def test_run_chunk_local_executes_real_perceval_processor():
     )
 
     torch.testing.assert_close(output, torch.tensor([[1.0, 0.0], [1.0, 0.0]]))
+
+
+def test_local_processor_two_quantum_layers_matches_direct_perceval_probabilities():
+    """Local MerlinProcessor execution matches a direct two-layer Perceval run."""
+
+    def make_phase_circuit(prefix: str, final_theta: float) -> pcvl.Circuit:
+        circuit = pcvl.Circuit(2)
+        circuit.add(0, pcvl.BS.H())
+        circuit.add(0, pcvl.PS(pcvl.P(f"{prefix}1")))
+        circuit.add(1, pcvl.PS(pcvl.P(f"{prefix}2")))
+        circuit.add(0, pcvl.BS(theta=final_theta))
+        return circuit
+
+    def make_phase_layer(circuit: pcvl.Circuit, prefix: str) -> QuantumLayer:
+        return QuantumLayer(
+            input_size=2,
+            circuit=circuit,
+            input_state=[1, 0],
+            trainable_parameters=[],
+            input_parameters=[prefix],
+            measurement_strategy=MeasurementStrategy.probs(
+                computation_space=ComputationSpace.UNBUNCHED,
+            ),
+            dtype=torch.float64,
+        ).eval()
+
+    def run_perceval_probabilities(
+        circuit: pcvl.Circuit, param_names: Sequence[str], inputs: torch.Tensor
+    ) -> torch.Tensor:
+        processor = Processor("SLOS")
+        processor.set_circuit(circuit.copy())
+        processor.with_input(pcvl.BasicState([1, 0]))
+
+        sampler = merlin_processor_module.Sampler(
+            processor,
+            max_shots_per_call=MerlinProcessor.DEFAULT_MAX_SHOTS,
+        )
+        sampler.clear_iterations()
+        input_values = inputs.detach().cpu().numpy()
+        for row in input_values:
+            sampler.add_iteration(
+                circuit_params={
+                    name: float(row[index]) for index, name in enumerate(param_names)
+                }
+            )
+
+        raw_results = sampler.probs.execute_sync()
+        output = torch.zeros((inputs.shape[0], 2), dtype=inputs.dtype)
+        state_to_index = {"|1,0>": 0, "|0,1>": 1}
+        for row_index, result_item in enumerate(raw_results["results_list"]):
+            for state, probability in result_item["results"].items():
+                output[row_index, state_to_index[str(state)]] = float(probability)
+        return output
+
+    first_circuit = make_phase_circuit("a", final_theta=0.8)
+    second_circuit = make_phase_circuit("b", final_theta=1.3)
+    first_layer = make_phase_layer(first_circuit, "a")
+    second_layer = make_phase_layer(second_circuit, "b")
+    model = torch.nn.Sequential(first_layer, second_layer).eval()
+    input_tensor = torch.tensor(
+        [[0.1, 0.7], [1.2, 0.3], [2.4, 1.1]],
+        dtype=torch.float64,
+    )
+
+    first_expected = run_perceval_probabilities(
+        first_circuit, ["a1", "a2"], input_tensor
+    )
+    expected = run_perceval_probabilities(
+        second_circuit, ["b1", "b2"], first_expected
+    )
+
+    processor = MerlinProcessor(processor=Processor("SLOS"))
+    actual = processor.forward(model, input_tensor, nsample=None)
+
+    assert first_layer.uid != second_layer.uid
+    assert len(processor._layer_cache) == 2
+    assert set(processor._layer_cache) == {first_layer.uid, second_layer.uid}
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-6)
 
 
 def test_run_chunk_local_executes_real_clifford_processor_samples():

--- a/tests/core/test_merlin_processor_unit.py
+++ b/tests/core/test_merlin_processor_unit.py
@@ -1521,13 +1521,26 @@ def test_local_processor_two_quantum_layers_matches_direct_perceval_probabilitie
     """Local MerlinProcessor execution matches a direct two-layer Perceval run."""
     n_modes = 3
 
-    def make_builder_layer(prefix: str) -> QuantumLayer:
+    class ReuploadInput(torch.nn.Module):
+        """Duplicate a feature tensor for a second angle-encoding upload."""
+
+        def forward(self, input_tensor: torch.Tensor) -> torch.Tensor:
+            return torch.cat((input_tensor, input_tensor), dim=-1)
+
+    def make_builder_layer(prefixes: Sequence[str]) -> QuantumLayer:
         builder = CircuitBuilder(n_modes=n_modes)
-        builder.add_entangling_layer(trainable=False, name=f"{prefix}_pre")
-        builder.add_angle_encoding(modes=list(range(n_modes)), name=prefix)
-        builder.add_entangling_layer(trainable=False, name=f"{prefix}_post")
+        builder.add_entangling_layer(trainable=False, name=f"{prefixes[0]}_pre")
+        for index, prefix in enumerate(prefixes):
+            builder.add_angle_encoding(modes=list(range(n_modes)), name=prefix)
+            entangler_name = (
+                f"{prefix}_post" if index == len(prefixes) - 1 else f"{prefix}_mid"
+            )
+            builder.add_entangling_layer(
+                trainable=False,
+                name=entangler_name,
+            )
         return QuantumLayer(
-            input_size=n_modes,
+            input_size=n_modes * len(prefixes),
             builder=builder,
             input_state=[1, 0, 0],
             measurement_strategy=MeasurementStrategy.probs(
@@ -1536,29 +1549,30 @@ def test_local_processor_two_quantum_layers_matches_direct_perceval_probabilitie
             dtype=torch.float64,
         ).eval()
 
-    def make_builder_equivalent_perceval_circuit(prefix: str) -> pcvl.Circuit:
+    def make_builder_equivalent_perceval_circuit(
+        prefixes: Sequence[str],
+    ) -> pcvl.Circuit:
         def fixed_mzi(_index: int) -> pcvl.Circuit:
             return pcvl.BS() // pcvl.PS(0.0) // pcvl.BS() // pcvl.PS(0.0)
 
+        def add_fixed_entangler(circuit: pcvl.Circuit) -> None:
+            circuit.add(
+                0,
+                pcvl.GenericInterferometer(
+                    n_modes,
+                    fixed_mzi,
+                    shape=pcvl.InterferometerShape.RECTANGLE,
+                ),
+            )
+
         circuit = pcvl.Circuit(n_modes)
-        circuit.add(
-            0,
-            pcvl.GenericInterferometer(
-                n_modes,
-                fixed_mzi,
-                shape=pcvl.InterferometerShape.RECTANGLE,
-            ),
-        )
-        for mode in range(n_modes):
-            circuit.add(mode, pcvl.PS(pcvl.P(f"{prefix}{mode + 1}")))
-        circuit.add(
-            0,
-            pcvl.GenericInterferometer(
-                n_modes,
-                fixed_mzi,
-                shape=pcvl.InterferometerShape.RECTANGLE,
-            ),
-        )
+        add_fixed_entangler(circuit)
+        parameter_index = 1
+        for prefix in prefixes:
+            for mode in range(n_modes):
+                circuit.add(mode, pcvl.PS(pcvl.P(f"{prefix}{parameter_index}")))
+                parameter_index += 1
+            add_fixed_entangler(circuit)
         return circuit
 
     def run_perceval_probabilities(
@@ -1589,21 +1603,35 @@ def test_local_processor_two_quantum_layers_matches_direct_perceval_probabilitie
                 output[row_index, state_to_index[str(state)]] = float(probability)
         return output
 
-    first_circuit = make_builder_equivalent_perceval_circuit("a")
-    second_circuit = make_builder_equivalent_perceval_circuit("b")
-    first_layer = make_builder_layer("a")
-    second_layer = make_builder_layer("b")
-    model = torch.nn.Sequential(first_layer, second_layer).eval()
+    first_circuit = make_builder_equivalent_perceval_circuit(["a"])
+    second_circuit = make_builder_equivalent_perceval_circuit(["b", "c"])
+    first_layer = make_builder_layer(["a"])
+    second_layer = make_builder_layer(["b", "c"])
+    model = torch.nn.Sequential(first_layer, ReuploadInput(), second_layer).eval()
     input_tensor = torch.tensor(
         [[0.1, 0.7, 1.4], [1.2, 0.3, 0.6], [2.4, 1.1, 0.2]],
         dtype=torch.float64,
     )
 
+    first_param_order = first_layer.export_config()["input_param_order"]
+    second_param_order = second_layer.export_config()["input_param_order"]
+    assert first_param_order == ["a1", "a2", "a3"]
+    assert second_param_order == [
+        "b1",
+        "b2",
+        "b3",
+        "c4",
+        "c5",
+        "c6",
+    ]
+    assert len(second_param_order) > len(first_param_order)
+
     first_expected = run_perceval_probabilities(
         first_circuit, ["a1", "a2", "a3"], input_tensor
     )
+    second_input = torch.cat((first_expected, first_expected), dim=-1)
     expected = run_perceval_probabilities(
-        second_circuit, ["b1", "b2", "b3"], first_expected
+        second_circuit, ["b1", "b2", "b3", "c4", "c5", "c6"], second_input
     )
 
     processor = MerlinProcessor(processor=Processor("SLOS"))

--- a/tests/core/test_merlin_processor_unit.py
+++ b/tests/core/test_merlin_processor_unit.py
@@ -23,6 +23,7 @@ from perceval.runtime.session import ISession
 import merlin.core.merlin_processor as merlin_processor_module
 from merlin.algorithms import QuantumLayer
 from merlin.algorithms.module import MerlinModule
+from merlin.builder.circuit_builder import CircuitBuilder
 from merlin.core.circuit import Circuit
 from merlin.core.computation_space import ComputationSpace
 from merlin.core.merlin_processor import (
@@ -1518,34 +1519,54 @@ def test_run_chunk_local_executes_real_perceval_processor():
 
 def test_local_processor_two_quantum_layers_matches_direct_perceval_probabilities():
     """Local MerlinProcessor execution matches a direct two-layer Perceval run."""
+    n_modes = 3
 
-    def make_phase_circuit(prefix: str, final_theta: float) -> pcvl.Circuit:
-        circuit = pcvl.Circuit(2)
-        circuit.add(0, pcvl.BS.H())
-        circuit.add(0, pcvl.PS(pcvl.P(f"{prefix}1")))
-        circuit.add(1, pcvl.PS(pcvl.P(f"{prefix}2")))
-        circuit.add(0, pcvl.BS(theta=final_theta))
-        return circuit
-
-    def make_phase_layer(circuit: pcvl.Circuit, prefix: str) -> QuantumLayer:
+    def make_builder_layer(prefix: str) -> QuantumLayer:
+        builder = CircuitBuilder(n_modes=n_modes)
+        builder.add_entangling_layer(trainable=False, name=f"{prefix}_pre")
+        builder.add_angle_encoding(modes=list(range(n_modes)), name=prefix)
+        builder.add_entangling_layer(trainable=False, name=f"{prefix}_post")
         return QuantumLayer(
-            input_size=2,
-            circuit=circuit,
-            input_state=[1, 0],
-            trainable_parameters=[],
-            input_parameters=[prefix],
+            input_size=n_modes,
+            builder=builder,
+            input_state=[1, 0, 0],
             measurement_strategy=MeasurementStrategy.probs(
                 computation_space=ComputationSpace.UNBUNCHED,
             ),
             dtype=torch.float64,
         ).eval()
 
+    def make_builder_equivalent_perceval_circuit(prefix: str) -> pcvl.Circuit:
+        def fixed_mzi(_index: int) -> pcvl.Circuit:
+            return pcvl.BS() // pcvl.PS(0.0) // pcvl.BS() // pcvl.PS(0.0)
+
+        circuit = pcvl.Circuit(n_modes)
+        circuit.add(
+            0,
+            pcvl.GenericInterferometer(
+                n_modes,
+                fixed_mzi,
+                shape=pcvl.InterferometerShape.RECTANGLE,
+            ),
+        )
+        for mode in range(n_modes):
+            circuit.add(mode, pcvl.PS(pcvl.P(f"{prefix}{mode + 1}")))
+        circuit.add(
+            0,
+            pcvl.GenericInterferometer(
+                n_modes,
+                fixed_mzi,
+                shape=pcvl.InterferometerShape.RECTANGLE,
+            ),
+        )
+        return circuit
+
     def run_perceval_probabilities(
         circuit: pcvl.Circuit, param_names: Sequence[str], inputs: torch.Tensor
     ) -> torch.Tensor:
         processor = Processor("SLOS")
         processor.set_circuit(circuit.copy())
-        processor.with_input(pcvl.BasicState([1, 0]))
+        processor.with_input(pcvl.BasicState([1, 0, 0]))
 
         sampler = merlin_processor_module.Sampler(
             processor,
@@ -1561,28 +1582,28 @@ def test_local_processor_two_quantum_layers_matches_direct_perceval_probabilitie
             )
 
         raw_results = sampler.probs.execute_sync()
-        output = torch.zeros((inputs.shape[0], 2), dtype=inputs.dtype)
-        state_to_index = {"|1,0>": 0, "|0,1>": 1}
+        output = torch.zeros((inputs.shape[0], n_modes), dtype=inputs.dtype)
+        state_to_index = {"|1,0,0>": 0, "|0,1,0>": 1, "|0,0,1>": 2}
         for row_index, result_item in enumerate(raw_results["results_list"]):
             for state, probability in result_item["results"].items():
                 output[row_index, state_to_index[str(state)]] = float(probability)
         return output
 
-    first_circuit = make_phase_circuit("a", final_theta=0.8)
-    second_circuit = make_phase_circuit("b", final_theta=1.3)
-    first_layer = make_phase_layer(first_circuit, "a")
-    second_layer = make_phase_layer(second_circuit, "b")
+    first_circuit = make_builder_equivalent_perceval_circuit("a")
+    second_circuit = make_builder_equivalent_perceval_circuit("b")
+    first_layer = make_builder_layer("a")
+    second_layer = make_builder_layer("b")
     model = torch.nn.Sequential(first_layer, second_layer).eval()
     input_tensor = torch.tensor(
-        [[0.1, 0.7], [1.2, 0.3], [2.4, 1.1]],
+        [[0.1, 0.7, 1.4], [1.2, 0.3, 0.6], [2.4, 1.1, 0.2]],
         dtype=torch.float64,
     )
 
     first_expected = run_perceval_probabilities(
-        first_circuit, ["a1", "a2"], input_tensor
+        first_circuit, ["a1", "a2", "a3"], input_tensor
     )
     expected = run_perceval_probabilities(
-        second_circuit, ["b1", "b2"], first_expected
+        second_circuit, ["b1", "b2", "b3"], first_expected
     )
 
     processor = MerlinProcessor(processor=Processor("SLOS"))

--- a/tests/core/test_merlin_processor_unit.py
+++ b/tests/core/test_merlin_processor_unit.py
@@ -2363,6 +2363,15 @@ def test_has_export_config():
     assert not isinstance(BadLayer(), SupportsExportConfig)
 
 
+def test_merlin_module_uid_is_instance_scoped():
+    first = MerlinModule()
+    second = MerlinModule()
+
+    assert first.uid != second.uid
+    assert "uid" in first.__dict__
+    assert "uid" in second.__dict__
+
+
 def test_offload_quantum_layer_with_chunking_validates_and_caches_export_config():
     proc = make_processor(["probs", "sample_count"])
 
@@ -2415,3 +2424,70 @@ def test_offload_quantum_layer_with_chunking_validates_and_caches_export_config(
         None,
     )
     assert layer.export_config_calls == 1
+
+
+def test_offload_quantum_layer_cache_isolated_by_merlin_module_instance_uid():
+    proc = make_processor(["probs", "sample_count"])
+
+    class LayerWithExportConfig(MerlinModule):
+        def __init__(self, label: str) -> None:
+            super().__init__()
+            self.label = label
+            self.export_config_calls = 0
+
+        def export_config(self):
+            self.export_config_calls += 1
+            return {
+                "circuit": pcvl.Circuit(m=2, name=f"Circuit {self.label}"),
+                "input_state": [1, 0],
+                "input_param_order": [f"theta_{self.label}"],
+            }
+
+    first = LayerWithExportConfig("first")
+    second = LayerWithExportConfig("second")
+    configs_used = []
+
+    def fake_run_chunks_pooled(
+        layer_arg, config, input_tensor, chunks, nsample, state, deadline
+    ):
+        configs_used.append((layer_arg.label, tuple(config.input_param_order)))
+        return torch.tensor([[1.0]])
+
+    proc._run_chunks_pooled = fake_run_chunks_pooled
+
+    proc._offload_quantum_layer_with_chunking(
+        first,
+        torch.zeros(1, 2),
+        None,
+        {},
+        None,
+    )
+    proc._offload_quantum_layer_with_chunking(
+        second,
+        torch.zeros(1, 2),
+        None,
+        {},
+        None,
+    )
+
+    assert first.uid != second.uid
+    assert first.export_config_calls == 1
+    assert second.export_config_calls == 1
+    assert len(proc._layer_cache) == 2
+    assert set(proc._layer_cache) == {first.uid, second.uid}
+    assert configs_used == [
+        ("first", ("theta_first",)),
+        ("second", ("theta_second",)),
+    ]
+
+    proc._offload_quantum_layer_with_chunking(
+        first,
+        torch.zeros(1, 2),
+        None,
+        {},
+        None,
+    )
+
+    assert first.export_config_calls == 1
+    assert second.export_config_calls == 1
+    assert configs_used[-1] == ("first", ("theta_first",))


### PR DESCRIPTION
## Summary

Fixes a remote/local processor cache collision caused by `MerlinModule.uid`
being defined as a class attribute shared by every instance.

`MerlinProcessor` uses `layer.uid` as the key for its validated layer-config
cache. Before this change, two distinct `QuantumLayer` instances inherited the
same class-level UUID, so the second layer could reuse the first layer's cached
`export_config()` result. That could silently execute a later quantum layer with
the wrong circuit, input state, or input parameter order.

This PR moves UID creation to `MerlinModule.__init__()` so every module instance
gets its own cache identity, then adds regression coverage for both the cache
key invariant and multi-layer local processor probability parity.

## Related Issue

Related Jira: PML-378

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / Cleanup
- [ ] Performance improvement
- [ ] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)

## Proposed changes

- Replace the shared class-level `MerlinModule.uid = uuid.uuid4()` value with an
  instance-level `self.uid = uuid.uuid4()` assigned during `MerlinModule`
  initialization.
- Add a unit test proving separate `MerlinModule` instances have distinct UIDs
  stored on the instance.
- Add a processor-cache regression test proving two distinct offloadable
  `MerlinModule` layers create separate `_layer_cache` entries and each layer's
  own `export_config()` is used.
- Add local `MerlinProcessor(processor=Processor("SLOS"))` probability parity
  coverage for a multi-`QuantumLayer` pipeline.
- Strengthen the parity test so the first and second quantum layers are
  structurally different:
  - layer 1: `entangling -> angle(a) -> entangling`;
  - layer 2: `entangling -> angle(b) -> entangling -> angle(c) -> entangling`.
- Mirror the builder-created layers with explicit pure Perceval reference
  circuits and compare exact probabilities.

## How to test / How to run

1. Run the focused UID/cache regression tests:

```bash
/home/benjamin/.virtualenvs/merlin/bin/python -m pytest \
  tests/core/test_merlin_processor_unit.py::test_merlin_module_uid_is_instance_scoped \
  tests/core/test_merlin_processor_unit.py::test_offload_quantum_layer_with_chunking_validates_and_caches_export_config \
  tests/core/test_merlin_processor_unit.py::test_offload_quantum_layer_cache_isolated_by_merlin_module_instance_uid
```

2. Run the multi-layer local processor parity test:

```bash
/home/benjamin/.virtualenvs/merlin/bin/python -m pytest \
  tests/core/test_merlin_processor_unit.py::test_local_processor_two_quantum_layers_matches_direct_perceval_probabilities
```

3. Run the touched processor unit file:

```bash
/home/benjamin/.virtualenvs/merlin/bin/python -m pytest tests/core/test_merlin_processor_unit.py
```

## Screenshots / Logs (optional)

Focused UID/cache regression tests: `3 passed`

Multi-layer local processor parity test: `1 passed`

Touched processor unit file:

```text
101 passed
```

## Performance considerations (optional)

No expected runtime impact in normal model execution. The production change is
one UUID allocation per `MerlinModule` instance during initialization.

The processor cache still preserves the intended behavior: repeated execution of
the same layer instance reuses the validated cached config, while different
layer instances no longer collide.

## Documentation

- [ ] User docs updated (Sphinx)
- [ ] Examples / notebooks updated
- [ ] Docstrings updated
- [ ] Updated the API

No user-facing API or documentation changes are required. This fixes an internal
identity/cache invariant and adds tests.

## Checklist

- [x] PR title includes Jira issue key (e.g., PML-126)
- [x] "Related Jira ticket" section includes the Jira issue key (no URL)
- [ ] Code formatted (ruff format)
- [ ] Lint passes (ruff)
- [ ] Static typing passes (mypy) if applicable
- [x] Unit tests added/updated (pytest)
- [x] Tests pass locally (pytest)
- [ ] Tests pass on GPU (pytest)
- [x] Test coverage not decreased significantly
- [ ] Docs build locally if affected (sphinx)
- [ ] With this command:

        > SPHINXOPTS="-W --keep-going -n" make -C docs clean html

    the docs are built without any warning or errors.
- [ ] New public classes/methods/packages are added in the API following the methodology presented in other files.
- [ ] Dependencies updated (if needed) and pinned appropriately
- [x] PR description explains what changed and how to validate it

Notes:

- Ruff, mypy, GPU tests, and docs were not run.
- Docs/API checklist items are not applicable because this PR does not add or
  change public APIs or docs.
