### PR TITLE
PML-379: Fix .cuda(), .cpu(), .float() for memristor

### DIFF
--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -1590,23 +1590,17 @@ class QuantumLayer(MerlinModule):
                 self.memristive_state[state] = fn(tensor)
 
         # infer canonical device/dtype AFTER move
-        ref_tensor = None
-        for p in self.parameters():
-            ref_tensor = p
-            break
+        old_device = self.device if self.device is not None else torch.device("cpu")
+        probe = torch.zeros((), device=old_device, dtype=torch.get_default_dtype())
+        moved = fn(probe)
 
-        if ref_tensor is None:
-            for b in self.buffers():
-                ref_tensor = b
-                break
+        if moved.device != old_device:  # a real device move was requested
+            self.device = moved.device  # ...otherwise leave it (stays None)
 
-        if ref_tensor is not None:
-            self.device = ref_tensor.device
-
-            if ref_tensor.dtype in (torch.float32, torch.float64):
-                _, self.dtype, self.complex_dtype = MerlinModule.setup_device_and_dtype(
-                    None, ref_tensor.dtype
-                )
+        if moved.dtype in (torch.float32, torch.float64):  # guards .half()/complex
+            _, self.dtype, self.complex_dtype = MerlinModule.setup_device_and_dtype(
+                None, moved.dtype
+            )
 
         self.computation_process.to(dtype=self.dtype, device=self.device)
 

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -1499,7 +1499,7 @@ class QuantumLayer(MerlinModule):
         # Fatal deprecation is handled by the sanitize_parameters decorator via registry.
         return None
 
-    # the to method refers to apply_ directly. They are intrinsically the same method.
+    # .to() routes through _apply (nn.Module.to calls self._apply), so this is the single move path.
     def _apply(self, fn, recurse=True):
         """Apply a transformation function to all tensors owned by the layer.
 
@@ -1520,7 +1520,7 @@ class QuantumLayer(MerlinModule):
             conversion. Typically generated internally by
             :meth:`torch.nn.Module._apply`.
         recurse:bool
-            Default is False. Whether or not to apply the function recursively.
+            Default is True. Whether or not to apply the function recursively.
 
         Returns
         -------
@@ -1532,7 +1532,7 @@ class QuantumLayer(MerlinModule):
         # infer canonical device/dtype
         old_device = self.device if self.device is not None else torch.device("cpu")
         old_dtype = self.dtype if self.dtype is not None else torch.get_default_dtype()
-        probe = torch.zeros((), device=old_device, dtype=torch.get_default_dtype())
+        probe = torch.zeros((), device=old_device, dtype=old_dtype)
         moved = fn(probe)
 
         if moved.device != old_device:  # a real device move was requested

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -1544,61 +1544,9 @@ class QuantumLayer(MerlinModule):
         if device is not None:
             self.device = torch.device(device)
 
-        if device is None and dtype is None:
-            return self
-
-        self.computation_process.to(dtype=self.dtype, device=self.device)
-
-        # Photon loss Module
-        if self._photon_loss_transform is not None:
-            if isinstance(self._photon_loss_transform, Sequence):
-                for i in range(len(self._photon_loss_transform)):
-                    self._photon_loss_transform[i] = self._photon_loss_transform[i].to(
-                        device=self.device,
-                        dtype=self.dtype,
-                    )
-            else:
-                self._photon_loss_transform = self._photon_loss_transform.to(
-                    device=self.device,
-                    dtype=self.dtype,
-                )
-
-        # Detector Module
-        if self._detector_transform is not None:
-            if isinstance(self._detector_transform, Sequence):
-                for i in range(len(self._detector_transform)):
-                    self._detector_transform[i] = self._detector_transform[i].to(
-                        device=self.device,
-                        dtype=self.dtype,
-                    )
-            else:
-                self._detector_transform = self._detector_transform.to(
-                    device=self.device,
-                    dtype=self.dtype,
-                )
-
-        if self._probability_readout is not None:
-            self._probability_readout = self._probability_readout.to(device=self.device)
-
-        target_kwargs: dict[str, Any] = {"dtype": self.dtype}
-        if self.device is not None:
-            target_kwargs["device"] = self.device
-
-        # memristor state and history
-        for state in range(len(self.memristive_history)):
-            for t in range(len(self.memristive_history[state])):
-                self.memristive_history[state][t] = self.memristive_history[state][
-                    t
-                ].to(**target_kwargs)
-
-        for state in range(len(self.memristive_state)):
-            self.memristive_state[state] = self.memristive_state[state].to(
-                **target_kwargs
-            )
-
         return self
 
-    def _apply(self, fn):
+    def _apply(self, fn, recurse=True):
         """Apply a transformation function to all tensors owned by the layer.
 
         This method extends :meth:`torch.nn.Module._apply` to ensure that
@@ -1607,7 +1555,7 @@ class QuantumLayer(MerlinModule):
         the rest of the module state. This guarantees that device and dtype
         conversions performed through methods such as :meth:`~torch.nn.Module.cuda`,
         :meth:`~torch.nn.Module.cpu`, :meth:`~torch.nn.Module.float`,
-        :meth:`~torch.nn.Module.double`, :meth:`~torch.nn.Module.half`, and
+        :meth:`~torch.nn.Module.double`, and
         :meth:`~torch.nn.Module.to` are consistently applied to all tensors
         associated with the layer.
 
