### PR TITLE
Fix release/0.4.1

### DIFF
--- a/docs/source/api_reference/api/merlin.core.execution.rst
+++ b/docs/source/api_reference/api/merlin.core.execution.rst
@@ -1,0 +1,22 @@
+=========================
+Execution API Reference
+=========================
+
+.. automodule:: merlin.core.execution
+   :no-members:
+
+.. currentmodule:: merlin.core.execution
+
+.. autoclass:: BatchChunker
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: RemoteJobRunner
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autofunction:: build_iteration_parameters
+
+.. autofunction:: select_sampling_command

--- a/docs/source/api_reference/api/merlin.core.merlin_processor.rst
+++ b/docs/source/api_reference/api/merlin.core.merlin_processor.rst
@@ -132,10 +132,7 @@ MerlinFuture
 MerlinProcessor
 ---------------
 .. autoclass:: merlin.core.merlin_processor.JobStatus
-   :members:
-   :undoc-members:
-   :show-inheritance:
-   :noindex:
+   :no-members:
 
 .. autoclass:: merlin.core.merlin_processor.CallState
    :members:

--- a/docs/source/api_reference/api/merlin.core.merlin_processor.rst
+++ b/docs/source/api_reference/api/merlin.core.merlin_processor.rst
@@ -131,6 +131,11 @@ MerlinFuture
 
 MerlinProcessor
 ---------------
+.. autoclass:: merlin.core.merlin_processor.JobStatus
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. autoclass:: merlin.core.merlin_processor.CallState
    :members:
    :undoc-members:

--- a/docs/source/api_reference/api/merlin.core.merlin_processor.rst
+++ b/docs/source/api_reference/api/merlin.core.merlin_processor.rst
@@ -135,6 +135,7 @@ MerlinProcessor
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 .. autoclass:: merlin.core.merlin_processor.CallState
    :members:

--- a/docs/source/api_reference/api/merlin.core.merlin_processor.rst
+++ b/docs/source/api_reference/api/merlin.core.merlin_processor.rst
@@ -131,6 +131,16 @@ MerlinFuture
 
 MerlinProcessor
 ---------------
+.. autoclass:: merlin.core.merlin_processor.CallState
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: merlin.core.merlin_processor.ValidatedLayerConfig
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. class:: MerlinProcessor(remote_processor=None, session=None, microbatch_size=32, timeout=3600.0, max_shots_per_call=None, chunk_concurrency=1, token=None, *, processor=None)
 
    Create a processor that offloads quantum leaves to a Perceval backend.

--- a/docs/source/api_reference/api/merlin.core.perceval_adapter.rst
+++ b/docs/source/api_reference/api/merlin.core.perceval_adapter.rst
@@ -1,0 +1,33 @@
+================================
+Perceval Adapter API Reference
+================================
+
+.. automodule:: merlin.core.perceval_adapter
+   :no-members:
+
+.. currentmodule:: merlin.core.perceval_adapter
+
+.. autoclass:: PercevalAdapter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: JobStatusSnapshot
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: LocalExperimentSnapshot
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: TokenExtractionError
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: RemoteJobFailedError
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/api/merlin.core.rst
+++ b/docs/source/api_reference/api/merlin.core.rst
@@ -19,6 +19,8 @@ Modules
      - Public circuit-component dataclasses such as rotations, beam splitters, and interferometers.
    * - :doc:`merlin.core.computation_space`
      - Computation-space enums and coercion helpers for Fock and related bases.
+   * - :doc:`merlin.core.execution`
+     - Batch chunking and remote job execution units used by Merlin processors.
    * - :doc:`merlin.core.encoding_space`
      - Input encoding definitions and logical-to-Fock mapping helpers.
    * - :doc:`merlin.core.generators`
@@ -33,6 +35,8 @@ Modules
      - Computation processes and factory logic used to execute Merlin circuits.
    * - :doc:`merlin.core.merlin_processor`
      - The high-level :class:`~merlin.core.merlin_processor.MerlinProcessor` remote/local execution interface.
+   * - :doc:`merlin.core.perceval_adapter`
+     - Compatibility adapter and normalized state objects for Perceval backends.
    * - :doc:`merlin.core.sectored_distribution`
      - Data classes used for g2 simulation outputs.
    * - :doc:`merlin.core.state`
@@ -47,6 +51,7 @@ Modules
    merlin.core.circuit
    merlin.core.components
    merlin.core.computation_space
+   merlin.core.execution
    merlin.core.encoding_space
    merlin.core.generators
    merlin.core.partial_measurement
@@ -54,6 +59,7 @@ Modules
    merlin.core.probability_distribution
    merlin.core.process
    merlin.core.merlin_processor
