### PR TITLE
PML-380: Unitary device fix for g2

### DIFF
--- a/merlin/pcvl_pytorch/noisy_slos.py
+++ b/merlin/pcvl_pytorch/noisy_slos.py
@@ -211,6 +211,8 @@ class NoisyG2SLOSComputeGraph:
             keys_regular, probs_regular = single_graph.compute_probs(
                 unitary, input_state
             )
+            # Ensure probabilities are on the same device as the unitary
+            probs_regular = probs_regular.to(unitary.device)
             # Generate one-hot states for each active mode and compute their probs
             one_hot_slos_graphs = {}
             for mode_idx in range(len(input_state)):
@@ -220,11 +222,20 @@ class NoisyG2SLOSComputeGraph:
                     keys_one_hot, probs_one_hot = single_graph._slos_graphs[
                         0
                     ].compute_probs(unitary, one_hot_state)
+                    # Ensure probabilities are on the same device as the unitary
+                    probs_one_hot = probs_one_hot.to(unitary.device)
                     one_hot_slos_graphs[mode_idx] = (keys_one_hot, probs_one_hot)
         else:
             # Cast for mypy: _slos_graphs is list when g2_distinguishable is False
             slos_graphs_list = cast(list[NoisySLOSComputeGraph], self._slos_graphs)
             probs_regular = slos_graphs_list[0].compute_probs(unitary, input_state)
+            # Ensure probabilities are on the same device as the unitary
+            if isinstance(probs_regular, tuple):
+                keys_regular, probs_regular = probs_regular
+                probs_regular = probs_regular.to(unitary.device)
+                probs_regular = (keys_regular, probs_regular)
+            else:
+                probs_regular = probs_regular.to(unitary.device)
 
         # Group possible extra emissions by sector. Entry k contains every
         # source-mode combination that produces n_photons + k output photons.
@@ -769,7 +780,7 @@ class _InputStateNoisySLOSComputeGraph:
         )
 
         for i, partition in enumerate(self._partitions):
-            bit_weight = self._weights[i]
+            bit_weight = self._weights[i].to(unitary.device)
 
             for cell, count in zip(partition[0], partition[1], strict=True):
                 cell_distributions = [
@@ -782,7 +793,9 @@ class _InputStateNoisySLOSComputeGraph:
                     fock_states,
                     *cell_distributions,
                 )
-                output_probs += bit_weight * convolution * count.item()
+                output_probs += (
+                    bit_weight * convolution.to(unitary.device) * count.item()
+                )
 
         # OBB partition weights do not generally sum to one. This normalization
         # assumes output_probs spans the full Fock basis for self.n_photons; it

--- a/merlin/pcvl_pytorch/noisy_slos.py
+++ b/merlin/pcvl_pytorch/noisy_slos.py
@@ -235,7 +235,7 @@ class NoisyG2SLOSComputeGraph:
         # probability p.  The two are related by g^(2)(0) = 2p/(1+p)^2, so:
         #   p = ((1 - g2) - sqrt(1 - 2*g2)) / g2,  valid for g2 in [0, 0.5].
         # For small g2, p ≈ g2/2 (L'Hôpital).  At g2=0 the limit is p=0.
-        _g2 = torch.as_tensor(self.g2, device=self.device, dtype=self.dtype)
+        _g2 = torch.as_tensor(self.g2, device=unitary.device, dtype=self.dtype)
         _disc = (1.0 - 2.0 * _g2).clamp(min=0.0)
         p_emit = ((1.0 - _g2) - _disc.sqrt()) / _g2.clamp(min=1e-15)
         for num_photons_added in range(len(extra_photons_combinations)):
@@ -251,7 +251,7 @@ class NoisyG2SLOSComputeGraph:
                         scheme="fock", n=self.n_photons + num_photons_added, m=self.m
                     ).compute_space_size(),
                     dtype=self.dtype,
-                    device=self.device,
+                    device=unitary.device,
                 ),
                 n_modes=self.m,
                 n_photons=self.n_photons + num_photons_added,

--- a/merlin/pcvl_pytorch/noisy_slos.py
+++ b/merlin/pcvl_pytorch/noisy_slos.py
@@ -200,6 +200,7 @@ class NoisyG2SLOSComputeGraph:
     ) -> SectoredDistribution:
 
         sector_outputs = []
+        probs_regular: torch.Tensor
 
         if unitary.size(0) == unitary.size(1) and unitary.ndim == 2:
             unitary = unitary.unsqueeze(0)
@@ -228,14 +229,13 @@ class NoisyG2SLOSComputeGraph:
         else:
             # Cast for mypy: _slos_graphs is list when g2_distinguishable is False
             slos_graphs_list = cast(list[NoisySLOSComputeGraph], self._slos_graphs)