@@ -1617,6 +1565,8 @@ class QuantumLayer(MerlinModule):
             Function applied by PyTorch to each tensor during device or dtype
             conversion. Typically generated internally by
             :meth:`torch.nn.Module._apply`.
+        recurse:bool
+            Default is False. Whether or not to apply the function recursively.
 
         Returns
         -------
@@ -1624,73 +1574,69 @@ class QuantumLayer(MerlinModule):
             The updated layer instance with all registered tensors and
             memristive state tensors transformed by ``fn``.
         """
-        super()._apply(fn)
-        try:
-            ref_tensor = next(self.parameters())
-        except StopIteration:
-            try:
-                ref_tensor = next(self.buffers())
-            except StopIteration:
-                return
 
-        self.device = ref_tensor.device
+        super()._apply(fn, recurse=recurse)
 
-        _, self.dtype, self.complex_dtype = MerlinModule.setup_device_and_dtype(
-            None,
-            ref_tensor.dtype,
-        )
-        #
-        # Keep auxiliary objects synchronized
-        #
-        self.computation_process.to(
-            device=self.device,
-            dtype=self.dtype,
-        )
-
-        # Photon loss module
-        if self._photon_loss_transform is not None:
-            if isinstance(self._photon_loss_transform, Sequence):
-                for i in range(len(self._photon_loss_transform)):
-                    self._photon_loss_transform[i] = self._photon_loss_transform[i].to(
-                        device=self.device,
-                        dtype=self.dtype,
-                    )
-            else:
-                self._photon_loss_transform = self._photon_loss_transform.to(
-                    device=self.device,
-                    dtype=self.dtype,
-                )
-
-        # Detector module
-        if self._detector_transform is not None:
-            if isinstance(self._detector_transform, Sequence):
-                for i in range(len(self._detector_transform)):
-                    self._detector_transform[i] = self._detector_transform[i].to(
-                        device=self.device,
-                        dtype=self.dtype,
-                    )
-            else:
-                self._detector_transform = self._detector_transform.to(
-                    device=self.device,
-                    dtype=self.dtype,
-                )
-
-        # Probability readout
-        if self._probability_readout is not None:
-            self._probability_readout = self._probability_readout.to(device=self.device)
-
-        # memristor history
+        # memristive tensors
         for state in range(len(self.memristive_history)):
             for t in range(len(self.memristive_history[state])):
                 tensor = self.memristive_history[state][t]
                 if torch.is_tensor(tensor):
                     self.memristive_history[state][t] = fn(tensor)
 
-        # memristor state
         for state in range(len(self.memristive_state)):
             tensor = self.memristive_state[state]
             if torch.is_tensor(tensor):
                 self.memristive_state[state] = fn(tensor)
+
+        # infer canonical device/dtype AFTER move
+        ref_tensor = None
+        for p in self.parameters():
+            ref_tensor = p
+            break
+
+        if ref_tensor is None:
+            for b in self.buffers():
+                ref_tensor = b
+                break
+
+        if ref_tensor is not None:
+            self.device = ref_tensor.device
+
+            if ref_tensor.dtype in (torch.float32, torch.float64):
+                _, self.dtype, self.complex_dtype = MerlinModule.setup_device_and_dtype(
+                    None, ref_tensor.dtype
+                )
+
+        self.computation_process.to(dtype=self.dtype, device=self.device)
+
+        # NOW move auxiliaries once
+        target_kwargs = {"dtype": self.dtype}
+        if self.device is not None:
+            target_kwargs["device"] = self.device
+
+        if self._photon_loss_transform is not None:
+            if isinstance(self._photon_loss_transform, Sequence):
+                for i in range(len(self._photon_loss_transform)):
+                    self._photon_loss_transform[i] = self._photon_loss_transform[i].to(
+                        **target_kwargs
+                    )
+            else:
+                self._photon_loss_transform = self._photon_loss_transform.to(
+                    **target_kwargs
+                )
+
+        if self._detector_transform is not None:
+            if isinstance(self._detector_transform, Sequence):
+                for i in range(len(self._detector_transform)):
+                    self._detector_transform[i] = self._detector_transform[i].to(
+                        **target_kwargs
+                    )
+            else:
+                self._detector_transform = self._detector_transform.to(**target_kwargs)
+
+        if self._probability_readout is not None:
+            self._probability_readout = self._probability_readout.to(device=self.device)
 
         return self
 

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -1499,53 +1499,7 @@ class QuantumLayer(MerlinModule):
         # Fatal deprecation is handled by the sanitize_parameters decorator via registry.
         return None
 
-    def to(self, *args: Any, **kwargs: Any) -> QuantumLayer:
-        """Move the layer and auxiliary transforms to a new device or dtype.
-
-        Parameters
-        ----------
-        *args
-            Positional arguments forwarded to :meth:`torch.nn.Module.to`.
-        **kwargs
-            Keyword arguments forwarded to :meth:`torch.nn.Module.to`.
-
-        Returns
-        -------
-        QuantumLayer
-            The updated layer instance.
-        """
-        super().to(*args, **kwargs)
-        # Manually move tensors that are not registered as parameters/buffers.
-        device = kwargs.get("device")
-        dtype = kwargs.get("dtype")
-
-        # Support all torch.nn.Module.to signatures.
-        if len(args) > 0:
-            first_arg = args[0]
-            if isinstance(first_arg, torch.dtype):
-                dtype = first_arg if dtype is None else dtype
-            elif isinstance(first_arg, (torch.device, str)):
-                device = first_arg if device is None else device
-            elif isinstance(first_arg, torch.Tensor):
-                if device is None:
-                    device = first_arg.device
-                if dtype is None and first_arg.dtype in (torch.float32, torch.float64):
-                    dtype = first_arg.dtype
-
-        if len(args) > 1 and isinstance(args[1], torch.dtype) and dtype is None:
-            dtype = args[1]
-
-        if dtype is not None:
-            _, self.dtype, self.complex_dtype = MerlinModule.setup_device_and_dtype(
-                None,
-                dtype,
-            )
-
-        if device is not None:
-            self.device = torch.device(device)
-
-        return self
-
+    # the to method refers to apply_ directly. They are intrinsically the same method.
     def _apply(self, fn, recurse=True):
         """Apply a transformation function to all tensors owned by the layer.
 