+   merlin.core.perceval_adapter
    merlin.core.sectored_distribution
    merlin.core.state
    merlin.core.state_vector

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -127,6 +127,7 @@ nitpick_ignore = [
     ("py:class", "perceval.runtime.RemoteProcessor"),
     ("py:class", "perceval.runtime.session.ISession"),
     ("py:class", "pcvl.ACircuit"),
+    ("py:class", "pcvl.SVDistribution"),
     ("py:attr", "dtype"),
     ("py:attr", "device"),
 ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -116,6 +116,17 @@ nitpick_ignore = [
     ("py:class", "merlin.measurement.strategies._LegacyMeasurementStrategy"),
     ("py:class", "torch.nn.modules.loss._Loss"),
     ("py:class", "Module"),
+    # Perceval's published v1.2 inventory does not expose these symbols under
+    # the import paths used by Merlin's type hints.
+    ("py:class", "AProcessor"),
+    ("py:class", "RemoteJob"),
+    ("py:class", "Sampler"),
+    ("py:class", "perceval.algorithm.Sampler"),
+    ("py:class", "perceval.runtime.AProcessor"),
+    ("py:class", "perceval.runtime.RemoteJob"),
+    ("py:class", "perceval.runtime.RemoteProcessor"),
+    ("py:class", "perceval.runtime.session.ISession"),
+    ("py:class", "pcvl.ACircuit"),
     ("py:attr", "dtype"),
     ("py:attr", "device"),
 ]

--- a/merlin/builder/circuit_builder.py
+++ b/merlin/builder/circuit_builder.py
@@ -598,7 +598,8 @@ class CircuitBuilder:
             Override for the output phase shifters.
         seed : int | None
             Optional seed for the random phases assigned to non-trainable
-            phase shifters. ``None`` draws fresh entropy each call.
+            phase shifters. When omitted, the seed is drawn from PyTorch's
+            global random generator.
 
         Returns
         -------

--- a/merlin/core/components.py
+++ b/merlin/core/components.py
@@ -31,6 +31,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
+import torch
+
 
 class ParameterRole(Enum):
     """Role definition for circuit parameters."""
@@ -193,8 +195,9 @@ class GenericInterferometer:
         Whether outer phase shifters are trainable.
     seed : int | None
         Optional seed controlling the random phases drawn for non-trainable
-        inner/outer phase shifters. ``None`` draws fresh entropy without
-        touching global random state.
+        inner/outer phase shifters. When omitted, a seed is drawn from
+        PyTorch's global random generator, so ``torch.manual_seed`` controls
+        reproducibility.
     fixed_inner_values : list[float]
         Fixed (non-trainable) values for the inner phase shifters, drawn
         randomly unless explicitly provided. When provided, must contain
@@ -264,6 +267,10 @@ class GenericInterferometer:
                     f"{count} entries for span {self.span}, got {len(values)}"
                 )
         if count > 0:
+            if self.seed is None and (
+                not self.trainable_inner or not self.trainable_outer
+            ):
+                self.seed = int(torch.randint(0, 2**31 - 1, ()).item())
             rng = random.Random(self.seed)
             if not self.trainable_inner and not self.fixed_inner_values:
                 self.fixed_inner_values = [

--- a/merlin/core/execution.py
+++ b/merlin/core/execution.py
@@ -25,7 +25,7 @@ import logging
 import threading
 import time
 import zlib
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from concurrent.futures import CancelledError
 from typing import TYPE_CHECKING
 
@@ -41,6 +41,87 @@ if TYPE_CHECKING:
     from .merlin_processor import CallState, ValidatedLayerConfig
 
 logger = logging.getLogger(__name__)
+
+
+def build_iteration_parameters(
+    input_chunk: torch.Tensor, input_parameter_names: Sequence[str]
+) -> list[dict[str, float]]:
+    """Map input rows to circuit parameters after validating their shape.
+
+    Parameters
+    ----------
+    input_chunk : torch.Tensor
+        Two-dimensional input tensor with one column per circuit parameter.
+    input_parameter_names : Sequence[str]
+        Circuit parameter names in the expected column order.
+
+    Returns
+    -------
+    list[dict[str, float]]
+        Parameter mappings for each input row.
+
+    Raises
+    ------
+    ValueError
+        If the input tensor column count does not match the parameter count.
+    """
+    if input_chunk.ndim != 2:
+        raise ValueError(
+            f"Input chunk must be 2-dimensional, got {input_chunk.ndim} dimensions."
+        )
+
+    expected_columns = len(input_parameter_names)
+    actual_columns = input_chunk.shape[1]
+    if actual_columns != expected_columns:
+        raise ValueError(
+            "Input column count does not match the circuit parameter count: "
+            f"received {actual_columns} column(s), expected {expected_columns}."
+        )
+
+    input_np = input_chunk.detach().cpu().numpy()
+    return [
+        {
+            parameter_name: float(input_np[row_index, column_index])
+            for column_index, parameter_name in enumerate(input_parameter_names)
+        }
+        for row_index in range(input_chunk.shape[0])
+    ]
+
+
+def select_sampling_command(
+    available_commands: Sequence[str], *, default_command: str | None = None
+) -> str:
+    """Select the supported sampling command for a backend.
+
+    Parameters
+    ----------
+    available_commands : Sequence[str]
+        Commands advertised by the backend.
+    default_command : str | None
+        Explicit command to use when capability metadata is unavailable.
+        Defaults to ``None``.
+
+    Returns
+    -------
+    str
+        ``"sample_count"`` when available, otherwise ``"samples"``.
+
+    Raises
+    ------
+    RuntimeError
+        If the backend advertises neither sampling command and no default was
+        provided.
+    """
+    if "sample_count" in available_commands:
+        return "sample_count"
+    if "samples" in available_commands:
+        return "samples"
+    if default_command is not None:
+        return default_command
+    raise RuntimeError(
+        "Backend does not support a sampling command; expected "
+        "'sample_count' or 'samples'."
+    )
 
 
 class BatchChunker:
@@ -260,6 +341,7 @@ class RemoteJobRunner:
         get_microbatch_limit: Callable[[], int | None],
         max_retries: int = 3,
         job_name_max: int = 50,
+        default_sampling_command: str | None = None,
     ) -> None:
         self._create_processor = create_processor
         self._get_available_commands = get_available_commands
