### PR TITLE
PML-384 amps bug

### DIFF
--- a/merlin/models/qcnn.py
+++ b/merlin/models/qcnn.py
@@ -13,6 +13,7 @@ from ..algorithms import QuantumLayer
 from ..core import ComputationSpace, StateVector
 from ..core.partial_measurement import PartialMeasurement
 from ..measurement import MeasurementStrategy
+from ..utils.dtypes import complex_dtype_for
 
 
 class QCNNClassifier(torch.nn.Module):
@@ -897,6 +898,26 @@ class QCNNClassifier(torch.nn.Module):
 
         return torch.tensor(basis_indices, dtype=torch.long)
 
+    def _model_complex_dtype(self) -> torch.dtype:
+        """Return the complex dtype matching the model's floating-point dtype.
+
+        The quantum layers hold the authoritative ``complex_dtype`` (kept in
+        sync with device/dtype conversions such as
+        :meth:`~torch.nn.Module.to` and :meth:`~torch.nn.Module.double`), so
+        the first quantum layer's value is used. If no quantum layer exists,
+        the dtype is derived from the model parameters instead.
+
+        Returns
+        -------
+        torch.dtype
+            ``torch.complex64`` for a float32 model, ``torch.complex128``
+            for a float64 model.
+        """
+        for layer in self.layers:
+            if isinstance(layer, QuantumLayer):
+                return layer.complex_dtype
+        return complex_dtype_for(next(self.parameters()).dtype)
+
     def amplitude_encode(self, x: torch.Tensor):
         """Encode image pixels as amplitudes of a two-photon state vector.
 
@@ -904,6 +925,11 @@ class QCNNClassifier(torch.nn.Module):
         ``i`` of the first register and one photon in mode
         ``input_shape[0] + j`` of the second register. The resulting state vector
         is normalized before being passed to the quantum layers.
+
+        The encoding follows the model's precision: amplitudes are created
+        with the complex dtype matching the model dtype (``complex64`` for a
+        float32 model, ``complex128`` for a float64 model), regardless of the
+        input tensor's dtype.
 
         Parameters
         ----------
@@ -924,10 +950,11 @@ class QCNNClassifier(torch.nn.Module):
         )
         basis_size = state_vector.basis_size
 
+        complex_dtype = self._model_complex_dtype()
         state_tensor = torch.zeros(
-            (batch_size, basis_size), dtype=torch.complex64, device=x.device
+            (batch_size, basis_size), dtype=complex_dtype, device=x.device
         )
-        pixel_amplitudes = x[:, 0, :, :].reshape(batch_size, -1).to(torch.complex64)
+        pixel_amplitudes = x[:, 0, :, :].reshape(batch_size, -1).to(complex_dtype)
         basis_indices = self._amplitude_basis_indices.to(x.device)
         expanded_indices = basis_indices.unsqueeze(0).expand(batch_size, -1)
         state_tensor = state_tensor.scatter(1, expanded_indices, pixel_amplitudes)

--- a/tests/models/test_qcnn.py
+++ b/tests/models/test_qcnn.py
@@ -102,7 +102,7 @@ def test_qcnn_basic_api():
     )
     with pytest.raises(AttributeError):
         qcnn_classifier_from_list.input_shape = (2, 2)
-    
+
     qcnn_classifier_above_former_limit = QCNNClassifier(
         input_shape_above_former_limit,
         accepted_num_classes,
@@ -791,3 +791,59 @@ def test_qcnn_state_dict_round_trip_with_export_config():
 
     assert torch.allclose(restored_logits, expected_logits, atol=1e-6, rtol=1e-6)
 
+
+def test_amplitude_encode_follows_model_dtype_after_to_float64():
+    """to(float64) yields complex128 encoding and float64 logits end to end."""
+    model = QCNNClassifier((4, 4), 10).to(torch.float64)
+    x = torch.rand(2, 1, 4, 4, dtype=torch.float64)
+
+    encoded = model.amplitude_encode(x)
+    assert encoded.tensor.dtype == torch.complex128
+
+    logits = model(x)
+    assert logits.dtype == torch.float64
+
+
+def test_amplitude_encode_default_model_uses_complex64():
+    """A default (float32) model keeps the historical complex64 encoding."""
+    model = QCNNClassifier((4, 4), 10)
+    x = torch.rand(2, 1, 4, 4)
+
+    assert model.amplitude_encode(x).tensor.dtype == torch.complex64
+
+
+def test_amplitude_encode_input_dtype_follows_model_not_input():
+    """A float64 input on a float32 model encodes at the model's precision."""
+    model = QCNNClassifier((4, 4), 10)
+    x = torch.rand(2, 1, 4, 4, dtype=torch.float64)
+
+    assert model.amplitude_encode(x).tensor.dtype == torch.complex64
+
+
+def test_amplitude_encode_float64_preserves_double_precision():
+    """Encoded amplitudes match an exact complex128 reference (no truncation)."""
+    model = QCNNClassifier((4, 4), 10).to(torch.float64)
+    x = torch.rand(2, 1, 4, 4, dtype=torch.float64)
+    batch_size = x.shape[0]
+
+    encoded = model.amplitude_encode(x).tensor
+
+    pixels = x[:, 0].reshape(batch_size, -1).to(torch.complex128)
+    indices = model._amplitude_basis_indices.unsqueeze(0).expand(batch_size, -1)
+    reference = torch.zeros_like(encoded).scatter(1, indices, pixels)
+    reference = reference / reference.abs().pow(2).sum(dim=1, keepdim=True).sqrt()
+
+    torch.testing.assert_close(encoded, reference, rtol=0.0, atol=1e-14)
+
+    # The truncated complex64 encoding would deviate by ~1e-8; double precision
+    # must beat that by orders of magnitude.
+    truncated = reference.to(torch.complex64).to(torch.complex128)
+    assert not torch.allclose(encoded, truncated, rtol=0.0, atol=1e-12)
+
+
+def test_to_unsupported_dtype_raises_clear_error():
+    """Half precision is rejected loudly instead of degrading silently."""
+    model = QCNNClassifier((4, 4), 10)
+
+    with pytest.raises(ValueError, match="torch.float32 or torch.float64"):
+        model.to(torch.float16)