@@ -1575,6 +1529,20 @@ class QuantumLayer(MerlinModule):
             memristive state tensors transformed by ``fn``.
         """
 
+        # infer canonical device/dtype
+        old_device = self.device if self.device is not None else torch.device("cpu")
+        old_dtype = self.dtype if self.dtype is not None else torch.get_default_dtype()
+        probe = torch.zeros((), device=old_device, dtype=torch.get_default_dtype())
+        moved = fn(probe)
+
+        if moved.device != old_device:  # a real device move was requested
+            self.device = moved.device  # ...otherwise leave it (stays None)
+
+        if moved.dtype != old_dtype:  # a real dtype change was requested
+            _, self.dtype, self.complex_dtype = MerlinModule.setup_device_and_dtype(
+                None, moved.dtype
+            )
+
         super()._apply(fn, recurse=recurse)
 
         # memristive tensors
@@ -1589,23 +1557,9 @@ class QuantumLayer(MerlinModule):
             if torch.is_tensor(tensor):
                 self.memristive_state[state] = fn(tensor)
 
-        # infer canonical device/dtype AFTER move
-        old_device = self.device if self.device is not None else torch.device("cpu")
-        old_dtype = self.dtype if self.dtype is not None else torch.get_default_dtype()
-        probe = torch.zeros((), device=old_device, dtype=torch.get_default_dtype())
-        moved = fn(probe)
-
-        if moved.device != old_device:  # a real device move was requested
-            self.device = moved.device  # ...otherwise leave it (stays None)
-
-        if moved.dtype != old_dtype:  # a real dtype change was requested
-            _, self.dtype, self.complex_dtype = MerlinModule.setup_device_and_dtype(
-                None, moved.dtype
-            )
-
         self.computation_process.to(dtype=self.dtype, device=self.device)
 
-        # NOW move auxiliaries once
+        # Move auxiliaries once
         target_kwargs = {"dtype": self.dtype}
         if self.device is not None:
             target_kwargs["device"] = self.device

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -1591,13 +1591,14 @@ class QuantumLayer(MerlinModule):
 
         # infer canonical device/dtype AFTER move
         old_device = self.device if self.device is not None else torch.device("cpu")
+        old_dtype = self.dtype if self.dtype is not None else torch.get_default_dtype()
         probe = torch.zeros((), device=old_device, dtype=torch.get_default_dtype())
         moved = fn(probe)
 
         if moved.device != old_device:  # a real device move was requested
             self.device = moved.device  # ...otherwise leave it (stays None)
 
-        if moved.dtype in (torch.float32, torch.float64):  # guards .half()/complex
+        if moved.dtype != old_dtype:  # a real dtype change was requested
             _, self.dtype, self.complex_dtype = MerlinModule.setup_device_and_dtype(
                 None, moved.dtype
             )

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -1891,9 +1891,9 @@ class QuantumLayer(MerlinModule):
                 n_photons=self.n_photons,
                 keys=_normalize_sector_keys(self._raw_output_keys),
             )
-            distribution_to_use: SectoredDistribution = SectoredDistribution(
-                (sector_result,)
-            )
+            distribution_to_use: SectoredDistribution = SectoredDistribution((
+                sector_result,
+            ))
         else:
             distribution_to_use: SectoredDistribution = distribution
 
@@ -1947,9 +1947,9 @@ class QuantumLayer(MerlinModule):
                 n_photons=self.n_photons,
                 keys=_normalize_sector_keys(self._raw_output_keys),
             )
-            distribution_to_use: SectoredDistribution = SectoredDistribution(
-                (sector_result,)
-            )
+            distribution_to_use: SectoredDistribution = SectoredDistribution((
+                sector_result,
+            ))
         else:
             distribution_to_use: SectoredDistribution = distribution
 

--- a/merlin/algorithms/layer.py
+++ b/merlin/algorithms/layer.py
@@ -1598,6 +1598,102 @@ class QuantumLayer(MerlinModule):
 
         return self
 
+    def _apply(self, fn):
+        """Apply a transformation function to all tensors owned by the layer.
+
+        This method extends :meth:`torch.nn.Module._apply` to ensure that
+        memristive state tensors, which are stored in Python containers rather
+        than registered as parameters or buffers, are transformed together with
+        the rest of the module state. This guarantees that device and dtype
+        conversions performed through methods such as :meth:`~torch.nn.Module.cuda`,
+        :meth:`~torch.nn.Module.cpu`, :meth:`~torch.nn.Module.float`,
+        :meth:`~torch.nn.Module.double`, :meth:`~torch.nn.Module.half`, and
+        :meth:`~torch.nn.Module.to` are consistently applied to all tensors
+        associated with the layer.
+
+        Parameters
+        ----------
+        fn : callable
+            Function applied by PyTorch to each tensor during device or dtype
+            conversion. Typically generated internally by
+            :meth:`torch.nn.Module._apply`.
+
+        Returns
+        -------
+        QuantumLayer
+            The updated layer instance with all registered tensors and
+            memristive state tensors transformed by ``fn``.
+        """
+        super()._apply(fn)
+        try:
+            ref_tensor = next(self.parameters())
+        except StopIteration:
+            try:
+                ref_tensor = next(self.buffers())
+            except StopIteration:
+                return
+
+        self.device = ref_tensor.device
+
+        _, self.dtype, self.complex_dtype = MerlinModule.setup_device_and_dtype(
+            None,
+            ref_tensor.dtype,
+        )
+        #
+        # Keep auxiliary objects synchronized
+        #
+        self.computation_process.to(
+            device=self.device,
+            dtype=self.dtype,
+        )
+
+        # Photon loss module
+        if self._photon_loss_transform is not None:
+            if isinstance(self._photon_loss_transform, Sequence):
+                for i in range(len(self._photon_loss_transform)):
+                    self._photon_loss_transform[i] = self._photon_loss_transform[i].to(
+                        device=self.device,
+                        dtype=self.dtype,
+                    )
+            else:
+                self._photon_loss_transform = self._photon_loss_transform.to(
+                    device=self.device,
+                    dtype=self.dtype,
+                )
+
+        # Detector module
+        if self._detector_transform is not None:
+            if isinstance(self._detector_transform, Sequence):
+                for i in range(len(self._detector_transform)):
+                    self._detector_transform[i] = self._detector_transform[i].to(
+                        device=self.device,
+                        dtype=self.dtype,
+                    )
+            else:
+                self._detector_transform = self._detector_transform.to(
+                    device=self.device,
+                    dtype=self.dtype,
+                )
+
+        # Probability readout
+        if self._probability_readout is not None:
+            self._probability_readout = self._probability_readout.to(device=self.device)
+
+        # memristor history
+        for state in range(len(self.memristive_history)):
+            for t in range(len(self.memristive_history[state])):
+                tensor = self.memristive_history[state][t]
+                if torch.is_tensor(tensor):
+                    self.memristive_history[state][t] = fn(tensor)
+
+        # memristor state
+        for state in range(len(self.memristive_state)):
+            tensor = self.memristive_state[state]
+            if torch.is_tensor(tensor):
+                self.memristive_state[state] = fn(tensor)
+
+        return self
+
     @property
     def output_keys(self):
         """Return the Fock basis associated with the layer outputs.