@@ -273,6 +355,7 @@ class RemoteJobRunner:
         self._get_microbatch_limit = get_microbatch_limit
         self._max_retries = max_retries
         self._job_name_max = job_name_max
+        self._default_sampling_command = default_sampling_command
 
     def run_chunk(
         self,
@@ -333,17 +416,9 @@ class RemoteJobRunner:
             )
 
         input_param_names = self._extract_input_params(config)
-        input_np = input_chunk.detach().cpu().numpy()
 
         # Pre-compute iteration params (cheap, only done once).
-        iteration_params: list[dict[str, float]] = []
-        for i in range(batch_size):
-            circuit_params = {}
-            for j, param_name in enumerate(input_param_names):
-                circuit_params[param_name] = (
-                    float(input_np[i, j]) if j < input_chunk.shape[1] else 0.0
-                )
-            iteration_params.append(circuit_params)
+        iteration_params = build_iteration_parameters(input_chunk, input_param_names)
 
         last_error: BaseException | None = None
         for attempt in range(self._max_retries):
@@ -422,7 +497,7 @@ class RemoteJobRunner:
 
         2. **Sampling** (``"sample_count"`` or ``"samples"`` commands):
            - Used if exact probabilities are not available or ``nsample > 0``.
-           - Tries ``"sample_count"`` first, falls back to ``"samples"``.
+           - Uses ``"sample_count"`` first, otherwise ``"samples"``.
            - Number of samples = ``effective_sample_count(nsample)``.
 
         Job names are sanitized and capped through :meth:`_capped_name`.
@@ -451,12 +526,10 @@ class RemoteJobRunner:
             cmd = "probs"
             max_samples = None
         else:
-            if "sample_count" in available_commands:
-                cmd = "sample_count"
-            elif "samples" in available_commands:
-                cmd = "samples"
-            else:
-                cmd = "sample_count"
+            cmd = select_sampling_command(
+                available_commands,
+                default_command=self._default_sampling_command,
+            )
             max_samples = self._effective_sample_count(nsample)
 
         name = self._capped_name(job_base_label, cmd) if job_base_label else None

--- a/merlin/core/execution.py
+++ b/merlin/core/execution.py
@@ -500,8 +500,7 @@ class RemoteJobRunner:
            - Uses ``"sample_count"`` first, otherwise ``"samples"``.
            - Number of samples = ``effective_sample_count(nsample)``.
 
-        Job names are sanitized and capped through
-        :meth:`~merlin.core.execution.RemoteJobRunner._capped_name`.
+        Job names are sanitized and capped through ``_capped_name``.
 
         Parameters
         ----------

--- a/merlin/core/execution.py
+++ b/merlin/core/execution.py
@@ -400,7 +400,7 @@ class RemoteJobRunner:
         ------
         ValueError
             If the chunk exceeds the microbatch guard (an internal invariant).
-        CancelledError
+        concurrent.futures.CancelledError
             If cancellation is requested during the attempt loop.
         TimeoutError
             If ``deadline`` elapses during the attempt loop.
@@ -500,7 +500,8 @@ class RemoteJobRunner:
            - Uses ``"sample_count"`` first, otherwise ``"samples"``.
            - Number of samples = ``effective_sample_count(nsample)``.
 
-        Job names are sanitized and capped through :meth:`_capped_name`.
+        Job names are sanitized and capped through
+        :meth:`~merlin.core.execution.RemoteJobRunner._capped_name`.
 
         Parameters
         ----------
@@ -580,7 +581,7 @@ class RemoteJobRunner:
 
         Raises
         ------
-        CancelledError
+        concurrent.futures.CancelledError
             If cancellation is requested or the backend reports a cancel.
         TimeoutError
             If ``deadline`` elapses while polling.

--- a/merlin/core/execution.py
+++ b/merlin/core/execution.py
@@ -181,9 +181,9 @@ class BatchChunker:
         in_flight = 0
         idx = 0
         futures: list[threading.Thread] = []
-        while idx < len(chunks) or in_flight > 0:
+        while in_flight > 0 or (not errors and idx < len(chunks)):
             concurrency = max(1, int(self._get_chunk_concurrency()))
-            while idx < len(chunks) and in_flight < concurrency:
+            while not errors and idx < len(chunks) and in_flight < concurrency:
                 s, e = chunks[idx]
                 state.mark_chunk_started()
                 th = threading.Thread(target=_call, args=(s, e, idx), daemon=True)

