### PR TITLE
PML-387 & PML-389: fixed user path in documentation

### DIFF
--- a/docs/build_multiversion.py
+++ b/docs/build_multiversion.py
@@ -345,7 +345,14 @@ def write_legacy_page_redirects(
     for docname in docnames:
         if docname == "index":
             continue
-        legacy_path = (output_path / docname).with_suffix(".html")
+        # Build the filename by string concatenation rather than
+        # ``Path.with_suffix()``. Many docnames contain dots, for example
+        # generated API reference pages like
+        # ``api_reference/api/merlin.algorithms.feed_forward``.
+        # ``with_suffix()`` replaces everything after the last dot in the
+        # final path component, which would both write the stub at the wrong
+        # path and collapse multiple docnames onto the same file.
+        legacy_path = output_path / f"{docname}.html"
         # Guard against a docname escaping the output directory, for example
         # via a leading "..".
         if output_path.resolve() not in legacy_path.resolve().parents:

--- a/docs/build_multiversion.py
+++ b/docs/build_multiversion.py
@@ -256,6 +256,33 @@ def build_metadata(
     return metadata
 
 
+def _redirect_page(target_url: str, link_text: str) -> str:
+    """Build a static HTML page that redirects to ``target_url``.
+
+        Parameters
+        ----------
+        target_url : str
+            Relative URL the browser should be redirected to.
+        link_text : str
+            Human-readable text for the fallback link.
+
+        Returns
+        -------
+        str
+            Complete HTML document contents for the redirect page.
+    """
+    return "\n".join(
+        [
+            "<!doctype html>",
+            '<meta charset="utf-8">',
+            f'<meta http-equiv="refresh" content="0; url={target_url}">',
+            f'<link rel="canonical" href="{target_url}">',
+            f'<a href="{target_url}">{link_text}</a>',
+            "",
+        ]
+    )
+
+
 def write_latest_redirect(output_path: Path, latest_version_name: str) -> None:
     """Write a root ``index.html`` redirect to the latest built version.
 
@@ -274,20 +301,68 @@ def write_latest_redirect(output_path: Path, latest_version_name: str) -> None:
     output_path.mkdir(parents=True, exist_ok=True)
     redirect_path = output_path / "index.html"
     redirect_path.write_text(
-        "\n".join(
-            [
-                "<!doctype html>",
-                '<meta charset="utf-8">',
-                '<meta http-equiv="refresh" '
-                f'content="0; url={latest_version_name}/index.html">',
-                f'<link rel="canonical" href="{latest_version_name}/index.html">',
-                f'<a href="{latest_version_name}/index.html">'
-                f"Open Merlin {latest_version_name} documentation</a>",
-                "",
-            ]
+        _redirect_page(
+            f"{latest_version_name}/index.html",
+            f"Open Merlin {latest_version_name} documentation",
         ),
         encoding="utf-8",
     )
+
+
+def write_legacy_page_redirects(
+    output_path: Path,
+    latest_version_name: str,
+    docnames: list[str],
+) -> None:
+    """Write root-level redirects for pre-versioning, unversioned page URLs.
+
+        Before multi-version documentation was introduced, pages were served
+        directly at the site root, for example
+        ``https://merlinquantum.ai/reproduced_papers/index.html``. Those pages
+        now live under a version prefix, for example
+        ``https://merlinquantum.ai/0.4/reproduced_papers/index.html``. This
+        writes a stub redirect page at each old unversioned location so that
+        existing external links and search engine results reach the
+        equivalent page in the latest built version instead of a 404.
+
+        Parameters
+        ----------
+        output_path : pathlib.Path
+            Root directory containing all versioned HTML builds.
+        latest_version_name : str
+            Public version name that unversioned URLs should redirect into.
+        docnames : list[str]
+            Document names (without suffix) present in the latest version,
+            relative to its Sphinx source directory.
+
+        Returns
+        -------
+        None
+            One redirect page per docname is written under ``output_path``,
+            skipping ``index`` which is already handled by
+            ``write_latest_redirect``.
+    """
+    for docname in docnames:
+        if docname == "index":
+            continue
+        legacy_path = (output_path / docname).with_suffix(".html")
+        # Guard against a docname escaping the output directory, for example
+        # via a leading "..".
+        if output_path.resolve() not in legacy_path.resolve().parents:
+            continue
+
+        depth = docname.count("/")
+        relative_prefix = "../" * depth
+        target_url = f"{relative_prefix}{latest_version_name}/{docname}.html"
+
+        legacy_path.parent.mkdir(parents=True, exist_ok=True)
+        legacy_path.write_text(
+            _redirect_page(
+                target_url,
+                f"This page moved to Merlin {latest_version_name} documentation",
+            ),
+            encoding="utf-8",
+        )
 
 
 def build_version(
@@ -504,6 +579,11 @@ def main() -> int:
             )
 
     write_latest_redirect(output_path, latest_version_name)
+    write_legacy_page_redirects(
+        output_path,
+        latest_version_name,
+        metadata[latest_version_name]["docnames"],
+    )
     print(f"Built versions: {', '.join(selected_versions)}")
     print(f"Open {output_path / 'index.html'}")
     return 0

--- a/docs/build_multiversion.py
+++ b/docs/build_multiversion.py
@@ -332,7 +332,10 @@ def build_version(
     """
     source_path = checkout_path / "docs" / "source"
     version_output_path = output_path / version_name
+    # Keep nbsphinx auxiliary images relative to the exported source tree.
+    doctree_path = checkout_path / "docs" / "build" / "doctrees" / version_name
     version_output_path.mkdir(parents=True, exist_ok=True)
+    doctree_path.mkdir(parents=True, exist_ok=True)
 
     env = os.environ.copy()
     env["MERLIN_DOCS_REPO_PATH"] = str(checkout_path)
@@ -348,6 +351,8 @@ def build_version(
         sphinx_build,
         "-b",
         "html",
+        "-d",
+        str(doctree_path),
         "-D",
         f"smv_metadata_path={metadata_path}",
         "-D",


### PR DESCRIPTION
<!--
Thank you for contributing to MerLin!
Please fill out the sections below to help us review your PR efficiently.

NOTE: this repo is a public repository, therefore, do NOT paste Jira URLs. Use the Jira issue key only (e.g., PML-126).
The Jira–GitHub integration will link PRs/commits automatically when the key is present.
-->

<!-- Add the Jira issue key in the title -->
<!-- e.g., PML-126 Updating PR template -->

## Summary
<!-- What does this PR do? A clear, concise description. -->
When building the doc on the server, it was using my path for the images in the notebook and there were errors displaying them.
Now, the multiversion builder now passes a per-version -d doctree directory inside the exported tag checkout. That keeps nbsphinx image artifacts relative to the source tree, so Sphinx copies them into _images instead of rendering /Users/.../.doctrees/nbsphinx/... paths.
I changed these lines, compiled and sent to the server and it is now fixed on merlinquantum.ai !

## Related Issue
   <!-- For internal contributors: Use Jira key (e.g., Related Jira: PML-126)
        For external contributors: Link to GitHub issue if applicable -->
PML-387

## Type of change
- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / Cleanup
- [ ] Performance improvement
- [ ] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)


## Proposed changes
<!-- Bulleted list of key changes. If API changes, list them explicitly. -->
The multiversion builder now passes a per-version -d doctree directory inside the exported tag checkout. That keeps nbsphinx image artifacts relative to the source tree, so Sphinx copies them into _images instead of rendering /Users/.../.doctrees/nbsphinx/... paths.

## How to test / How to run
<!-- Describe test plan and steps for reviewers to validate and run your changes locally. Include datasets if relevant. -->

Go on merlinquantum.ai

## Checklist
- [x] PR title includes Jira issue key (e.g., PML-126)
- [x] "Related Jira ticket" section includes the Jira issue key (no URL)
- [x] Code formatted (ruff format)
- [x] Lint passes (ruff)
- [x] Static typing passes (mypy) if applicable
- [x] Unit tests added/updated (pytest)
- [x] Tests pass locally (pytest)
- [x] Tests pass on GPU (pytest)
- [x] Test coverage not decreased significantly
- [x] Docs build locally if affected (sphinx)
- [x] With this command: `SPHINXOPTS="-W --keep-going -n" make -C docs clean html `the docs are built without any warning or errors.
- [x] New public classes/methods/packages are added in the API following the methodology presented in other files.
- [x] Dependencies updated (if needed) and pinned appropriately
- [x] PR description explains what changed and how to validate it


<!-- Helpful local commands – run from repo root:

# Lint & format
ruff format && ruff check .

# Type check (if used)
mypy .

# Tests with coverage
pytest

# Build docs
pip install -r requirements-docs.txt && make -C docs html

-->