@@ -1854,9 +1950,9 @@ class QuantumLayer(MerlinModule):
                 n_photons=self.n_photons,
                 keys=_normalize_sector_keys(self._raw_output_keys),
             )
-            distribution_to_use: SectoredDistribution = SectoredDistribution((
-                sector_result,
-            ))
+            distribution_to_use: SectoredDistribution = SectoredDistribution(
+                (sector_result,)
+            )
         else:
             distribution_to_use: SectoredDistribution = distribution
 
@@ -1910,9 +2006,9 @@ class QuantumLayer(MerlinModule):
                 n_photons=self.n_photons,
                 keys=_normalize_sector_keys(self._raw_output_keys),
             )
-            distribution_to_use: SectoredDistribution = SectoredDistribution((
-                sector_result,
-            ))
+            distribution_to_use: SectoredDistribution = SectoredDistribution(
+                (sector_result,)
+            )
         else:
             distribution_to_use: SectoredDistribution = distribution
 

--- a/merlin/models/reservoir_classifier.py
+++ b/merlin/models/reservoir_classifier.py
@@ -230,10 +230,10 @@ class ReservoirClassifier(MerlinModule):
         ----------
         *args : tuple[Any, ...]
             Positional arguments forwarded to :meth:`torch.nn.Module.to` and
-            :meth:`merlin.algorithms.layer.QuantumLayer.to`.
+            :meth:`merlin.algorithms.layer.QuantumLayer._apply`.
         **kwargs : dict[str, Any]
             Keyword arguments forwarded to :meth:`torch.nn.Module.to` and
-            :meth:`merlin.algorithms.layer.QuantumLayer.to`.
+            :meth:`merlin.algorithms.layer.QuantumLayer._apply`.
 
         Returns
         -------

--- a/merlin/models/reservoir_classifier.py
+++ b/merlin/models/reservoir_classifier.py
@@ -230,10 +230,10 @@ class ReservoirClassifier(MerlinModule):
         ----------
         *args : tuple[Any, ...]
             Positional arguments forwarded to :meth:`torch.nn.Module.to` and
-            :meth:`merlin.algorithms.layer.QuantumLayer._apply`.
+            the :class:`merlin.algorithms.layer.QuantumLayer`'s to method.
         **kwargs : dict[str, Any]
             Keyword arguments forwarded to :meth:`torch.nn.Module.to` and
-            :meth:`merlin.algorithms.layer.QuantumLayer._apply`.
+            the :class:`merlin.algorithms.layer.QuantumLayer`'s to method.
 
         Returns
         -------

--- a/tests/algorithms/test_layer.py
+++ b/tests/algorithms/test_layer.py
@@ -3548,12 +3548,6 @@ def test_cuda_lands_on_expected_state(layer):
     assert_layer_on(moved, device="cuda", real_dtype=torch.float32)
 
 