--- a/merlin/core/merlin_processor.py
+++ b/merlin/core/merlin_processor.py
@@ -18,7 +18,12 @@ from torch.futures import Future
 
 from ..algorithms.module import MerlinModule
 from ..utils.combinadics import Combinadics
-from .execution import BatchChunker, RemoteJobRunner
+from .execution import (
+    BatchChunker,
+    RemoteJobRunner,
+    build_iteration_parameters,
+    select_sampling_command,
+)
 from .perceval_adapter import (
     LocalExperimentSnapshot,
     PercevalAdapter,
@@ -1274,6 +1279,11 @@ class MerlinProcessor:
             ),
             max_retries=self._MAX_CHUNK_RETRIES,
             job_name_max=self._JOB_NAME_MAX,
+            default_sampling_command=(
+                "sample_count"
+                if getattr(self, "session", None) is not None
+                else None
+            ),
         )
 
     def _register_job(self, job: RemoteJob) -> None:
@@ -1407,16 +1417,7 @@ class MerlinProcessor:
 
         batch_size = input_chunk.shape[0]
         input_param_names = self._extract_input_params(config)
-        input_np = input_chunk.detach().cpu().numpy()
-
-        iteration_params: list[dict[str, float]] = []
-        for i in range(batch_size):
-            circuit_params = {}
-            for j, param_name in enumerate(input_param_names):
-                circuit_params[param_name] = (
-                    float(input_np[i, j]) if j < input_chunk.shape[1] else 0.0
-                )
-            iteration_params.append(circuit_params)
+        iteration_params = build_iteration_parameters(input_chunk, input_param_names)
 
         processor, experiment_snapshot = self._create_fresh_local_processor()
         PercevalAdapter.set_circuit(
@@ -1437,12 +1438,10 @@ class MerlinProcessor:
             raw_results = PercevalAdapter.execute_sync(sampler, "probs")
         else:
             use_shots = self._effective_sample_count(nsample)
-            if "sample_count" in self.available_commands:
-                cmd = "sample_count"
-            elif "samples" in self.available_commands:
-                cmd = "samples"
-            else:
-                cmd = "sample_count"
+            cmd = select_sampling_command(
+                self.available_commands,
+                default_command="sample_count",
+            )
             raw_results = PercevalAdapter.execute_sync(
                 sampler, cmd, max_samples=use_shots
             )

--- a/merlin/core/merlin_processor.py
+++ b/merlin/core/merlin_processor.py
@@ -1583,42 +1583,45 @@ class MerlinProcessor:
                         result_item["results"], is_probability
                     )
                     probs = torch.zeros(dist_size)
-                    if state_counts:
-                        if valid_states is not None:
-                            filtered_counts = {}
-                            for state_str, count in state_counts.items():
-                                state_tuple = self._parse_perceval_state(state_str)
-                                if state_tuple in valid_states:
-                                    filtered_counts[state_str] = count
-                            state_counts = filtered_counts
-
-                        if not state_counts:
-                            output_tensors.append(torch.zeros(dist_size))
-                            continue
-
-                        total = 1.0 if is_probability else sum(state_counts.values())
-
-                        for state_str, value in state_counts.items():
-                            state_tuple = self._parse_perceval_state(state_str)
-                            if not state_tuple:
-                                continue
-                            if state_to_index is not None:
-                                if state_tuple not in state_to_index:
-                                    continue
-                                idx = state_to_index[state_tuple]
-                            else:
-                                continue
-                            if idx < dist_size:
-                                probs[idx] = (
-                                    value
-                                    if is_probability
-                                    else (value / total if total > 0 else 0)
-                                )
-
-                        prob_sum = probs.sum()
-                        if prob_sum > 0 and abs(float(prob_sum) - 1.0) > 1e-6:
-                            probs = probs / prob_sum
+                    if not state_counts:
                         output_tensors.append(probs)
+                        continue
+
+                    if valid_states is not None:
+                        filtered_counts = {}
+                        for state_str, count in state_counts.items():
+                            state_tuple = self._parse_perceval_state(state_str)
+                            if state_tuple in valid_states:
+                                filtered_counts[state_str] = count
+                        state_counts = filtered_counts
+
+                    if not state_counts:
+                        output_tensors.append(probs)
+                        continue
+
+                    total = 1.0 if is_probability else sum(state_counts.values())
+
+                    for state_str, value in state_counts.items():
+                        state_tuple = self._parse_perceval_state(state_str)
+                        if not state_tuple:
+                            continue
+                        if state_to_index is not None:
+                            if state_tuple not in state_to_index:
+                                continue
+                            idx = state_to_index[state_tuple]
+                        else:
+                            continue
+                        if idx < dist_size:
+                            probs[idx] = (
+                                value
+                                if is_probability
+                                else (value / total if total > 0 else 0)
+                            )
+
+                    prob_sum = probs.sum()
+                    if prob_sum > 0 and abs(float(prob_sum) - 1.0) > 1e-6:
+                        probs = probs / prob_sum
+                    output_tensors.append(probs)
                 else:
                     output_tensors.append(torch.zeros(dist_size))
 

