### PR TITLE
PML-385: generator seed for Latent space of theQGAN

### DIFF
--- a/docs/source/reproduced_papers/reproductions/photonic_QGAN.rst
+++ b/docs/source/reproduced_papers/reproductions/photonic_QGAN.rst
@@ -56,6 +56,11 @@ The adversarial loop in ``lib/qgan.py`` is fully differentiable:
 * BCE-with-logits loss is used for both adversaries,
 * optional label smoothing and configurable ``d_steps`` / ``g_steps`` are supported.
 
+For reproducible generated batches, the MerLin ``PhotonicGenerator`` accepts a
+dedicated ``torch.Generator`` through ``sample_latent`` and ``generate``. This
+controls normal latent sampling without advancing PyTorch's global random
+number generator; use a generator compatible with the latent sampling device.
+
 At this stage:
 
 * ``smoke`` mode is a lightweight wiring check,

--- a/docs/source/user_guide/models/qgan.rst
+++ b/docs/source/user_guide/models/qgan.rst
@@ -78,6 +78,24 @@ MerLin implementation
 ----------------------
 The ready-to-use MerLin model creats the generator. It is defined as the :class:`~merlin.models.photonic_generator.PhotonicGenerator` object. This model takes noise as input and generates new features that are close to the data distribution as an output.
 
+By default, ``sample_latent`` and ``generate`` draw normal latent vectors from
+PyTorch's global random-number generator. For reproducible batches, pass a
+dedicated ``torch.Generator``. The same generator can be supplied to
+``generate`` during evaluation or to ``sample_latent`` when the latent batch is
+also needed:
+
+.. code-block:: python
+
+   sampling_generator = torch.Generator().manual_seed(1234)
+   fake_images = generator.generate(
+       batch_size=32,
+       generator=sampling_generator,
+   )
+
+Using a dedicated generator keeps latent sampling reproducible without
+advancing PyTorch's global random-number generator. The generator must be
+compatible with the device used for sampling.
+
 There is also a helper classes to help transform the output.
 
 * ``ImageAdapter``: Adapt tensor measurements to GAN-native image tensors.

--- a/merlin/models/photonic_generator.py
+++ b/merlin/models/photonic_generator.py
@@ -87,6 +87,7 @@ class LatentDistribution(ABC):
         *,
         device: torch.device | None = None,
         dtype: torch.dtype | None = None,
+        generator: torch.Generator | None = None,
     ) -> torch.Tensor:
         """Sample a latent batch.
 
@@ -100,6 +101,8 @@ class LatentDistribution(ABC):
         dtype : torch.dtype | None
             Floating dtype of the returned tensor. If omitted, the concrete
             distribution chooses its default.
+        generator : torch.Generator | None
+            Generator used for random sampling. Default is ``None``.
 
         Returns
         -------
@@ -146,6 +149,7 @@ class NormalLatent(LatentDistribution):
         *,
         device: torch.device | None = None,
         dtype: torch.dtype | None = None,
+        generator: torch.Generator | None = None,
     ) -> torch.Tensor:
         """Sample normally distributed latent vectors.
 
@@ -158,6 +162,8 @@ class NormalLatent(LatentDistribution):
         dtype : torch.dtype | None
             Floating dtype of the returned tensor. If omitted, the current
             PyTorch default dtype is used.
+        generator : torch.Generator | None
+            Generator used for random sampling. Default is ``None``.
 
         Returns
         -------
@@ -183,6 +189,7 @@ class NormalLatent(LatentDistribution):
                 self.dim,
                 device=device,
                 dtype=resolved_dtype,
+                generator=generator,
             )
             .mul(self.std)
             .add(self.mean)
@@ -547,6 +554,7 @@ class PhotonicGenerator(nn.Module):
         *,
         device: torch.device | None = None,
         dtype: torch.dtype | None = None,