-def _example_input(layer):
-    # adapt to your fixture's expected input shape/dtype (see the existing
-    # memristive forward tests in this file for the right shape)
-    return torch.rand(1, layer.input_size, dtype=layer.dtype, device=layer.device)
-
-
 @pytest.mark.parametrize(
     "move",
     [

--- a/tests/algorithms/test_layer.py
+++ b/tests/algorithms/test_layer.py
@@ -26,6 +26,7 @@ Tests for the main QuantumLayer class.
 
 import math
 import re
+from collections.abc import Sequence
 from copy import deepcopy
 
 import numpy as np
@@ -3410,3 +3411,267 @@ def test_memristive_amplitude_input_batched_with_noise():
     output = ql(input)
 
     assert not torch.allclose(output[0], output[1])
+
+
+def _module_or_sequence_equal(expected, actual):
+    if expected is None:
+        assert actual is None
+        return True
+
+    if isinstance(expected, Sequence):
+        assert isinstance(actual, Sequence)
+        assert len(expected) == len(actual)
+
+        for e, a in zip(expected, actual):
+            _module_or_sequence_equal(e, a)
+
+        return True
+
+    assert type(expected) is type(actual)
+
+    for ep, ap in zip(
+        expected.parameters(),
+        actual.parameters(),
+    ):
+        assert ep.device == ap.device
+        assert ep.dtype == ap.dtype
+        assert torch.equal(ep, ap)
+
+    for eb, ab in zip(
+        expected.buffers(),
+        actual.buffers(),
+    ):
+        assert eb.device == ab.device
+        assert eb.dtype == ab.dtype
+        assert torch.equal(eb, ab)
+
+    return True
+
+
+def assert_computation_process_equal(expected, actual):
+    assert type(expected) is type(actual)
+
+    # These are the fields that should change when calling
+    # .to(), .cuda(), .float(), .double(), etc.
+    assert expected.device == actual.device
+    assert expected.dtype == actual.dtype
+
+    # Sanity-check a few structural fields that should not change.
+    assert expected.n_photons == actual.n_photons
+    assert expected.m == actual.m
+    assert expected.computation_space == actual.computation_space
+
+    assert expected.trainable_parameters == actual.trainable_parameters
+    assert expected.input_parameters == actual.input_parameters
+
+
+def assert_layers_equal(expected, actual):
+    #
+    # Layer bookkeeping
+    #
+    assert expected.device == actual.device
+    assert expected.dtype == actual.dtype
+    assert expected.complex_dtype == actual.complex_dtype
+
+    #
+    # Parameters
+    #
+    expected_params = dict(expected.named_parameters())
+    actual_params = dict(actual.named_parameters())
+
+    assert expected_params.keys() == actual_params.keys()
+
+    for name in expected_params:
+        ep = expected_params[name]
+        ap = actual_params[name]
+
+        assert ep.device == ap.device, name
+        assert ep.dtype == ap.dtype, name
+        assert torch.equal(ep, ap), name
+
+    #
+    # Buffers
+    #
+    expected_buffers = dict(expected.named_buffers())
+    actual_buffers = dict(actual.named_buffers())
+
+    assert expected_buffers.keys() == actual_buffers.keys()
+
+    for name in expected_buffers:
+        eb = expected_buffers[name]
+        ab = actual_buffers[name]
+
+        assert eb.device == ab.device, name
+        assert eb.dtype == ab.dtype, name
+        assert torch.equal(eb, ab), name
+
+    #
+    # Memristive state
+    #
+    assert len(expected.memristive_state) == len(actual.memristive_state)
+
+    for i, (es, as_) in enumerate(
+        zip(expected.memristive_state, actual.memristive_state)
+    ):
+        assert es.device == as_.device, i
+        assert es.dtype == as_.dtype, i
+        assert torch.equal(es, as_), i
+
+    #
+    # Memristive history
+    #
+    assert len(expected.memristive_history) == len(actual.memristive_history)
+
+    for i, (eh, ah) in enumerate(
+        zip(expected.memristive_history, actual.memristive_history)
+    ):
+        assert len(eh) == len(ah)
+
+        for j, (et, at) in enumerate(zip(eh, ah)):
+            assert et.device == at.device, (i, j)
+            assert et.dtype == at.dtype, (i, j)
+            assert torch.equal(et, at), (i, j)
+
+    #
+    # Probability readout
+    #
+    if expected._probability_readout is None:
+        assert actual._probability_readout is None
+    else:
+        assert type(expected._probability_readout) is type(actual._probability_readout)
+
+        for ep, ap in zip(
+            expected._probability_readout.parameters(),
+            actual._probability_readout.parameters(),
+        ):
+            assert ep.device == ap.device
+            assert ep.dtype == ap.dtype
+            assert torch.equal(ep, ap)
+
+    #
+    # Photon loss transform
+    #
+    assert _module_or_sequence_equal(
+        expected._photon_loss_transform,
+        actual._photon_loss_transform,
+    )
+
+    #
+    # Detector transform
+    #
+    assert _module_or_sequence_equal(
+        expected._detector_transform,
+        actual._detector_transform,
+    )
+
+    #
+    # Computation process
+    #
+    assert_computation_process_equal(
+        expected.computation_process,
+        actual.computation_process,
+    )
+
+
+@pytest.fixture
+def layer():
+    def update_rule(state: torch.Tensor, output: torch.Tensor):
+        x = state + output[:, 0]
+        return x
+
+    circ = ML.CircuitBuilder(n_modes=3)
+    circ.add_entangling_layer()
+    circ.add_memristive_ps(mode=0, update_rule=update_rule, initial_state=0)
+    circ.add_entangling_layer()
+
+    # Both source and phase
+    ql = ML.QuantumLayer(
+        builder=circ,
+        n_photons=1,
+        measurement_strategy=ML.MeasurementStrategy.probs(
+            computation_space=ML.ComputationSpace.FOCK
+        ),
+    )
+    return ql
+
+
+@pytest.mark.parametrize(
+    ("to_args", "apply_method"),
+    [
+        ({"device": "cpu"}, "cpu"),
+        ({"dtype": torch.float32}, "float"),
+        ({"dtype": torch.float64}, "double"),
+    ],
+)
+def test_apply_methods_match_to(layer, to_args, apply_method):
+    expected = deepcopy(layer).to(**to_args)
+    actual = getattr(deepcopy(layer), apply_method)()
+
+    assert_layers_equal(expected, actual)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA unavailable",
+)
+def test_cuda_matches_to(layer):
+    expected = deepcopy(layer).to("cuda")
+    actual = deepcopy(layer).cuda()
+
+    assert_layers_equal(expected, actual)
+
+
+@pytest.fixture
+def noisy_layer():
+    def update_rule(state: torch.Tensor, output: torch.Tensor):
+        x = state + output[:, 0]
+        return x
+
+    circ = ML.CircuitBuilder(n_modes=3)
+    circ.add_entangling_layer()
+    circ.add_memristive_ps(mode=0, update_rule=update_rule, initial_state=0)
+    circ.add_entangling_layer()
+
+    # Both source and phase
+    ql = ML.QuantumLayer(
+        builder=circ,
+        n_photons=1,
+        measurement_strategy=ML.MeasurementStrategy.probs(
+            computation_space=ML.ComputationSpace.FOCK
+        ),
+        noise=pcvl.NoiseModel(
+            brightness=0.9,
+            indistinguishability=0.7,
+            g2=0.1,
+            phase_error=0.01,
+            phase_imprecision=0.01,
+        ),
+        n_phase_error_samples=1,
+    )
+    return ql
+
+
+@pytest.mark.parametrize(
+    ("to_args", "apply_method"),
+    [
+        ({"device": "cpu"}, "cpu"),
+        ({"dtype": torch.float32}, "float"),
+        ({"dtype": torch.float64}, "double"),
+    ],
+)
+def test_apply_methods_match_to_noisy(noisy_layer, to_args, apply_method):
+    expected = deepcopy(noisy_layer).to(**to_args)
+    actual = getattr(deepcopy(noisy_layer), apply_method)()
+
+    assert_layers_equal(expected, actual)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA unavailable",
+)
+def test_cuda_matches_to_noisy(noisy_layer):
+    expected = deepcopy(noisy_layer).to("cuda")
+    actual = deepcopy(noisy_layer).cuda()
+
+    assert_layers_equal(expected, actual)