-            probs_regular = slos_graphs_list[0].compute_probs(unitary, input_state)
+            slos_output = slos_graphs_list[0].compute_probs(unitary, input_state)
             # Ensure probabilities are on the same device as the unitary
-            if isinstance(probs_regular, tuple):
-                keys_regular, probs_regular = probs_regular
+            if isinstance(slos_output, tuple):
+                keys_regular, probs_regular = slos_output
                 probs_regular = probs_regular.to(unitary.device)
-                probs_regular = (keys_regular, probs_regular)
             else:
-                probs_regular = probs_regular.to(unitary.device)
+                probs_regular = slos_output.to(unitary.device)
 
         # Group possible extra emissions by sector. Entry k contains every
         # source-mode combination that produces n_photons + k output photons.

--- a/tests/pcvl_pytorch/test_noisy_slos.py
+++ b/tests/pcvl_pytorch/test_noisy_slos.py
@@ -372,7 +372,7 @@ def test_noisy_g2_slos_unitary_cuda_graph_cpu():
     )
 
     unitary = torch.tensor(
-        np.array(pcvl.Matrix.random_unitary(m=5), dtype=np.complex128),
+        np.array(pcvl.Matrix.random_unitary(n=5), dtype=np.complex64),
         device=torch.device("cuda"),
     )
 

--- a/tests/pcvl_pytorch/test_noisy_slos.py
+++ b/tests/pcvl_pytorch/test_noisy_slos.py
@@ -7,6 +7,7 @@ from merlin import Combinadics, ComputationSpace
 from merlin.algorithms.layer_utils import NoiseGroups, classify_noise
 from merlin.pcvl_pytorch.locirc_to_tensor import CircuitConverter
 from merlin.pcvl_pytorch.noisy_slos import (
+    NoisyG2SLOSComputeGraph,
     NoisySLOSComputeGraph,
     _InputStateNoisySLOSComputeGraph,
 )
@@ -360,3 +361,20 @@ def test_computation_space_and_indistinguishability_default_value(
         groups, m=5, n_photons=3, computation_space=ComputationSpace.FOCK
     )
     assert noisy_slos.indistinguishability == 1.0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_noisy_g2_slos_unitary_cuda_graph_cpu():
+    noise = pcvl.NoiseModel(indistinguishability=0.2, g2=0.7)
+    groups = classify_noise(noise)
+    noisy_slos = NoisyG2SLOSComputeGraph(
+        groups, m=5, n_photons=3, computation_space=ComputationSpace.FOCK, device=None
+    )
+
+    unitary = torch.tensor(
+        np.array(pcvl.Matrix.random_unitary(m=5), dtype=np.complex128),
+        device=torch.device("cuda"),
+    )
+
+    probs = noisy_slos.compute_probs(unitary=unitary, input_state=[1, 0, 1, 0, 1])
+    assert probs.sectors[0].tensor.device == unitary.device

--- a/tests/pcvl_pytorch/test_noisy_slos.py
+++ b/tests/pcvl_pytorch/test_noisy_slos.py
@@ -365,7 +365,7 @@ def test_computation_space_and_indistinguishability_default_value(
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_noisy_g2_slos_unitary_cuda_graph_cpu():
-    noise = pcvl.NoiseModel(indistinguishability=0.2, g2=0.7)
+    noise = pcvl.NoiseModel(indistinguishability=0.2, g2=0.2)
     groups = classify_noise(noise)
     noisy_slos = NoisyG2SLOSComputeGraph(
         groups, m=5, n_photons=3, computation_space=ComputationSpace.FOCK, device=None
@@ -377,4 +377,4 @@ def test_noisy_g2_slos_unitary_cuda_graph_cpu():
     )
 
     probs = noisy_slos.compute_probs(unitary=unitary, input_state=[1, 0, 1, 0, 1])
-    assert probs.sectors[0].tensor.device == unitary.device
+    assert all(s.tensor.device == unitary.device for s in probs.sectors)


### PR DESCRIPTION
## Summary
Fixed this issue:

Noisy g2 path allocates on self.device/self.dtype, not unitary.device — merlin/pcvl_pytorch/noisy_slos.py:238-258,316. p_emit/weight_k and each SectorResult.tensor are built on self.device, while the sub-graph probs live on unitary.device. A CUDA unitary on a graph constructed with default device=None (without a prior .to()) raises a cross-device error. The non-g2 path correctly derives device from unitary.device (:768) — mirror that here.

## Related Issue
PML-380

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / Cleanup
- [ ] Performance improvement
- [ ] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)


## Proposed changes
- Initialized the g2 and sectors results with the unitary's device instead of the SLOS'.

## How to test / How to run
```
pytest -q
```

## Documentation
- [ ] User docs updated (Sphinx)
- [ ] Examples / notebooks updated
- [ ] Docstrings updated
- [ ] Updated the API