+        generator: torch.Generator | None = None,
     ) -> torch.Tensor:
         """Sample latent vectors from the configured latent distribution.
 
@@ -562,6 +570,8 @@ class PhotonicGenerator(nn.Module):
             Floating dtype of the returned tensor. If omitted, the generator
             uses the first floating parameter or buffer dtype, falling back to
             the current PyTorch default dtype. Default is ``None``.
+        generator : torch.Generator | None
+            Generator used for latent sampling. Default is ``None``.
 
         Returns
         -------
@@ -572,7 +582,10 @@ class PhotonicGenerator(nn.Module):
             device, dtype
         )
         return self.latent.sample(
-            batch_size, device=resolved_device, dtype=resolved_dtype
+            batch_size,
+            device=resolved_device,
+            dtype=resolved_dtype,
+            generator=generator,
         )
 
     def generate(
@@ -581,6 +594,7 @@ class PhotonicGenerator(nn.Module):
         *,
         device: torch.device | None = None,
         dtype: torch.dtype | None = None,
+        generator: torch.Generator | None = None,
     ) -> torch.Tensor:
         """Sample latent vectors and generate classical samples.
 
@@ -596,13 +610,17 @@ class PhotonicGenerator(nn.Module):
             Floating dtype of sampled latent vectors. If omitted, the generator
             chooses a dtype from its parameters and buffers. Default is
             ``None``.