--- a/tests/algorithms/test_layer.py
+++ b/tests/algorithms/test_layer.py
@@ -3675,3 +3675,19 @@ def test_cuda_matches_to_noisy(noisy_layer):
     actual = deepcopy(noisy_layer).cuda()
 
     assert_layers_equal(expected, actual)
+
+
+def test_half_raises_value_error(layer):
+    """Merlin only supports float32/float64, so .half()/float16 must raise."""
+    with pytest.raises(ValueError):
+        deepcopy(layer).half()
+    with pytest.raises(ValueError):
+        deepcopy(layer).to(torch.float16)
+
+
+def test_dtype_only_move_leaves_device_unchanged(layer):
+    """A pure dtype move must not assign a concrete device."""
+    original_device = layer.device
+    moved = deepcopy(layer).double()
+    assert moved.device == original_device
+    assert moved.dtype == torch.float64

--- a/tests/algorithms/test_layer.py
+++ b/tests/algorithms/test_layer.py
@@ -3413,166 +3413,6 @@ def test_memristive_amplitude_input_batched_with_noise():
     assert not torch.allclose(output[0], output[1])
 
 
-def _module_or_sequence_equal(expected, actual):
-    if expected is None:
-        assert actual is None
-        return True
-
-    if isinstance(expected, Sequence):
-        assert isinstance(actual, Sequence)
-        assert len(expected) == len(actual)
-
-        for e, a in zip(expected, actual):
-            _module_or_sequence_equal(e, a)
-
-        return True
-
-    assert type(expected) is type(actual)
-
-    for ep, ap in zip(
-        expected.parameters(),
-        actual.parameters(),
-    ):
-        assert ep.device == ap.device
-        assert ep.dtype == ap.dtype
-        assert torch.equal(ep, ap)
-
-    for eb, ab in zip(
-        expected.buffers(),
-        actual.buffers(),
-    ):
-        assert eb.device == ab.device
-        assert eb.dtype == ab.dtype
-        assert torch.equal(eb, ab)
-
-    return True
-
-
-def assert_computation_process_equal(expected, actual):
-    assert type(expected) is type(actual)
-
-    # These are the fields that should change when calling
-    # .to(), .cuda(), .float(), .double(), etc.
-    assert expected.device == actual.device
-    assert expected.dtype == actual.dtype
-
-    # Sanity-check a few structural fields that should not change.
-    assert expected.n_photons == actual.n_photons
-    assert expected.m == actual.m
-    assert expected.computation_space == actual.computation_space
-
-    assert expected.trainable_parameters == actual.trainable_parameters
-    assert expected.input_parameters == actual.input_parameters
-
-
-def assert_layers_equal(expected, actual):
-    #
-    # Layer bookkeeping
-    #
-    assert expected.device == actual.device
-    assert expected.dtype == actual.dtype
-    assert expected.complex_dtype == actual.complex_dtype
-
-    #
-    # Parameters
-    #
-    expected_params = dict(expected.named_parameters())
-    actual_params = dict(actual.named_parameters())
-
-    assert expected_params.keys() == actual_params.keys()
-
-    for name in expected_params:
-        ep = expected_params[name]
-        ap = actual_params[name]
-
-        assert ep.device == ap.device, name
-        assert ep.dtype == ap.dtype, name
-        assert torch.equal(ep, ap), name
-
-    #
-    # Buffers
-    #
-    expected_buffers = dict(expected.named_buffers())
-    actual_buffers = dict(actual.named_buffers())
-
-    assert expected_buffers.keys() == actual_buffers.keys()
-
-    for name in expected_buffers:
-        eb = expected_buffers[name]
-        ab = actual_buffers[name]
-
-        assert eb.device == ab.device, name
-        assert eb.dtype == ab.dtype, name
-        assert torch.equal(eb, ab), name
-
-    #
-    # Memristive state
-    #
-    assert len(expected.memristive_state) == len(actual.memristive_state)
-
-    for i, (es, as_) in enumerate(
-        zip(expected.memristive_state, actual.memristive_state)
-    ):
-        assert es.device == as_.device, i
-        assert es.dtype == as_.dtype, i
-        assert torch.equal(es, as_), i
-
-    #
-    # Memristive history
-    #
-    assert len(expected.memristive_history) == len(actual.memristive_history)
-
-    for i, (eh, ah) in enumerate(
-        zip(expected.memristive_history, actual.memristive_history)
-    ):
-        assert len(eh) == len(ah)
-
-        for j, (et, at) in enumerate(zip(eh, ah)):
-            assert et.device == at.device, (i, j)
-            assert et.dtype == at.dtype, (i, j)
-            assert torch.equal(et, at), (i, j)
-
-    #
-    # Probability readout
-    #
-    if expected._probability_readout is None:
-        assert actual._probability_readout is None
-    else:
-        assert type(expected._probability_readout) is type(actual._probability_readout)
-
-        for ep, ap in zip(
-            expected._probability_readout.parameters(),
-            actual._probability_readout.parameters(),
-        ):
-            assert ep.device == ap.device
-            assert ep.dtype == ap.dtype
-            assert torch.equal(ep, ap)
-
-    #
-    # Photon loss transform
-    #
-    assert _module_or_sequence_equal(
-        expected._photon_loss_transform,
-        actual._photon_loss_transform,
-    )
-
-    #
-    # Detector transform
-    #
-    assert _module_or_sequence_equal(
-        expected._detector_transform,
-        actual._detector_transform,
-    )
-
-    #
-    # Computation process
-    #
-    assert_computation_process_equal(
-        expected.computation_process,
-        actual.computation_process,
-    )
-
-
 @pytest.fixture
 def layer():
     def update_rule(state: torch.Tensor, output: torch.Tensor):
