### PR TITLE
Fix large code block in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -62,11 +62,7 @@ Block of code
 - [ ] Tests pass on GPU (pytest)
 - [ ] Test coverage not decreased significantly
 - [ ] Docs build locally if affected (sphinx)
-- [ ] With this command: 
-
-        > SPHINXOPTS="-W --keep-going -n" make -C docs clean html 
-
-    the docs are built without any warning or errors.
+- [ ] With this command: `SPHINXOPTS="-W --keep-going -n" make -C docs clean html` the docs are built without any warning or errors.
 - [ ] New public classes/methods/packages are added in the API following the methodology presented in other files.
 - [ ] Dependencies updated (if needed) and pinned appropriately
 - [ ] PR description explains what changed and how to validate it


### PR DESCRIPTION

- [ ] With this command: 

        > SPHINXOPTS="-W --keep-going -n" make -C docs clean html 

    the docs are built without any warning or errors.

is becoming
- [ ] With this command: `SPHINXOPTS="-W --keep-going -n" make -C docs clean html` the docs are built without any warning or errors.

This avoids the PR description being too large from the large space between all bullet points in the checklist