--- a/merlin/core/merlin_processor.py
+++ b/merlin/core/merlin_processor.py
@@ -1199,6 +1199,14 @@ class MerlinProcessor:
 
         B = input_tensor.shape[0]
 
+        if B == 0:
+            dist_size, _, _ = self._get_state_mapping(layer)
+            return torch.empty(
+                (0, dist_size),
+                dtype=input_tensor.dtype,
+                device=input_tensor.device,
+            )
+
         if self.backend_kind == "local_processor":
             return self._run_chunk_local(
                 layer, config, input_tensor, nsample, state, deadline

--- a/merlin/core/merlin_processor.py
+++ b/merlin/core/merlin_processor.py
@@ -71,7 +71,7 @@ class JobStatus:
 
 class CallState:
     """Typed per-call execution state for one
-    :meth:`~merlin.core.merlin_processor.MerlinProcessor.forward_async` call.
+    ``MerlinProcessor.forward_async`` call.
 
     Replaces the anonymous mutable ``state`` dict previously threaded through
     ``forward_async()``, chunk orchestration, chunk execution, and job polling.

--- a/merlin/core/merlin_processor.py
+++ b/merlin/core/merlin_processor.py
@@ -1618,9 +1618,6 @@ class MerlinProcessor:
                                 else (value / total if total > 0 else 0)
                             )
 
-                    prob_sum = probs.sum()
-                    if prob_sum > 0 and abs(float(prob_sum) - 1.0) > 1e-6:
-                        probs = probs / prob_sum
                     output_tensors.append(probs)
                 else:
                     output_tensors.append(torch.zeros(dist_size))

--- a/merlin/core/merlin_processor.py
+++ b/merlin/core/merlin_processor.py
@@ -70,7 +70,8 @@ class JobStatus:
 
 
 class CallState:
-    """Typed per-call execution state for one :meth:`MerlinProcessor.forward_async` call.
+    """Typed per-call execution state for one
+    :meth:`~merlin.core.merlin_processor.MerlinProcessor.forward_async` call.
 
     Replaces the anonymous mutable ``state`` dict previously threaded through
     ``forward_async()``, chunk orchestration, chunk execution, and job polling.
@@ -249,7 +250,8 @@ class CallState:
 
 
 class MerlinFuture(Future):
-    """Typed async handle returned by :meth:`MerlinProcessor.forward_async`.
+    """Typed async handle returned by
+    :meth:`~merlin.core.merlin_processor.MerlinProcessor.forward_async`.
 
     Extends ``torch.futures.Future[torch.Tensor]`` with the Merlin-specific
     async contract that was previously monkey-patched onto plain Future
@@ -387,7 +389,7 @@ class ValidatedLayerConfig:
     circuit : pcvl.ACircuit
         Perceval circuit associated with the layer.
 
-    input_state : Sequence[Integral] | pcvl.BasicState | pcvl.StateVector | pcvl.BSDistribution | pcvl.SVDistribution | None
+    input_state : Sequence[numbers.Integral] | pcvl.BasicState | pcvl.StateVector | pcvl.BSDistribution | pcvl.SVDistribution | None
         Input state for the circuit. May be ``None``, a sequence of integers,
         or one of the supported Perceval state objects. Sequence-like inputs
         are normalized through ``check_sequence()``.

--- a/merlin/core/merlin_processor.py
+++ b/merlin/core/merlin_processor.py
@@ -1280,9 +1280,7 @@ class MerlinProcessor:
             max_retries=self._MAX_CHUNK_RETRIES,
             job_name_max=self._JOB_NAME_MAX,
             default_sampling_command=(
-                "sample_count"
-                if getattr(self, "session", None) is not None
-                else None
+                "sample_count" if getattr(self, "session", None) is not None else None
             ),
         )
 

--- a/merlin/core/process.py
+++ b/merlin/core/process.py
@@ -869,13 +869,11 @@ class ComputationProcess(AbstractComputationProcess):
         memristive_current_state = (
             [] if memristive_current_state is None else memristive_current_state
         )
-        prepared_state = (
-            self._prepare_superposition_support() if amplitude_encoding else None
-        )
         memristive_batched = (
-            prepared_state is not None
-            and prepared_state.batch_size > 1
-            and memristive_current_state != []
+            bool(memristive_current_state)
+            and isinstance(self.input_state, torch.Tensor)
+            and amplitude_encoding
+            and self._prepare_superposition_support().batch_size > 1
         )
 
         for _sample_index in range(self._n_phase_error_samples):
@@ -966,21 +964,19 @@ class ComputationProcess(AbstractComputationProcess):
         memristive_current_state = (
             [] if memristive_current_state is None else memristive_current_state
         )
-        prepared_state = (
-            self._prepare_superposition_support() if amplitude_encoding else None
-        )
-        memristive_batched_amplitudes = (
-            prepared_state is not None
-            and prepared_state.batch_size > 1
-            and (memristive_current_state != [])
-        )
-
         if self._has_phase_error():
             return self._compute_phase_error_probabilities(
                 parameters,
                 amplitude_encoding=amplitude_encoding,
                 memristive_current_state=memristive_current_state,
             )
+
+        memristive_batched_amplitudes = (
+            bool(memristive_current_state)
+            and isinstance(self.input_state, torch.Tensor)
+            and amplitude_encoding
+            and self._prepare_superposition_support().batch_size > 1
+        )
 
         # If there is memristive PS and batched amplitude encoding, create a
         # unitary per amplitude input

--- a/merlin/measurement/strategies.py
+++ b/merlin/measurement/strategies.py
@@ -282,7 +282,7 @@ class MeasurementStrategy(metaclass=_MeasurementStrategyMeta):
         Optional grouping applied to probability outputs. If
         ``occupancy_readout`` is ``True``, grouping is applied after the
         occupancy readout.
-        occupancy_readout : bool
+    occupancy_readout : bool
         Whether probability outputs are collapsed to binary occupied/unoccupied
         output keys. If the distribution reaches the readout with sub-unit
         mass, raw tensor outputs preserve that mass without renormalizing. When

--- a/tests/builder/test_circuit_builder.py
+++ b/tests/builder/test_circuit_builder.py
@@ -448,6 +448,23 @@ def test_non_trainable_entangling_layer_seed_is_reproducible():
     assert np.allclose(unitary_a, unitary_b)
 
 
+def test_non_trainable_entangling_layer_uses_torch_global_seed():
+    """Omitted seeds are reproducible through ``torch.manual_seed``."""
+    torch.manual_seed(1234)
+    builder_a = CircuitBuilder(n_modes=4)
+    builder_a.add_entangling_layer(trainable=False, name="pre_mix")
+
+    torch.manual_seed(1234)
+    builder_b = CircuitBuilder(n_modes=4)
+    builder_b.add_entangling_layer(trainable=False, name="pre_mix")
+
+    component_a = builder_a.circuit.components[-1]
+    component_b = builder_b.circuit.components[-1]
+    assert component_a.seed == component_b.seed
+    assert component_a.fixed_inner_values == component_b.fixed_inner_values
+    assert component_a.fixed_outer_values == component_b.fixed_outer_values
+
+
 def test_non_trainable_entangling_layer_partial_trainable_mix():
     """Only the trainable side should expose parameters; the other side stays random."""
     builder = CircuitBuilder(n_modes=4)

--- a/tests/core/test_execution_units.py
+++ b/tests/core/test_execution_units.py
@@ -17,7 +17,11 @@ import torch
 
 import merlin.core.execution as execution_module
 import merlin.core.perceval_adapter as perceval_adapter_module
-from merlin.core.execution import BatchChunker, RemoteJobRunner
+from merlin.core.execution import (
+    BatchChunker,
+    RemoteJobRunner,
+    build_iteration_parameters,
+)
 from merlin.core.merlin_processor import CallState
 from merlin.core.perceval_adapter import RemoteJobFailedError
 
@@ -340,6 +344,25 @@ class TestBatchChunkerRunChunks:
         assert output.shape == (2, 1)
 
 
+class TestIterationParameters:
+    def test_input_columns_match_circuit_parameters(self):
+        """Input columns map to circuit parameters in order."""
+        input_tensor = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+
+        assert build_iteration_parameters(input_tensor, ["theta", "phi"]) == [
+            {"theta": 1.0, "phi": 2.0},
+            {"theta": 3.0, "phi": 4.0},
+        ]
+
+    @pytest.mark.parametrize("column_count", [1, 3])
+    def test_input_column_mismatch_is_rejected(self, column_count):
+        """Missing and extra input columns raise instead of being discarded."""
+        input_tensor = torch.zeros(2, column_count)
+
+        with pytest.raises(ValueError, match="column count does not match"):
+            build_iteration_parameters(input_tensor, ["theta", "phi"])
+
+
 # ---------------------------------------------------------------------------
 # RemoteJobRunner.submit_job
 # ---------------------------------------------------------------------------
@@ -379,14 +402,13 @@ class TestSubmitJob:
         assert job is sampler.samples
         assert is_probability is False
 
-    def test_sample_count_is_default_fallback_without_commands(self):
-        """sample_count is attempted when no commands are advertised."""
+    def test_sampling_raises_without_supported_commands(self):
+        """Sampling fails clearly when no sampling command is advertised."""
         runner = make_runner(get_available_commands=lambda: ())
         sampler = FakeSampler()
 
-        job, _ = runner.submit_job(sampler, None, None)
-
-        assert job is sampler.sample_count
+        with pytest.raises(RuntimeError, match="does not support a sampling command"):
+            runner.submit_job(sampler, None, None)
 
     def test_shot_count_flows_through_effective_sample_count(self):
         """Submitted shots come from the injected effective_sample_count."""

--- a/tests/core/test_execution_units.py
+++ b/tests/core/test_execution_units.py
@@ -264,9 +264,11 @@ class TestBatchChunkerRunChunks:
         assert state.active_chunks == 0
 
     def test_first_chunk_error_is_raised(self):
-        """A failing chunk propagates its error after the pool drains."""
+        """A failing chunk propagates without submitting later chunks."""
+        started_chunks: list[float] = []
 
         def run_chunk(layer, config, chunk, nsample, state, deadline, job_base_label):
+            started_chunks.append(float(chunk[0, 0]))
             if chunk[0, 0] == 2:
                 raise RuntimeError("chunk exploded")
             return torch.ones(chunk.shape[0], 1)
@@ -279,12 +281,14 @@ class TestBatchChunkerRunChunks:
             chunker.run_chunks(
                 object(),
                 make_chunk_config(),
-                torch.tensor([[0.0], [2.0]]),
-                BatchChunker.split_batch(2, 1),
+                torch.tensor([[0.0], [2.0], [4.0]]),
+                BatchChunker.split_batch(3, 1),
                 None,
                 CallState.new(),
                 None,
             )
+
+        assert started_chunks == [0.0, 2.0]
 
     def test_deadline_cancels_all_and_raises_timeout(self):
         """An elapsed deadline cancels in-flight jobs and raises TimeoutError."""

--- a/tests/core/test_merlin_processor_unit.py
+++ b/tests/core/test_merlin_processor_unit.py
@@ -2095,7 +2095,7 @@ def test_process_batch_results_preserves_probability_row_mass():
         "results_list": [{"results": {"|1,0>": 1.0, "|0,1>": 1.0}}],
     }
 
-    result = proc._process_batch_results(raw_results, 1, layer)
+    result = proc._process_batch_results(raw_results, 1, layer, is_probability=True)
 
     assert torch.allclose(result, torch.tensor([[1.0, 1.0]]))
 

--- a/tests/core/test_merlin_processor_unit.py
+++ b/tests/core/test_merlin_processor_unit.py
@@ -2087,8 +2087,8 @@ def test_process_batch_results_preserves_alignment_for_empty_rows():
     )
 
 
-def test_process_batch_results_probability_heuristic_renormalizes_float_rows():
-    """The current heuristic treats first float <= 1 as probability payloads."""
+def test_process_batch_results_preserves_probability_row_mass():
+    """Probability payloads preserve their reported total mass."""
     proc = make_processor(["probs"])
     layer = FakeLayer()
     raw_results = {
@@ -2097,7 +2097,7 @@ def test_process_batch_results_probability_heuristic_renormalizes_float_rows():
 
     result = proc._process_batch_results(raw_results, 1, layer)
 
-    assert torch.allclose(result, torch.tensor([[0.5, 0.5]]))
+    assert torch.allclose(result, torch.tensor([[1.0, 1.0]]))
 
 
 # ────── Tests for _create_fresh_rp() ──────

--- a/tests/core/test_merlin_processor_unit.py
+++ b/tests/core/test_merlin_processor_unit.py
@@ -2585,6 +2585,35 @@ def test_offload_quantum_layer_with_chunking_validates_and_caches_export_config(
     assert layer.export_config_calls == 1
 
 
+def test_offload_quantum_layer_with_chunking_returns_empty_batch():
+    """An empty remote batch returns the layer's distribution width."""
+    proc = make_processor(["probs", "sample_count"])
+
+    class EmptyBatchLayer(FakeLayer):
+        uid = 43
+
+        def export_config(self):
+            return {
+                "circuit": pcvl.Circuit(m=2, name="Circuit"),
+                "input_state": [1, 0],
+                "input_param_order": [],
+            }
+
+    proc._run_chunks_pooled = MagicMock(side_effect=AssertionError("must not submit"))
+
+    result = proc._offload_quantum_layer_with_chunking(
+        EmptyBatchLayer(),
+        torch.empty((0, 2), dtype=torch.float64),
+        None,
+        {},
+        None,
+    )
+
+    assert result.shape == (0, 2)
+    assert result.dtype == torch.float64
+    proc._run_chunks_pooled.assert_not_called()
+
+
 def test_offload_quantum_layer_cache_isolated_by_merlin_module_instance_uid():
     proc = make_processor(["probs", "sample_count"])
 

--- a/tests/core/test_merlin_processor_unit.py
+++ b/tests/core/test_merlin_processor_unit.py
@@ -2065,6 +2065,28 @@ def test_process_batch_results_zero_fills_missing_rows():
     )
 
 