@@ -3593,32 +3433,6 @@ def layer():
         ),
     )
     return ql
-
-
-@pytest.mark.parametrize(
-    ("to_args", "apply_method"),
-    [
-        ({"device": "cpu"}, "cpu"),
-        ({"dtype": torch.float32}, "float"),
-        ({"dtype": torch.float64}, "double"),
-    ],
-)
-def test_apply_methods_match_to(layer, to_args, apply_method):
-    expected = deepcopy(layer).to(**to_args)
-    actual = getattr(deepcopy(layer), apply_method)()
-
-    assert_layers_equal(expected, actual)
-
-
-@pytest.mark.skipif(
-    not torch.cuda.is_available(),
-    reason="CUDA unavailable",
-)
-def test_cuda_matches_to(layer):
-    expected = deepcopy(layer).to("cuda")
-    actual = deepcopy(layer).cuda()
-
-    assert_layers_equal(expected, actual)
 
 
 @pytest.fixture
@@ -3651,32 +3465,6 @@ def noisy_layer():
     return ql
 
 
-@pytest.mark.parametrize(
-    ("to_args", "apply_method"),
-    [
-        ({"device": "cpu"}, "cpu"),
-        ({"dtype": torch.float32}, "float"),
-        ({"dtype": torch.float64}, "double"),
-    ],
-)
-def test_apply_methods_match_to_noisy(noisy_layer, to_args, apply_method):
-    expected = deepcopy(noisy_layer).to(**to_args)
-    actual = getattr(deepcopy(noisy_layer), apply_method)()
-
-    assert_layers_equal(expected, actual)
-
-
-@pytest.mark.skipif(
-    not torch.cuda.is_available(),
-    reason="CUDA unavailable",
-)
-def test_cuda_matches_to_noisy(noisy_layer):
-    expected = deepcopy(noisy_layer).to("cuda")
-    actual = deepcopy(noisy_layer).cuda()
-
-    assert_layers_equal(expected, actual)
-
-
 def test_half_raises_value_error(layer):
     """Merlin only supports float32/float64, so .half()/float16 must raise."""
     with pytest.raises(ValueError):
@@ -3691,3 +3479,107 @@ def test_dtype_only_move_leaves_device_unchanged(layer):
     moved = deepcopy(layer).double()
     assert moved.device == original_device
     assert moved.dtype == torch.float64