### PR DESCRIPTION
## Summary

`QCNNClassifier.amplitude_encode` hardcoded `torch.complex64`. After `model.to(torch.float64)` the quantum layers correctly switch to `complex128`, but the encoder kept truncating every input to single precision at the pipeline entry. The layers then silently upcast the state, so the model returned float64 logits computed from float32-quality amplitudes: no error, no warning, and a double-precision QCNN produced the same numbers as a float32 one (measured ~1e-8 truncation on encoded amplitudes, ~7e-8 agreement between a float64 and a float32 model on identical data).

The fix derives the encoding dtype from the model, so `model.to(torch.float64)` now gives double precision end to end. The contract, pinned by regression tests: a module computes in its parameter dtype; the encoding follows the model dtype regardless of the input tensor's dtype; unsupported dtypes such as float16 raise `ValueError`.

This mainly affects anyone using `.double()` for numerical validation — `torch.autograd.gradcheck` requires float64 and perturbs at ~1e-6, so the ~1e-8 encoding noise could produce marginal or flaky Jacobian mismatches with no visible cause.

## Related Issue

Related Jira: PML-384

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / Cleanup
- [ ] Performance improvement
- [ ] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)

## Proposed changes

**Fix** (`9483f9a8`)
- New `QCNNClassifier._model_complex_dtype()` helper: returns the first quantum layer's `complex_dtype` (kept in sync with `.to()`/`.double()`/`.float()` conversions by `QuantumLayer._apply`), falling back to the parameter dtype through the existing `merlin.utils.dtypes.complex_dtype_for` utility.
- `amplitude_encode` uses it for both the state tensor and the pixel amplitudes instead of hardcoded `complex64`; docstring states the dtype contract.
- No behavior change for default float32 models: they keep producing `complex64` encodings, byte for byte.