+        generator : torch.Generator | None
+            Generator used for latent sampling. Default is ``None``.
 
         Returns
         -------
         torch.Tensor
             Generated samples returned by ``output_adapter``.
         """
-        z = self.sample_latent(batch_size, device=device, dtype=dtype)
+        z = self.sample_latent(
+            batch_size, device=device, dtype=dtype, generator=generator
+        )
         return self(z)
 
     def measure(self, z: torch.Tensor) -> GeneratorMeasurements:

--- a/merlin/models/photonic_generator.py
+++ b/merlin/models/photonic_generator.py
@@ -581,6 +581,12 @@ class PhotonicGenerator(nn.Module):
         resolved_device, resolved_dtype = self._resolve_sample_device_dtype(
             device, dtype
         )
+        if generator is None:
+            # Forward the generator argument only when set so latent
+            # distributions implemented before it existed keep working.
+            return self.latent.sample(
+                batch_size, device=resolved_device, dtype=resolved_dtype
+            )
         return self.latent.sample(
             batch_size,
             device=resolved_device,

--- a/tests/models/test_photonic_generator.py
+++ b/tests/models/test_photonic_generator.py
@@ -83,6 +83,7 @@ class ConstantLatent(ML.LatentDistribution):
         *,
         device: torch.device | None = None,
         dtype: torch.dtype | None = None,
+        generator: torch.Generator | None = None,
     ) -> torch.Tensor:
         resolved_dtype = dtype if dtype is not None else torch.get_default_dtype()
         return torch.full(
@@ -426,6 +427,40 @@ def test_sample_latent_respects_explicit_dtype():
     z = generator.sample_latent(batch_size=5, dtype=torch.float64)
 
     assert z.dtype == torch.float64
+
+
+def test_sample_latent_uses_explicit_generator_without_advancing_global_rng():
+    generator = ML.PhotonicGenerator(
+        layers=[_make_layer(input_size=3)],
+        output_adapter=ML.VectorAdapter(size=4),
+    )
+    sampling_generator = torch.Generator().manual_seed(1234)
+    global_state = torch.random.get_rng_state()
+
+    first = generator.sample_latent(batch_size=5, generator=sampling_generator)
+    expected_global_sample = torch.randn(5)
+
+    torch.random.set_rng_state(global_state)
+    repeated = generator.sample_latent(
+        batch_size=5, generator=torch.Generator().manual_seed(1234)
+    )
+    actual_global_sample = torch.randn(5)
+
+    assert torch.equal(first, repeated)
+    assert torch.equal(actual_global_sample, expected_global_sample)
+
+
+def test_generate_accepts_explicit_generator():
+    generator = ML.PhotonicGenerator(
+        layers=[_make_layer(input_size=2)],
+        output_adapter=ML.VectorAdapter(size=5),
+    )
+
+    output = generator.generate(
+        batch_size=3, generator=torch.Generator().manual_seed(1234)
+    )
+
+    assert output.shape == (3, 5)
 
 
 def test_custom_latent_distribution_is_supported():

--- a/tests/models/test_photonic_generator.py
+++ b/tests/models/test_photonic_generator.py
@@ -94,6 +94,20 @@ class ConstantLatent(ML.LatentDistribution):
         )
 
 
+class LegacyLatent(ML.LatentDistribution):
+    """Latent sampler written before the generator parameter was introduced."""
+
+    def sample(
+        self,
+        batch_size: int,
+        *,
+        device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> torch.Tensor:
+        resolved_dtype = dtype if dtype is not None else torch.get_default_dtype()
+        return torch.zeros(batch_size, self.dim, device=device, dtype=resolved_dtype)
+
+
 class FirstFeatureAdapter(ML.OutputAdapter):
     """OutputAdapter subclass used to prove the extension contract works."""
 
@@ -456,11 +470,29 @@ def test_generate_accepts_explicit_generator():
         output_adapter=ML.VectorAdapter(size=5),
     )
 
-    output = generator.generate(
+    first = generator.generate(
+        batch_size=3, generator=torch.Generator().manual_seed(1234)
+    )
+    second = generator.generate(
         batch_size=3, generator=torch.Generator().manual_seed(1234)
     )
 
-    assert output.shape == (3, 5)
+    assert first.shape == (3, 5)
+    assert torch.equal(first, second)
+
+
+def test_latent_distribution_without_generator_parameter_is_supported():
+    generator = ML.PhotonicGenerator(
+        layers=[_make_layer(input_size=2)],
+        output_adapter=ML.VectorAdapter(size=4),
+        latent=LegacyLatent(dim=2),
+    )
+
+    z = generator.sample_latent(batch_size=3)
+    output = generator.generate(batch_size=3)
+
+    assert z.shape == (3, 2)
+    assert output.shape == (3, 4)
 
 
 def test_custom_latent_distribution_is_supported():


### PR DESCRIPTION
<!--
Thank you for contributing to MerLin!
Please fill out the sections below to help us review your PR efficiently.

NOTE: this repo is a public repository, therefore, do NOT paste Jira URLs. Use the Jira issue key only (e.g., PML-126).
The Jira–GitHub integration will link PRs/commits automatically when the key is present.
-->

<!-- Add the Jira issue key in the title -->
<!-- e.g., PML-126 Updating PR template -->

## Summary
<!-- What does this PR do? A clear, concise description. -->
Adds support for passing a dedicated `torch.Generator` to `PhotonicGenerator.sample_latent()` and `PhotonicGenerator.generate()`
This enables reproducible latent batches without advancing PyTorch’s global random-number generator
Backward compatibility is ensured.

## Related Issue
   <!-- For internal contributors: Use Jira key (e.g., Related Jira: PML-126)
        For external contributors: Link to GitHub issue if applicable -->
PML-385

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / Cleanup
- [ ] Performance improvement
- [ ] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)


## Proposed changes
<!-- Bulleted list of key changes. If API changes, list them explicitly. -->
Added the **generator parameter** to:

- `LatentDistribution.sample()`
- `NormalLatent.sample()`
- `PhotonicGenerator.sample_latent()`
- `PhotonicGenerator.generate()`

Preserved **compatibility** with custom latent distributions implemented before the new parameter existed.
Added **tests** covering:

- Reproducibility with an explicit generator.
- Preservation of global RNG state.
- Generator support through generate().
- Backward compatibility with legacy latent distributions.

Updated the QGAN documentation and photonic QGAN reproduction notes.
## How to test / How to run
<!-- Describe test plan and steps for reviewers to validate and run your changes locally. Include datasets if relevant. -->

1. Command lines

```
pytest tests/models/test_photonic_generator.py
```

## Documentation
- [x] User docs updated (Sphinx)
- [ ] Examples / notebooks updated
- [x] Docstrings updated
- [ ] Updated the API

## Checklist
- [x] PR title includes Jira issue key (e.g., PML-126)
- [x] "Related Jira ticket" section includes the Jira issue key (no URL)
- [x] Code formatted (ruff format)
- [x] Lint passes (ruff)
- [x] Static typing passes (mypy) if applicable
- [x] Unit tests added/updated (pytest)
- [x] Tests pass locally (pytest)
- [x] Tests pass on GPU (pytest)
- [x] Test coverage not decreased significantly
- [x] Docs build locally if affected (sphinx)
- [x] With this command: `SPHINXOPTS="-W --keep-going -n" make -C docs clean html` the docs are built without any warning or errors.
- [x] New public classes/methods/packages are added in the API following the methodology presented in other files.
- [x] Dependencies updated (if needed) and pinned appropriately
- [x] PR description explains what changed and how to validate it


<!-- Helpful local commands – run from repo root:

# Lint & format
ruff format && ruff check .

# Type check (if used)
mypy .

# Tests with coverage
pytest

# Build docs
pip install -r requirements-docs.txt && make -C docs html

-->