+
+
+def _iter_layer_tensors(layer):
+    """Yield (name, tensor) for every tensor the layer owns — including the
+    memristive state/history stored in plain Python lists (not buffers)."""
+    yield from layer.named_parameters()
+    yield from layer.named_buffers()
+    for i, s in enumerate(layer.memristive_state):
+        if torch.is_tensor(s):
+            yield f"memristive_state[{i}]", s
+    for i, hist in enumerate(layer.memristive_history):
+        for j, t in enumerate(hist):
+            if torch.is_tensor(t):
+                yield f"memristive_history[{i}][{j}]", t
+
+
+def assert_layer_on(layer, *, device, real_dtype):
+    """Ground truth: assert the end state of a move directly, with no reference
+    to any other code path."""
+    dev = torch.device(device)
+    seen_memristive = False
+    for name, t in _iter_layer_tensors(layer):
+        assert t.device.type == dev.type, f"{name}: {t.device} != {dev}"
+        if t.is_floating_point():  # complex left to its own test
+            assert t.dtype == real_dtype, f"{name}: {t.dtype} != {real_dtype}"
+        if name.startswith("memristive"):
+            seen_memristive = True
+    # guard against a fixture that silently has no memristive tensors —
+    # otherwise this whole helper would vacuously pass
+    assert seen_memristive, "fixture has no memristive tensors to check"
+    # layer bookkeeping
+    assert layer.dtype == real_dtype
+    assert layer.computation_process.dtype == real_dtype
+    if layer.device is not None:  # None == 'default/cpu', allowed
+        assert layer.device.type == dev.type
+
+
+@pytest.mark.parametrize(
+    ("move", "exp_device", "exp_dtype"),
+    [
+        (lambda l: l.cpu(), "cpu", torch.float32),  # default real dtype
+        (lambda l: l.float(), "cpu", torch.float32),
+        (lambda l: l.double(), "cpu", torch.float64),
+    ],
+)
+def test_move_lands_on_expected_state(layer, move, exp_device, exp_dtype):
+    moved = move(deepcopy(layer))
+    assert_layer_on(moved, device=exp_device, real_dtype=exp_dtype)
+
+
+@pytest.mark.parametrize(
+    ("move", "exp_device", "exp_dtype"),
+    [
+        (lambda l: l.cpu(), "cpu", torch.float32),
+        (lambda l: l.float(), "cpu", torch.float32),
+        (lambda l: l.double(), "cpu", torch.float64),
+    ],
+)
+def test_move_lands_on_expected_state_noisy(noisy_layer, move, exp_device, exp_dtype):
+    moved = move(deepcopy(noisy_layer))
+    assert_layer_on(moved, device=exp_device, real_dtype=exp_dtype)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA unavailable")
+def test_cuda_lands_on_expected_state(layer):
+    moved = deepcopy(layer).cuda()
+    assert_layer_on(moved, device="cuda", real_dtype=torch.float32)
+
+
+def _example_input(layer):
+    # adapt to your fixture's expected input shape/dtype (see the existing
+    # memristive forward tests in this file for the right shape)
+    return torch.rand(1, layer.input_size, dtype=layer.dtype, device=layer.device)
+
+
+@pytest.mark.parametrize(
+    "move",
+    [
+        lambda l: l.float(),
+        lambda l: l.double(),
+        lambda l: l.cpu(),
+    ],
+)
+def test_forward_runs_after_move(layer, move):
+    moved = move(deepcopy(layer))
+    out = moved()  # must not raise device/dtype mismatch
+    assert out.device.type == (moved.device.type if moved.device is not None else "cpu")
+    if out.is_floating_point():
+        assert out.dtype == moved.dtype
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA unavailable")
+def test_forward_runs_after_cuda_roundtrip(layer):
+    moved = deepcopy(layer).cuda().cpu()  # round-trip exercises both directions
+    out = moved()
+    assert out.device.type == "cpu"
+
+
+def test_to_delegates_to_apply(layer):
+    """to() must remain a thin alias of _apply (no divergent override)."""
+    via_to = deepcopy(layer).to(dtype=torch.float64)
+    via_apply = deepcopy(layer).double()
+    assert_layer_on(via_to, device="cpu", real_dtype=torch.float64)
+    assert_layer_on(via_apply, device="cpu", real_dtype=torch.float64)


### PR DESCRIPTION
## Summary
Issue raised by Claude on review of release 0.4.0

Memristive state not moved by .cuda()/.cpu()/.float() (device/dtype split)
QuantumLayer overrides to() to move memristive_state/memristive_history, but nn.Module.cuda()/.cpu()/.float()/.double()/.half() route through _apply, not to(). Since the memristive tensors are plain Python lists (not registered buffers), those move paths leave them on the old device/dtype, and the next forward() mixes devices → runtime error or silent wrong-device compute.
Fix: override _apply (or register the state/history as buffers) so all torch move paths convert the memristive tensors.

## Related Issue
PML-379

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / Cleanup
- [ ] Performance improvement
- [ ] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)


## Proposed changes
- Added a _apply method, does the same thing as to by moving all auxiliary modules with to and the rest uses apply like it is supposed to do.

## How to test / How to run

```
pytest -q
```

## Documentation
- [ ] User docs updated (Sphinx)
- [ ] Examples / notebooks updated
- [ ] Docstrings updated
- [ ] Updated the API