+def test_process_batch_results_preserves_alignment_for_empty_rows():
+    """Rows with empty counts do not shift subsequent result rows."""
+    proc = make_processor(["probs"])
+    layer = FakeLayer()
+    raw_results = {
+        "results_list": [
+            {"results": {}},
+            {"results": {"|0,1>": 1.0}},
+        ],
+    }
+
+    result = proc._process_batch_results(raw_results, 2, layer)
+
+    assert torch.allclose(
+        result,
+        torch.tensor([
+            [0.0, 0.0],
+            [0.0, 1.0],
+        ]),
+    )
+
+
 def test_process_batch_results_probability_heuristic_renormalizes_float_rows():
     """The current heuristic treats first float <= 1 as probability payloads."""
     proc = make_processor(["probs"])

--- a/tests/core/test_merlin_processor_unit.py
+++ b/tests/core/test_merlin_processor_unit.py
@@ -1797,23 +1797,19 @@ def test_submit_job_falls_back_to_samples_when_sample_count_is_unavailable():
     assert sampler.sample_count.executed is False
 
 
-def test_submit_job_defaults_to_sample_count_when_commands_are_empty():
-    """An empty command list currently means sampling through sample_count."""
+def test_submit_job_raises_when_commands_are_empty():
+    """An empty command list clearly rejects unsupported sampling."""
     proc = make_processor([])
     sampler = FakeSampler()
 