**Regression tests** (`ad077e94`), five new tests in `tests/models/test_qcnn.py`:
- `.to(float64)` produces a `complex128` encoded state and float64 logits end to end.
- A default float32 model keeps the historical `complex64` encoding.
- The encoding follows the model dtype, not the input dtype: a float64 input on a float32 model still encodes as `complex64`.
- Float64 encoding matches an exact `complex128` reference to 1e-14 and measurably differs from the old `complex64` truncation — this test fails on the pre-fix code.
- `.to(torch.float16)` raises the existing `ValueError` instead of degrading silently.

**API changes**: none. `_model_complex_dtype` is private; `amplitude_encode`'s signature is unchanged.

## Out of scope — related gaps found during the investigation

Both are candidates for follow-up tickets; neither causes silent wrong numbers once this fix lands.

1. **`QuantumLayer` ignores `torch.set_default_dtype()` at construction.** `MerlinModule.setup_device_and_dtype` falls back to a hardcoded `torch.float32` when no `dtype=` is passed (merlin/algorithms/module.py:102), so `set_default_dtype(float64)` before construction still yields float32 quantum layers. Core torch modules honor the global default. Fixing it is one line but changes the construction default of every layer in the library — anyone setting a global double default while relying on quantum layers staying float32 would see simulation cost roughly double, so it needs its own ticket and a release-notes entry. After this PR the behavior is at least coherent: the whole pipeline stays float32 and `layer.dtype` reports it honestly.

2. **`QCNNClassifier` has no `dtype`/`device` constructor arguments.** Raw `QuantumLayer` accepts `dtype=` at construction; the classifier does not, so the only precision route is construct-then-`.to()`, which builds at float32 and converts afterwards. 

## How to test / How to run

1. Regression suite (the precision test fails on the pre-fix code):

```
pytest tests/models/test_qcnn.py -q
```

Expected: 17 passed, 1 skipped. Full `tests/models`: 101 passed, 8 skipped.

2. Manual check of the fixed behavior:

```python
import torch
from merlin.models import QCNNClassifier

model = QCNNClassifier((4, 4), 10).to(torch.float64)
x = torch.rand(2, 1, 4, 4, dtype=torch.float64)
print(model.amplitude_encode(x).tensor.dtype)   # complex128 (was complex64)
print(model(x).dtype)                           # float64
```

## Screenshots / Logs (optional)

Pre-fix measurement on identical data and seeds: encoded amplitudes truncated by ~2.4e-8 (complex64 round-trip), float64-model logits within ~6.8e-8 of a float32 model. Post-fix: encoding matches an exact complex128 reference to 1e-14.

## Performance considerations (optional)

None for existing float32 usage (unchanged path). Float64 models now genuinely compute in double precision downstream of the encoder, with the usual ~2x memory/compute cost of complex128 simulation — which is what `.to(torch.float64)` was asking for.

## Documentation
- [ ] User docs updated (Sphinx)
- [ ] Examples / notebooks updated
- [x] Docstrings updated — *`amplitude_encode` now states the dtype contract; new helper fully documented*
- [ ] Updated the API — *n/a: no public API change*

## Checklist
- [ ] PR title includes Jira issue key (e.g., PML-126)
- [x] "Related Jira ticket" section includes the Jira issue key (no URL)
- [x] Code formatted (ruff format)
- [x] Lint passes (ruff)
- [ ] Static typing passes (mypy) if applicable — *not configured for this repo; not run*
- [x] Unit tests added/updated (pytest) — *5 regression tests*
- [x] Tests pass locally (pytest) — *tests/models: 101 passed, 8 skipped*
- [ ] Tests pass on GPU (pytest) — *not run; the change is dtype selection only, no device-specific paths*
- [x] Test coverage not decreased significantly — *increased: the encoding dtype contract had no coverage*
- [x] Docs build locally if affected (sphinx)
- [x] With this command:

        > SPHINXOPTS="-W --keep-going -n" make -C docs clean html

    the docs are built without any warning or errors.
- [x] New public classes/methods/packages are added in the API following the methodology presented in other files — *n/a: no new public API*
- [x] Dependencies updated (if needed) and pinned appropriately — *no dependency changes*
- [x] PR description explains what changed and how to validate it