-    returned_job, is_probability = proc._make_job_runner().submit_job(
-        sampler,
-        nsample=None,
-        job_base_label=None,
-    )
-
-    assert returned_job is sampler.sample_count
-    assert is_probability is False
-    assert sampler.sample_count.executed is True
-    assert sampler.sample_count.execute_kwargs == {
-        "max_samples": MerlinProcessor.DEFAULT_SHOTS_PER_CALL
-    }
+    with pytest.raises(RuntimeError, match="does not support a sampling command"):
+        proc._make_job_runner().submit_job(
+            sampler,
+            nsample=None,
+            job_base_label=None,
+        )
+    assert sampler.sample_count.executed is False
+    assert sampler.sample_count.execute_kwargs is None
     assert sampler.probs.executed is False
     assert sampler.samples.executed is False
 

--- a/tests/core/test_phase_noise_process.py
+++ b/tests/core/test_phase_noise_process.py
@@ -80,6 +80,24 @@ def _phase_parameter(value: float = 0.37) -> list[torch.Tensor]:
     return [torch.tensor([value], dtype=torch.float64, requires_grad=True)]
 
 
+def test_phase_error_accepts_fock_input_with_amplitude_encoding_flag():
+    """Deprecated amplitude encoding does not force tensor support preparation."""
+    process = _process(
+        noise_groups=NoiseGroups(
+            source=None,
+            circuit={"phase_error": 0.1},
+            post_measurement=None,
+        )
+    )
+
+    probabilities = process.compute(
+        _phase_parameter(),
+        amplitude_encoding=True,
+    )
+
+    assert isinstance(probabilities, torch.Tensor)
+
+
 def _manual_phase_error_average(
     process: ComputationProcess,
     parameters: list[torch.Tensor],


### PR DESCRIPTION
<!--
Thank you for contributing to MerLin!
Please fill out the sections below to help us review your PR efficiently.

NOTE: this repo is a public repository, therefore, do NOT paste Jira URLs. Use the Jira issue key only (e.g., PML-126).
The Jira–GitHub integration will link PRs/commits automatically when the key is present.
-->

<!-- Add the Jira issue key in the title -->
<!-- e.g., PML-126 Updating PR template -->

## Summary
<!-- What does this PR do? A clear, concise description. -->
Fixes reproducibility, execution, result-mapping, and documentation issues introduced during the 0.4.1 release work.

## Related Issue
   <!-- For internal contributors: Use Jira key (e.g., Related Jira: PML-126)
        For external contributors: Link to GitHub issue if applicable -->

## Type of change
- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / Cleanup
- [ ] Performance improvement
- [ ] CI / Build / Tooling
- [ ] Breaking change (requires migration notes)


## Proposed changes
<!-- Bulleted list of key changes. If API changes, list them explicitly. -->
- Seed non-trainable entangling-layer phases from PyTorch’s global RNG when no seed is provided.
- Prevent eager superposition preparation for non-tensor input states.
- Stop scheduling new remote chunks after the first failure.
- Return correctly shaped empty tensors for zero-row batches.
- Validate input-column counts against circuit parameters.
- Centralize input mapping and sampling-command selection.
- Raise clearly when remote backends expose no supported sampling command.
- Preserve explicit `sample_count` defaults for local processors and sessions with unavailable capability metadata.
- Preserve result-row alignment when backend rows contain empty or fully filtered counts.
- Preserve probability mass in remote probability payloads.
- Add API documentation for:
  - `merlin.core.execution`
  - `merlin.core.perceval_adapter`
- Fix the `occupancy_readout` docstring indentation.

## How to test / How to run
<!-- Describe test plan and steps for reviewers to validate and run your changes locally. Include datasets if relevant. -->

1. Command lines

```
pytest tests
```

## Checklist
- [x] PR title includes Jira issue key (e.g., PML-126)
- [x] "Related Jira ticket" section includes the Jira issue key (no URL)
- [x] Code formatted (ruff format)
- [x] Lint passes (ruff)
- [x] Static typing passes (mypy) if applicable
- [x] Unit tests added/updated (pytest)
- [x] Tests pass locally (pytest)
- [x] Tests pass on GPU (pytest)
- [x] Test coverage not decreased significantly
- [x] Docs build locally if affected (sphinx)
- [x] With this command: `SPHINXOPTS="-W --keep-going -n" make -C docs clean html` the docs are built without any warning or errors.
- [x] New public classes/methods/packages are added in the API following the methodology presented in other files.
- [x] Dependencies updated (if needed) and pinned appropriately
- [x] PR description explains what changed and how to validate it


<!-- Helpful local commands – run from repo root:

# Lint & format
ruff format && ruff check .

# Type check (if used)
mypy .

# Tests with coverage
pytest

# Build docs
pip install -r requirements-docs.txt && make -C docs html

-->
